### PR TITLE
Force login for email verification

### DIFF
--- a/app/auth/pages/verifyEmail/[code].tsx
+++ b/app/auth/pages/verifyEmail/[code].tsx
@@ -54,6 +54,7 @@ const VerifyMail: BlitzPage = () => {
   )
 }
 
+VerifyMail.authenticate = true
 VerifyMail.getLayout = (page) => <Layout title="Verifying Email ...">{page}</Layout>
 
 export default VerifyMail


### PR DESCRIPTION
This PR fixes #48.

The verification of the email now requires the user to be logged in - this is a secure way of ensuring the person verifying is the person who made the account. Verification without login could cause a disconnect.

Upon login, the user is redirected to the verification page and subsequently to wherever that redirects them (currently `/`).