### PR TITLE
Add basic styling for search results

### DIFF
--- a/app/core/components/Navbar.tsx
+++ b/app/core/components/Navbar.tsx
@@ -3,6 +3,9 @@ import { Suspense } from "react"
 import { ProgressBarRound32 } from "@carbon/icons-react"
 import { getAlgoliaResults } from "@algolia/autocomplete-js"
 import algoliasearch from "algoliasearch"
+import { Blog32 } from "@carbon/icons-react"
+import SearchResultWorkspace from "./SearchResultWorkspace"
+import SearchResultModule from "./SearchResultModule"
 
 import "@algolia/autocomplete-theme-classic"
 import Autocomplete from "./Autocomplete"
@@ -69,8 +72,20 @@ const Navbar = () => {
                       },
                       templates: {
                         item({ item, components }) {
-                          // TODO: Need to update search results per Algolia index
-                          return <div>{JSON.stringify(item)}</div>
+                          return (
+                            <>
+                              {item.__autocomplete_indexName.match(/_workspaces/g) ? (
+                                <SearchResultWorkspace item={item} />
+                              ) : (
+                                ""
+                              )}
+                              {item.__autocomplete_indexName.match(/_modules/g) ? (
+                                <SearchResultModule item={item} />
+                              ) : (
+                                ""
+                              )}
+                            </>
+                          )
                         },
                       },
                     },

--- a/app/core/components/SearchResultModule.tsx
+++ b/app/core/components/SearchResultModule.tsx
@@ -1,0 +1,19 @@
+import { Blog32 } from "@carbon/icons-react"
+
+const SearchResultModule = ({ item }) => {
+  return (
+    <>
+      <div className="flex my-2">
+        <div className="mr-4">
+          <Blog32 />
+        </div>
+        <div>
+          <p className="text-gray-500 text-xs">{item.type}</p>
+          <p>{item.name}</p>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default SearchResultModule

--- a/app/core/components/SearchResultWorkspace.tsx
+++ b/app/core/components/SearchResultWorkspace.tsx
@@ -1,0 +1,17 @@
+const SearchResultWorkspace = ({ item }) => {
+  return (
+    <>
+      <div className="flex my-2">
+        <div className="mr-4">
+          <img className="w-8 h-8 rounded-full" src={item.avatar} />
+        </div>
+        <div>
+          <p>{item.name}</p>
+          <p className="text-gray-500 text-xs">@{item.handle}</p>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default SearchResultWorkspace

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -11,11 +11,11 @@ const Layout = ({ title, children }: LayoutProps) => {
   return (
     <>
       <Head>
-        <title>{title || "web-app-tbd"}</title>
+        <title>{title || "ResearchEquals"}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="h-screen bg-gray-300 dark:bg-gray-900 text-black dark:text-white">
-        {children}
+      <div className="min-h-screen flex flex-col bg-gray-300 dark:bg-gray-900 text-black dark:text-white">
+        <div className="flex-grow">{children}</div>
       </div>
       <CookieConsent
         location="bottom"

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -18,3 +18,7 @@
 .uploadcare--widget {
   display: none;
 }
+
+.uploadcare--panel {
+  font-family: "Noto Sans", sans-serif;
+}

--- a/app/modules/components/AuthorAvatars.tsx
+++ b/app/modules/components/AuthorAvatars.tsx
@@ -1,0 +1,20 @@
+const AuthorAvatars = ({ module }) => {
+  return (
+    <div className="inline-block h-full align-middle">
+      {module?.authors.map((author) => (
+        <>
+          {/* Tricks it into the middle */}
+          <span className="inline-block h-full align-middle"></span>
+          <img
+            key={author.id + author.workspace!.handle}
+            alt={`Avatar of ${author.workspace!.handle}`}
+            className="inline-block align-middle relative z-30 inline-block h-8 w-8 rounded-full"
+            src={author.workspace?.avatar!}
+          />
+        </>
+      ))}
+    </div>
+  )
+}
+
+export default AuthorAvatars

--- a/app/modules/components/FollowsFromView.tsx
+++ b/app/modules/components/FollowsFromView.tsx
@@ -1,0 +1,111 @@
+import { Fragment, useState } from "react"
+import { Dialog, Transition } from "@headlessui/react"
+import { XIcon } from "@heroicons/react/outline"
+import { Link, Routes } from "blitz"
+import moment from "moment"
+
+import ModuleCard from "../../core/components/ModuleCard"
+
+const FollowsFromView = ({ module }) => {
+  const [followsFromOpen, setFollowsFromOpen] = useState(false)
+
+  return (
+    <>
+      <Transition.Root show={followsFromOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="fixed inset-0 overflow-hidden"
+          onClose={() => {
+            setFollowsFromOpen(false)
+          }}
+        >
+          <div className="absolute inset-0 overflow-hidden">
+            <Dialog.Overlay className="absolute inset-0" />
+
+            <div className="fixed inset-y-0 right-0 pl-10 max-w-full flex">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <div className="w-screen max-w-md">
+                  <div className="h-full flex flex-col py-6 bg-gray-300 shadow-xl overflow-y-scroll">
+                    <div className="px-4 sm:px-6">
+                      <div className="flex items-start justify-between">
+                        <Dialog.Title className="text-lg font-medium text-gray-900">
+                          Parent modules
+                        </Dialog.Title>
+                        <div className="ml-3 h-7 flex items-center">
+                          <button
+                            type="button"
+                            className=" rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                            onClick={() => setFollowsFromOpen(false)}
+                          >
+                            <span className="sr-only">Close panel</span>
+                            <XIcon className="h-6 w-6" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="mt-6 relative flex-1 px-4 sm:px-6">
+                      {/* Replace with your content */}
+                      {module.parents.map((parent) => (
+                        <>
+                          <Link href={Routes.ModulePage({ suffix: parent.suffix })}>
+                            <a target="_blank">
+                              <ModuleCard
+                                type={parent.type.name}
+                                title={parent.title}
+                                status={`10.53962/${parent.suffix}`}
+                                time={moment(parent.publishedAt).fromNow()}
+                                authors={parent.authors}
+                              />
+                            </a>
+                          </Link>
+                        </>
+                      ))}
+                      {/* /End replace */}
+                    </div>
+                  </div>
+                </div>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+      <div className="flex-grow flex">
+        <div className="flex w-full">
+          Follows from:
+          {module.parents.length > 0 ? (
+            <span
+              className="flex-grow cursor-pointer bg-gray-100 hover:bg-gray-50 ml-2 pl-2 border border-gray-500 rounded"
+              onClick={() => {
+                setFollowsFromOpen(true)
+              }}
+            >
+              <div
+                key={module.parents[0].title + "object"}
+                className="inline-block align-middle w-full"
+              >
+                <div className="flex">
+                  <span className="flex-grow">
+                    [{module.parents[0].type.name}] {module.parents[0].title}
+                  </span>
+                  <span className="mx-2">[...]</span>
+                </div>
+              </div>
+            </span>
+          ) : (
+            ""
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default FollowsFromView

--- a/app/modules/components/LeadsToView.tsx
+++ b/app/modules/components/LeadsToView.tsx
@@ -1,0 +1,111 @@
+import { Fragment, useState } from "react"
+import { Dialog, Transition } from "@headlessui/react"
+import { XIcon } from "@heroicons/react/outline"
+import { Link, Routes } from "blitz"
+import moment from "moment"
+
+import ModuleCard from "../../core/components/ModuleCard"
+
+const LeadsToView = ({ module }) => {
+  const [leadsToOpen, setLeadsToOpen] = useState(false)
+
+  return (
+    <>
+      <Transition.Root show={leadsToOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="fixed inset-0 overflow-hidden"
+          onClose={() => {
+            setLeadsToOpen(false)
+          }}
+        >
+          <div className="absolute inset-0 overflow-hidden">
+            <Dialog.Overlay className="absolute inset-0" />
+
+            <div className="fixed inset-y-0 right-0 pl-10 max-w-full flex">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <div className="w-screen max-w-md">
+                  <div className="h-full flex flex-col py-6 bg-gray-300 shadow-xl overflow-y-scroll">
+                    <div className="px-4 sm:px-6">
+                      <div className="flex items-start justify-between">
+                        <Dialog.Title className="text-lg font-medium text-gray-900">
+                          Child modules
+                        </Dialog.Title>
+                        <div className="ml-3 h-7 flex items-center">
+                          <button
+                            type="button"
+                            className=" rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                            onClick={() => setLeadsToOpen(false)}
+                          >
+                            <span className="sr-only">Close panel</span>
+                            <XIcon className="h-6 w-6" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="mt-6 relative flex-1 px-4 sm:px-6">
+                      {/* Replace with your content */}
+                      {module.children.map((parent) => (
+                        <>
+                          <Link href={Routes.ModulePage({ suffix: parent.suffix })}>
+                            <a target="_blank">
+                              <ModuleCard
+                                type={parent.type.name}
+                                title={parent.title}
+                                status={`10.53962/${parent.suffix}`}
+                                time={moment(parent.publishedAt).fromNow()}
+                                authors={parent.authors}
+                              />
+                            </a>
+                          </Link>
+                        </>
+                      ))}
+                      {/* /End replace */}
+                    </div>
+                  </div>
+                </div>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+      <div className="flex-grow flex">
+        <div className="flex w-full">
+          Leads to:
+          {module.children.length > 0 ? (
+            <span
+              className="flex-grow cursor-pointer bg-gray-100 hover:bg-gray-50 ml-2 pl-2 border border-gray-500 rounded"
+              onClick={() => {
+                setLeadsToOpen(true)
+              }}
+            >
+              <div
+                key={module.children[0].title + "object"}
+                className="inline-block align-middle w-full"
+              >
+                <div className="flex">
+                  <span className="flex-grow">
+                    [{module.children[0].type.name}] {module.children[0].title}
+                  </span>
+                  <span className="mx-2">[...]</span>
+                </div>
+              </div>
+            </span>
+          ) : (
+            ""
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default LeadsToView

--- a/app/modules/components/ManageAuthors.tsx
+++ b/app/modules/components/ManageAuthors.tsx
@@ -11,6 +11,7 @@ import Autocomplete from "../../core/components/Autocomplete"
 import addAuthor from "../mutations/addAuthor"
 import updateAuthorRank from "../../authorship/mutations/updateAuthorRank"
 import AuthorList from "../../core/components/AuthorList"
+import SearchResultWorkspace from "../../core/components/SearchResultWorkspace"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -158,7 +159,7 @@ const ManageAuthors = ({ open, setOpen, moduleEdit, setQueryData }) => {
                                           },
                                           templates: {
                                             item({ item, components }) {
-                                              return <div>{item.handle}</div>
+                                              return <SearchResultWorkspace item={item} />
                                             },
                                           },
                                         },

--- a/app/modules/components/MetadataView.tsx
+++ b/app/modules/components/MetadataView.tsx
@@ -1,0 +1,39 @@
+import { Link } from "blitz"
+
+const MetadataView = ({ module }) => {
+  return (
+    <div className="w-full mt-8">
+      <p className="text-gray-500">{module.type.name}</p>
+      <h1 className="min-h-16 mb-2 font-bold text-xl">{module.title}</h1>
+      {/* Description */}
+      <div className="my-2">{module.description}</div>
+      {/* License */}
+      {module.license ? (
+        <div className="my-2">
+          License:{" "}
+          <Link href={module.license.url}>
+            <a className="underline" target="_blank">
+              {module.license.name}
+            </a>
+          </Link>
+        </div>
+      ) : (
+        <></>
+      )}
+      {module.published ? (
+        <div className="my-2">
+          DOI:{" "}
+          <Link href={`https://doi.org/10.53962/${module.suffix}`}>
+            <a target="_blank" className="underline">
+              10.53962/{module.suffix}
+            </a>
+          </Link>
+        </div>
+      ) : (
+        <></>
+      )}
+    </div>
+  )
+}
+
+export default MetadataView

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -22,6 +22,8 @@ import getTypes from "../../core/queries/getTypes"
 import getLicenses from "app/core/queries/getLicenses"
 import editModuleScreen from "../mutations/editModuleScreen"
 import EditSupportingFileDisplay from "../../core/components/EditSupportingFileDisplay"
+import MetadataView from "./MetadataView"
+import AuthorAvatars from "./AuthorAvatars"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -74,7 +76,7 @@ const ModuleEdit = ({ user, module, isAuthor }) => {
     formik.setFieldValue("type", moduleEdit!.type.id.toString())
     formik.setFieldValue("title", moduleEdit!.title)
     formik.setFieldValue("description", moduleEdit!.description)
-    formik.setFieldValue("license", moduleEdit!.license!.id)
+    formik.setFieldValue("license", moduleEdit!.license!.id.toString())
   }, [moduleEdit])
 
   return (
@@ -236,48 +238,12 @@ const ModuleEdit = ({ user, module, isAuthor }) => {
           </form>
         </div>
       ) : (
-        <div className="w-full mt-8">
-          <p className="text-gray-500 ">{moduleEdit!.type.name}</p>
-          <h1 className="min-h-16">{moduleEdit!.title}</h1>
-          {/* Description */}
-          <div className="">{moduleEdit!.description}</div>
-          {/* License */}
-          {moduleEdit!.license ? (
-            <div>
-              License:{" "}
-              {isEditing ? (
-                <Link href={moduleEdit!.license!.url}>
-                  <a target="_blank">{moduleEdit!.license!.name}</a>
-                </Link>
-              ) : (
-                <Link href={moduleEdit!.license!.url}>
-                  <a target="_blank">{moduleEdit!.license!.name}</a>
-                </Link>
-              )}
-            </div>
-          ) : (
-            <></>
-          )}
-        </div>
+        <MetadataView module={moduleEdit} />
       )}
-
       {/* Authors */}
       <div className="flex border-t border-b border-gray-800 mt-2 py-2">
         <div className="flex-grow flex -space-x-2 relative z-0 overflow-hidden">
-          <div className="inline-block h-full align-middle">
-            {moduleEdit?.authors.map((author) => (
-              <>
-                {/* Tricks it into the middle */}
-                <span className="inline-block h-full align-middle"></span>
-                <img
-                  key={author.id + author.workspace!.handle}
-                  alt={`Avatar of ${author.workspace!.handle}`}
-                  className="inline-block align-middle relative z-30 inline-block h-8 w-8 rounded-full"
-                  src={author.workspace?.avatar!}
-                />
-              </>
-            ))}
-          </div>
+          <AuthorAvatars module={module} />
         </div>
         <ManageAuthors
           open={manageAuthorsOpen}

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -24,6 +24,7 @@ import editModuleScreen from "../mutations/editModuleScreen"
 import EditSupportingFileDisplay from "../../core/components/EditSupportingFileDisplay"
 import MetadataView from "./MetadataView"
 import AuthorAvatars from "./AuthorAvatars"
+import SearchResultModule from "../../core/components/SearchResultModule"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -150,7 +151,7 @@ const ModuleEdit = ({ user, module, isAuthor }) => {
               templates: {
                 item({ item, components }) {
                   // TODO: Need to update search results per Algolia index
-                  return <div>{JSON.stringify(item)}</div>
+                  return <SearchResultModule item={item} />
                 },
               },
             },

--- a/app/modules/components/ViewAuthors.tsx
+++ b/app/modules/components/ViewAuthors.tsx
@@ -1,0 +1,139 @@
+import { Fragment, useState } from "react"
+import { Dialog, Transition } from "@headlessui/react"
+import { XIcon } from "@heroicons/react/outline"
+import { Link, Routes } from "blitz"
+
+const ViewAuthors = ({ button, module }) => {
+  const [viewAuthorsOpen, setViewAuthorsOpen] = useState(false)
+
+  return (
+    <>
+      <Transition.Root show={viewAuthorsOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="fixed inset-0 overflow-hidden"
+          onClose={() => {
+            setViewAuthorsOpen(false)
+          }}
+        >
+          <div className="absolute inset-0 overflow-hidden">
+            <Dialog.Overlay className="absolute inset-0" />
+
+            <div className="fixed inset-y-0 right-0 pl-10 max-w-full flex">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <div className="w-screen max-w-md">
+                  <div className="h-full flex flex-col py-6 bg-gray-300 shadow-xl overflow-y-scroll">
+                    <div className="px-4 sm:px-6">
+                      <div className="flex items-start justify-between">
+                        <Dialog.Title className="text-lg font-medium text-gray-900">
+                          Authors
+                        </Dialog.Title>
+                        <div className="ml-3 h-7 flex items-center">
+                          <button
+                            type="button"
+                            className=" rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                            onClick={() => setViewAuthorsOpen(false)}
+                          >
+                            <span className="sr-only">Close panel</span>
+                            <XIcon className="h-6 w-6" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="mt-6 relative flex-1 px-4 sm:px-6">
+                      {/* Replace with your content */}
+
+                      <div className="flex flex-col bg-gray-50">
+                        <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                          <div className="py-2 align-middle inline-block sm:px-6 lg:px-8 w-full">
+                            <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                              <table className="divide-y divide-gray-200 w-full">
+                                <thead>
+                                  <tr>
+                                    <th
+                                      scope="col"
+                                      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                                    >
+                                      Name
+                                    </th>
+                                  </tr>
+                                </thead>
+                                <tbody className=" divide-y divide-gray-200">
+                                  {/* TODO: Add author list */}
+                                  {module.authors.map((author) => (
+                                    <>
+                                      <tr>
+                                        <td className="px-6 py-4 whitespace-nowrap">
+                                          <div className="flex items-center">
+                                            <div className="flex-shrink-0 h-10 w-10">
+                                              <img
+                                                className="h-10 w-10 rounded-full"
+                                                src={author!.workspace!.avatar}
+                                                alt={`Avatar of ${author!.workspace!.name}`}
+                                              />
+                                            </div>
+                                            <div className="ml-4">
+                                              <div className="text-sm font-medium text-gray-900">
+                                                {author!.workspace!.name}
+                                              </div>
+                                              <div className="text-sm text-gray-500 underline">
+                                                <Link
+                                                  href={Routes.HandlePage({
+                                                    handle: author.workspace.handle,
+                                                  })}
+                                                >
+                                                  <a target="_blank">
+                                                    @{author!.workspace!.handle}
+                                                  </a>
+                                                </Link>
+                                              </div>
+                                              <div className="text-sm text-gray-500 underline">
+                                                <Link
+                                                  href={`https://orcid.org/${author.workspace.orcid}`}
+                                                >
+                                                  <a target="_blank">{author.workspace.orcid}</a>
+                                                </Link>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </td>
+                                      </tr>
+                                    </>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      {/* /End replace */}
+                    </div>
+                  </div>
+                </div>
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+      <button
+        type="button"
+        className="inline-flex items-center h-8  px-6 py-3 border border-transparent  font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        onClick={() => {
+          setViewAuthorsOpen(true)
+        }}
+      >
+        View authors
+      </button>
+    </>
+  )
+}
+
+export default ViewAuthors

--- a/app/modules/components/ViewFiles.tsx
+++ b/app/modules/components/ViewFiles.tsx
@@ -1,0 +1,19 @@
+import { Download32 } from "@carbon/icons-react"
+
+const ViewFiles = ({ name, size, url }) => {
+  return (
+    <div className="flex my-2">
+      <p className="flex-grow flex border-2 border-gray-700 px-2 py-1 hover:bg-indigo-500">
+        <span className="flex-grow">{name}</span>
+        <span>{size / 1000}KB</span>
+      </p>
+      <p className="flex">
+        <a href={url} target="_blank" download rel="noreferrer">
+          <Download32 />
+        </a>
+      </p>
+    </div>
+  )
+}
+
+export default ViewFiles

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -12,7 +12,15 @@ import { Prisma } from "prisma"
 import Layout from "../../core/layouts/Layout"
 import db from "db"
 import NavbarApp from "../../core/components/Navbar"
+import { Link } from "blitz"
+import MetadataView from "../../modules/components/MetadataView"
+import ViewFiles from "../../modules/components/ViewFiles"
+import ViewAuthors from "../../modules/components/ViewAuthors"
+import FollowsFromView from "../../modules/components/FollowsFromView"
+import LeadsToView from "../../modules/components/LeadsToView"
+import AuthorAvatars from "../../modules/components/AuthorAvatars"
 
+// TODO: Replace with getServerSideProps
 export async function getStaticPaths() {
   const modules = await db.module.findMany({
     where: {
@@ -42,8 +50,28 @@ export async function getStaticProps(context) {
       suffix: context.params.suffix,
     },
     include: {
-      parents: true,
-      children: true,
+      parents: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+      children: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+      license: true,
+      type: true,
       authors: {
         include: {
           workspace: true,
@@ -64,9 +92,9 @@ const ModulePage = ({ module }) => {
   const supportingRaw = module!.supporting as Prisma.JsonObject
 
   return (
-    <Layout title={`R= ${module.title}`}>
+    <Layout title={`R=${module.title}`}>
       <NavbarApp />
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-7xl mx-auto my-4">
         <div className="w-full bg-gray-300 flex">
           <div className="flex-grow"></div>
           <Share32 />
@@ -76,123 +104,56 @@ const ModulePage = ({ module }) => {
         <div className="text-center">
           Published {moment(module.publishedAt).fromNow()} ({module.publishedAt.toUTCString()})
         </div>
-        <div className="w-full bg-gray-500 flex">
-          <div className="flex-grow flex">
-            Follows from:
-            {module.parents.map((parent) => (
-              <div key={parent.title + "object"} className="bg-gray-200 w-full">
-                [{parent.type}] {parent.title}
-              </div>
-            ))}
-          </div>
-          <Flow32 className="transform rotate-180" />
-          <div className="flex-grow flex">
-            Leads to:
-            {module.children.map((children) => (
-              <div key={children.title + "object"} className="bg-gray-200 w-full">
-                [{children.type}] {children.title}
-              </div>
-            ))}
-          </div>
+        <div className="w-full flex my-8">
+          <FollowsFromView module={module} />
+          <svg
+            className="fill-current text-black w-8 h-8 mx-4 "
+            viewBox="0 0 32 32"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M27 13L32 15.8868L27 18.7735V16.3868H26C21.5298 16.3868 17.7807 19.4742 16.7689 23.6331C16.6473 23.0488 16.4793 22.4815 16.2689 21.9352C17.83 18.0946 21.5988 15.3868 26 15.3868H27V13Z"
+            />
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M6 16.3867H0V15.3867H6C11.799 15.3867 16.5 20.0877 16.5 25.8867V26.8867H18.8868L16 31.8867L13.1132 26.8867H15.5V25.8867C15.5 20.64 11.2467 16.3867 6 16.3867Z"
+            />
+          </svg>
+          <LeadsToView module={module} />
         </div>
-        {/* parent/child bar */}
         {/* metadata */}
+        <MetadataView module={module} />
+
         {/* main file */}
-        <div className="w-full">
-          <p>{module.type}</p>
-          <h1>{module.title}</h1>
-        </div>
-        <div className="border-t-2 border-gray-400 flex">
-          <span className="flex-grow">
-            {module.authors.map((author) => (
-              <>
-                <img
-                  className="relative z-30 inline-block h-6 w-6 rounded-full ring-2 ring-white"
-                  key={author.name}
-                  src={author.workspace.avatar}
-                />
-                <img
-                  className="relative z-30 inline-block h-6 w-6 rounded-full ring-2 ring-white"
-                  key={author.name}
-                  src={author.workspace.avatar}
-                />
-                <img
-                  className="relative z-30 inline-block h-6 w-6 rounded-full ring-2 ring-white"
-                  key={author.name}
-                  src={author.workspace.avatar}
-                />
-                <img
-                  className="relative z-30 inline-block h-6 w-6 rounded-full ring-2 ring-white"
-                  key={author.name}
-                  src={author.workspace.avatar}
-                />
-              </>
-            ))}
-          </span>
-          <button className="px-4 py-2 text-white bg-indigo-600">View authors</button>
-        </div>
-        <div>
-          <p>{module.description}</p>
+        <div className="flex border-t border-b border-gray-800 mt-2 py-2">
+          <div className="flex-grow flex -space-x-2 relative z-0 overflow-hidden">
+            <AuthorAvatars module={module} />
+          </div>
+          <ViewAuthors button="button" module={module} />
         </div>
         <div>
           <div>
             <h2>Main file</h2>
-            <div className="flex">
-              <p className="flex-grow border-2 border-gray-800 flex">
-                <span className="flex-grow">Filename</span>
-                <span>4KB</span>
-              </p>
-              <Download32 className="w-6 h-6" />
-              <TrashCan32 className="w-6 h-6" />
-            </div>
+            <ViewFiles name={mainFile.name} size={mainFile.size} url={mainFile.cdnUrl} />
           </div>
-          <div>
+          <div className="pb-16">
             <h2>Supporting files</h2>
-            <div className="flex">
-              <p className="flex-grow border-2 border-gray-800 flex">
-                <span className="flex-grow">Filename</span>
-                <span>4KB</span>
-              </p>
-              <Download32 className="w-6 h-6" />
-              <TrashCan32 className="w-6 h-6" />
-            </div>
-            <div className="flex">
-              <p className="flex-grow border-2 border-gray-800 flex">
-                <span className="flex-grow">Filename</span>
-                <span>4KB</span>
-              </p>
-              <Download32 className="w-6 h-6" />
-              <TrashCan32 className="w-6 h-6" />
-            </div>
-            <div className="flex">
-              <p className="flex-grow border-2 border-gray-800 flex">
-                <span className="flex-grow">Filename</span>
-                <span>4KB</span>
-              </p>
-              <Download32 className="w-6 h-6" />
-              <TrashCan32 className="w-6 h-6" />
-            </div>
-            <div className="flex">
-              <p className="flex-grow border-2 border-gray-800 flex">
-                <span className="flex-grow">Filename</span>
-                <span>4KB</span>
-              </p>
-              <Download32 className="w-6 h-6" />
-              <TrashCan32 className="w-6 h-6" />
-            </div>
+            {supportingRaw.files.map((file) => (
+              <>
+                <ViewFiles
+                  name={file.original_filename}
+                  size={file.size}
+                  url={file.original_file_url}
+                />
+              </>
+            ))}
           </div>
         </div>
-        {/* supplemental files */}
-        {/* references */}
-        {/* footer */}
-        {/* doi */}
-        {/* license */}
-        <footer>
-          <div>DOI: 10.53962/{module.suffix}</div>
-          <div>{module.license}</div>
-        </footer>
       </div>
-      {/* <div>{JSON.stringify(module)}</div> */}
     </Layout>
   )
 }


### PR DESCRIPTION
This PR adds basic styling for the search results throughout the application.

![Screenshot 2021-11-24 at 11 42 48](https://user-images.githubusercontent.com/2946344/143223643-9967d6a2-ff6e-4035-8084-fe658aadfb38.png)

For workspaces, the avatar is included. For modules, a generic icon is used, but technically we could expand this by using a (1) content type related icon or (2) user selected icon from a preselected library. But that, that is another feature so writing it here for future reference only :-)

Further styling will require some more work, given that Algolia's autocomplete is themed (see [theme](https://github.com/algolia/autocomplete/blob/next/packages/autocomplete-theme-classic/src/theme.scss)) from which deviations can be added.
