### PR TITLE
Add R= logo

### DIFF
--- a/app/core/components/Navbar.tsx
+++ b/app/core/components/Navbar.tsx
@@ -6,6 +6,7 @@ import algoliasearch from "algoliasearch"
 import { Blog32 } from "@carbon/icons-react"
 import SearchResultWorkspace from "./SearchResultWorkspace"
 import SearchResultModule from "./SearchResultModule"
+import ResearchEqualsLogo from "./ResearchEqualsLogo"
 
 import "@algolia/autocomplete-theme-classic"
 import Autocomplete from "./Autocomplete"
@@ -26,11 +27,7 @@ const Navbar = () => {
               {/* TODO: Replace w logo */}
               <Link href={Routes.Home()}>
                 <a>
-                  <img
-                    className="block h-8 w-auto"
-                    src="https://tailwindui.com/img/logos/workflow-mark.svg?color=indigo&shade=600"
-                    alt="Workflow"
-                  />
+                  <ResearchEqualsLogo />
                 </a>
               </Link>
             </div>

--- a/app/core/components/NavbarDropdown.tsx
+++ b/app/core/components/NavbarDropdown.tsx
@@ -10,6 +10,7 @@ import logout from "../../auth/mutations/logout"
 import SettingsModal from "../modals/settings"
 import changeSessionWorkspace from "../../workspaces/mutations/changeSessionWorkspace"
 import getDrafts from "../queries/getDrafts"
+import ResearchEqualsLogo from "./ResearchEqualsLogo"
 
 const DropdownContents = () => {
   const currentUser = useCurrentUser()
@@ -238,11 +239,12 @@ const NavbarDropdown = () => {
                   <div className="pt-0 pb-6 px-0">
                     <div className="flex items-center justify-between">
                       <div>
-                        <img
+                        <ResearchEqualsLogo />
+                        {/* <img
                           className="block h-8 w-auto"
                           src="https://tailwindui.com/img/logos/workflow-mark.svg?color=indigo&shade=600"
                           alt="Workflow"
-                        />
+                        /> */}
                       </div>
                       <div className="-mr-2">
                         <button className="rounded-md p-2 inline-flex items-center justify-center text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">

--- a/app/core/components/NavbarDropdown.tsx
+++ b/app/core/components/NavbarDropdown.tsx
@@ -240,11 +240,6 @@ const NavbarDropdown = () => {
                     <div className="flex items-center justify-between">
                       <div>
                         <ResearchEqualsLogo />
-                        {/* <img
-                          className="block h-8 w-auto"
-                          src="https://tailwindui.com/img/logos/workflow-mark.svg?color=indigo&shade=600"
-                          alt="Workflow"
-                        /> */}
                       </div>
                       <div className="-mr-2">
                         <button className="rounded-md p-2 inline-flex items-center justify-center text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">


### PR DESCRIPTION
This PR adds the R= logo to the navigation.

![Screenshot 2021-11-25 at 14 56 35](https://user-images.githubusercontent.com/2946344/143454318-fab4f828-d573-4c95-a03e-7236d8627102.png)
![Screenshot 2021-11-25 at 14 56 37](https://user-images.githubusercontent.com/2946344/143454325-771e723f-da61-4c87-933a-303947a3244c.png)
