### PR TITLE
Add invitations tab and notifications

### DIFF
--- a/app/core/components/NavbarFullwidthMenu.tsx
+++ b/app/core/components/NavbarFullwidthMenu.tsx
@@ -7,7 +7,12 @@ import {
   validateZodSchema,
   useQuery,
 } from "blitz"
-import { OverflowMenuHorizontal32, Notification32, Settings32 } from "@carbon/icons-react"
+import {
+  OverflowMenuHorizontal32,
+  Notification32,
+  NotificationNew32,
+  Settings32,
+} from "@carbon/icons-react"
 import { Listbox, Menu, Popover, Transition } from "@headlessui/react"
 import { Fragment, useState } from "react"
 import { CheckIcon, SelectorIcon, ChevronDownIcon } from "@heroicons/react/solid"
@@ -128,7 +133,11 @@ const FullWidthMenu = () => {
                 ml-5 flex-shrink-0 p-1 text-gray-400 hover:text-gray-500 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500`}
               >
                 <span className="sr-only">View notifications</span>
-                <Notification32 className="h-6 w-6" aria-hidden="true" />
+                {invitedModules.length > 0 ? (
+                  <NotificationNew32 className="h-6 w-6" aria-hidden="true" />
+                ) : (
+                  <Notification32 className="h-6 w-6" aria-hidden="true" />
+                )}
               </Popover.Button>
               <Transition
                 as={Fragment}
@@ -143,13 +152,15 @@ const FullWidthMenu = () => {
                   <ul className="divide-y divide-gray-500">
                     {invitedModules.map((invited) => (
                       <>
-                        <li className="p-2">
-                          <p className="text-xs leading-4 text-gray-500">
-                            {moment(invited.updatedAt).fromNow()}
-                          </p>
-                          <p className="text-xs leading-4 font-bold">Invited to co-author</p>
-                          <p className="text-xs leading-4">{invited.title}</p>
-                        </li>
+                        <Link href="/invitations">
+                          <li className="cursor-pointer p-2">
+                            <p className="text-xs leading-4 text-gray-500">
+                              {moment(invited.updatedAt).fromNow()}
+                            </p>
+                            <p className="text-xs leading-4 font-bold">{invited.title}</p>
+                            <p className="text-xs leading-4">Invited to co-author</p>
+                          </li>
+                        </Link>
                       </>
                     ))}
                   </ul>

--- a/app/core/components/NavbarFullwidthMenu.tsx
+++ b/app/core/components/NavbarFullwidthMenu.tsx
@@ -1,8 +1,8 @@
 import { Link, Routes, useMutation, useSession, useRouter, validateZodSchema } from "blitz"
 import { OverflowMenuHorizontal32, Notification32, Settings32 } from "@carbon/icons-react"
-import { Listbox, Menu, Transition } from "@headlessui/react"
+import { Listbox, Menu, Popover, Transition } from "@headlessui/react"
 import { Fragment, useState } from "react"
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid"
+import { CheckIcon, SelectorIcon, ChevronDownIcon } from "@heroicons/react/solid"
 
 import { useCurrentUser } from "../hooks/useCurrentUser"
 import { useCurrentWorkspace } from "../hooks/useCurrentWorkspace"
@@ -108,13 +108,33 @@ const FullWidthMenu = () => {
             </Transition>
           </div>
         </Listbox>
-        <a
-          href="#"
-          className="ml-5 flex-shrink-0 p-1 text-gray-400 hover:text-gray-500 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        >
-          <span className="sr-only">View notifications</span>
-          <Notification32 className="h-6 w-6" aria-hidden="true" />
-        </a>
+        <Popover className="relative">
+          {({ open }) => (
+            <>
+              <Popover.Button
+                className={`
+                ${open ? "" : "text-opacity-90"}
+                ml-5 flex-shrink-0 p-1 text-gray-400 hover:text-gray-500 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500`}
+              >
+                <span className="sr-only">View notifications</span>
+                <Notification32 className="h-6 w-6" aria-hidden="true" />
+              </Popover.Button>
+              <Transition
+                as={Fragment}
+                enter="transition ease-out duration-200"
+                enterFrom="opacity-0 translate-y-1"
+                enterTo="opacity-100 translate-y-0"
+                leave="transition ease-in duration-150"
+                leaveFrom="opacity-100 translate-y-0"
+                leaveTo="opacity-0 translate-y-1"
+              >
+                <Popover.Panel className="absolute z-10 max-w-28 w-28 bg-gray-300 dark:bg-gray-300 px-4 mt-3 transform -translate-x-1/2 left-1/2 sm:px-0">
+                  <div className="p-2">test</div>
+                </Popover.Panel>
+              </Transition>
+            </>
+          )}
+        </Popover>
         <span className="sr-only">Open settings</span>
         <SettingsModal
           styling="block text-left text-sm text-gray-700 rounded-full flex focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 lg:ml-5"

--- a/app/core/components/NavbarFullwidthMenu.tsx
+++ b/app/core/components/NavbarFullwidthMenu.tsx
@@ -1,8 +1,17 @@
-import { Link, Routes, useMutation, useSession, useRouter, validateZodSchema } from "blitz"
+import {
+  Link,
+  Routes,
+  useMutation,
+  useSession,
+  useRouter,
+  validateZodSchema,
+  useQuery,
+} from "blitz"
 import { OverflowMenuHorizontal32, Notification32, Settings32 } from "@carbon/icons-react"
 import { Listbox, Menu, Popover, Transition } from "@headlessui/react"
 import { Fragment, useState } from "react"
 import { CheckIcon, SelectorIcon, ChevronDownIcon } from "@heroicons/react/solid"
+import moment from "moment"
 
 import { useCurrentUser } from "../hooks/useCurrentUser"
 import { useCurrentWorkspace } from "../hooks/useCurrentWorkspace"
@@ -10,12 +19,14 @@ import logout from "../../auth/mutations/logout"
 import SettingsModal from "../modals/settings"
 import changeSessionWorkspace from "../../workspaces/mutations/changeSessionWorkspace"
 import QuickDraft from "../../modules/components/QuickDraft"
+import getInvitedModules from "../../workspaces/queries/getInvitedModules"
 
 const FullWidthMenu = () => {
   const currentUser = useCurrentUser()
   const session = useSession()
   const router = useRouter()
   const currentWorkspace = useCurrentWorkspace()
+  const [invitedModules] = useQuery(getInvitedModules, { session })
   const [logoutMutation] = useMutation(logout)
   const [changeSessionWorkspaceMutation] = useMutation(changeSessionWorkspace)
   // Match the selected state with the session workspace
@@ -128,8 +139,20 @@ const FullWidthMenu = () => {
                 leaveFrom="opacity-100 translate-y-0"
                 leaveTo="opacity-0 translate-y-1"
               >
-                <Popover.Panel className="absolute z-10 max-w-28 w-28 bg-gray-300 dark:bg-gray-300 px-4 mt-3 transform -translate-x-1/2 left-1/2 sm:px-0">
-                  <div className="p-2">test</div>
+                <Popover.Panel className="absolute z-10 max-w-72 w-72 bg-gray-300 dark:bg-gray-300 px-4 mt-3 transform -translate-x-1/2 left-1/2 sm:px-0 shadow-2xl">
+                  <ul className="divide-y divide-gray-500">
+                    {invitedModules.map((invited) => (
+                      <>
+                        <li className="p-2">
+                          <p className="text-xs leading-4 text-gray-500">
+                            {moment(invited.updatedAt).fromNow()}
+                          </p>
+                          <p className="text-xs leading-4 font-bold">Invited to co-author</p>
+                          <p className="text-xs leading-4">{invited.title}</p>
+                        </li>
+                      </>
+                    ))}
+                  </ul>
                 </Popover.Panel>
               </Transition>
             </>

--- a/app/core/components/NavbarTabs.tsx
+++ b/app/core/components/NavbarTabs.tsx
@@ -1,3 +1,4 @@
+import getInvitedModules from "app/workspaces/queries/getInvitedModules"
 import { Link, Routes, useQuery, useSession, useRouter } from "blitz"
 
 import { useCurrentUser } from "../hooks/useCurrentUser"
@@ -14,7 +15,7 @@ const NavTabs = () => {
   const currentWorkspace = useCurrentWorkspace()
   const router = useRouter()
   const [drafts] = useQuery(getDrafts, { session })
-  console.log(currentWorkspace)
+  const [invitations] = useQuery(getInvitedModules, { session })
 
   let tabs
   if (currentWorkspace) {
@@ -34,6 +35,12 @@ const NavTabs = () => {
         href: Routes.DraftsPage(),
         count: drafts.length,
         current: router.asPath === Routes.DraftsPage().pathname,
+      },
+      {
+        name: "Invitations",
+        href: Routes.InvitationsPage(),
+        count: invitations.length,
+        current: router.asPath === Routes.InvitationsPage().pathname,
       },
     ]
   }

--- a/app/core/components/NavbarTabs.tsx
+++ b/app/core/components/NavbarTabs.tsx
@@ -58,7 +58,8 @@ const NavTabs = () => {
                       tab.current
                         ? "border-indigo-500 text-gray-200"
                         : "border-transparent hover:text-gray-300 hover:border-gray-200",
-                      "whitespace-nowrap flex py-4 px-1 border-b-2 font-medium text-sm"
+                      tab.count === 0 ? "pointer-events-none text-gray-300" : "",
+                      "whitespace-nowrap flex py-4 px-1 border-b-2 font-medium text-sm disabled"
                     )}
                     aria-current={tab.current ? "page" : undefined}
                   >

--- a/app/modules/components/ModuleInvitation.tsx
+++ b/app/modules/components/ModuleInvitation.tsx
@@ -66,38 +66,23 @@ const ModuleEdit = ({ user, module, isAuthor }) => {
       ) : (
         ""
       )}
-
       {/* Supporting files */}
-      {/* <div className="my-8">
-        <h2>Supporting file(s)</h2>
-        {supportingRaw.files.map((file) => (
-          <>
-            <ViewFiles
-              name={file.original_filename}
-              size={file.size}
-              url={file.original_file_url}
-            />
-          </>
-        ))}
-        {supportingRaw.files.length > 0 ? (
-          <>
-            {supportingRaw.files.map((file) => (
-              <>
-                <EditSupportingFileDisplay
-                  name={file.original_filename}
-                  size={file.size}
-                  url={file.original_file_url}
-                  uuid={file.uuid}
-                  suffix={moduleEdit!.suffix}
-                  setQueryData={setQueryData}
-                />
-              </>
-            ))}
-          </>
-        ) : (
-          <></>
-        )}
-      </div> */}
+      {supportingRaw.length > 0 ? (
+        <div className="my-8">
+          <h2>Supporting file(s)</h2>
+          {supportingRaw.files.map((file) => (
+            <>
+              <ViewFiles
+                name={file.original_filename}
+                size={file.size}
+                url={file.original_file_url}
+              />
+            </>
+          ))}
+        </div>
+      ) : (
+        ""
+      )}
       {/* PLACEHOLDER References */}
     </div>
   )

--- a/app/modules/components/ModuleInvitation.tsx
+++ b/app/modules/components/ModuleInvitation.tsx
@@ -1,0 +1,106 @@
+import { useQuery, useMutation, Link, validateZodSchema } from "blitz"
+import { useState, useEffect } from "react"
+import moment from "moment"
+import algoliasearch from "algoliasearch"
+import { Toaster } from "react-hot-toast"
+import { Edit32, EditOff32, Save32 } from "@carbon/icons-react"
+import { Prisma } from "prisma"
+import useCurrentModule from "../queries/useCurrentModule"
+import MetadataView from "./MetadataView"
+import AuthorAvatars from "./AuthorAvatars"
+import ViewAuthors from "./ViewAuthors"
+import ViewFiles from "./ViewFiles"
+import FollowsFromView from "./FollowsFromView"
+
+const ModuleEdit = ({ user, module, isAuthor }) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [manageAuthorsOpen, setManageAuthorsOpen] = useState(false)
+  const [moduleEdit, { refetch, setQueryData }] = useQuery(
+    useCurrentModule,
+    { suffix: module.suffix },
+    { refetchOnWindowFocus: true }
+  )
+
+  const mainFile = moduleEdit!.main as Prisma.JsonObject
+  const supportingRaw = moduleEdit!.supporting as Prisma.JsonObject
+
+  return (
+    <div className="max-w-4xl mx-auto overflow-y-auto text-base">
+      <Toaster position="bottom-center" reverseOrder={false} />
+      {/* Menu bar */}
+      <div className="w-full flex">
+        {/* Push all menu bars to the right */}
+        <div className="flex-grow"></div>
+        <div>
+          <span className="inline-block h-full align-middle"> </span>
+        </div>
+      </div>
+      {/* Last updated */}
+      <div className="text-center ">
+        Last updated: {moment(moduleEdit?.updatedAt).fromNow()} (
+        {moduleEdit?.updatedAt.toISOString()})
+      </div>
+      {/* Parents */}
+      {moduleEdit?.parents!.length! > 0 ? (
+        <div className="flex w-full max-h-8 my-2">
+          <FollowsFromView module={moduleEdit} />
+        </div>
+      ) : (
+        ""
+      )}
+      <MetadataView module={moduleEdit} />
+      {/* Authors */}
+      <div className="flex border-t border-b border-gray-800 mt-2 py-2">
+        <div className="flex-grow flex -space-x-2 relative z-0 overflow-hidden">
+          <AuthorAvatars module={module} />
+        </div>
+        {/* TODO: View Authors */}
+        <ViewAuthors button="button" module={module} />
+      </div>
+
+      {mainFile ? (
+        <div className="my-8">
+          <h2 className="">Main file</h2>
+          <ViewFiles name={mainFile.name} size={mainFile.size} url={mainFile.cdnUrl} />
+        </div>
+      ) : (
+        ""
+      )}
+
+      {/* Supporting files */}
+      {/* <div className="my-8">
+        <h2>Supporting file(s)</h2>
+        {supportingRaw.files.map((file) => (
+          <>
+            <ViewFiles
+              name={file.original_filename}
+              size={file.size}
+              url={file.original_file_url}
+            />
+          </>
+        ))}
+        {supportingRaw.files.length > 0 ? (
+          <>
+            {supportingRaw.files.map((file) => (
+              <>
+                <EditSupportingFileDisplay
+                  name={file.original_filename}
+                  size={file.size}
+                  url={file.original_file_url}
+                  uuid={file.uuid}
+                  suffix={moduleEdit!.suffix}
+                  setQueryData={setQueryData}
+                />
+              </>
+            ))}
+          </>
+        ) : (
+          <></>
+        )}
+      </div> */}
+      {/* PLACEHOLDER References */}
+    </div>
+  )
+}
+
+export default ModuleEdit

--- a/app/modules/mutations/addParent.ts
+++ b/app/modules/mutations/addParent.ts
@@ -17,7 +17,16 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
       },
       license: true,
       type: true,
-      parents: true,
+      parents: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
     },
   })
 

--- a/app/modules/mutations/editModuleScreen.ts
+++ b/app/modules/mutations/editModuleScreen.ts
@@ -42,7 +42,16 @@ export default resolver.pipe(
         },
         license: true,
         type: true,
-        parents: true,
+        parents: {
+          include: {
+            type: true,
+            authors: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
+        },
       },
     })
 

--- a/app/modules/queries/useCurrentModule.ts
+++ b/app/modules/queries/useCurrentModule.ts
@@ -12,7 +12,16 @@ export default async function getCurrentWorkspace({ suffix }) {
       },
       license: true,
       type: true,
-      parents: true,
+      parents: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
     },
   })
 

--- a/app/pages/invitations.tsx
+++ b/app/pages/invitations.tsx
@@ -1,0 +1,138 @@
+import { BlitzPage, useSession, useQuery, useRouterQuery, Router } from "blitz"
+import Layout from "app/core/layouts/Layout"
+import { Disclosure } from "@headlessui/react"
+import { ChevronRightIcon } from "@heroicons/react/solid"
+import { Suspense, useState } from "react"
+import { ProgressBarRound32 } from "@carbon/icons-react"
+import moment from "moment"
+
+import Navbar from "../core/components/Navbar"
+import getDrafts from "../core/queries/getDrafts"
+import ModuleEdit from "../modules/components/ModuleEdit"
+import { useCurrentUser } from "../core/hooks/useCurrentUser"
+import ModuleCard from "../core/components/ModuleCard"
+import getInvitedModules from "app/workspaces/queries/getInvitedModules"
+
+const Invitations = () => {
+  const session = useSession()
+  const [currentModule, setModule] = useState<any>(undefined)
+  const [invitations] = useQuery(getInvitedModules, { session })
+  const user = useCurrentUser()
+  // TODO: Actualy use routerquery for setmodule
+  const query = useRouterQuery()
+
+  return (
+    <Disclosure defaultOpen={true}>
+      {({ open }) => (
+        <>
+          <Disclosure.Panel
+            className="float-left w-full sm:border-r border-gray-700 sm:w-1/4 bg-gray-300 text-2xl text-gray-500 overflow-y-auto"
+            style={{
+              height: "calc(100vh - 78.233333px)",
+              float: "left",
+            }}
+          >
+            <Suspense fallback="Loading...">
+              <ul role="list" className="divide-y divide-gray-200">
+                {invitations.map((message, index) => (
+                  <>
+                    <li
+                      key={message.id + index}
+                      className={`cursor-pointer hidden sm:block relative focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-600 ${
+                        currentModule === message ? "bg-indigo-300" : "bg-white"
+                      }`}
+                      onClick={() => {
+                        setModule(message)
+                        Router.push("/invitations", { query: { suffix: message.suffix } })
+                      }}
+                    >
+                      <ModuleCard
+                        type={message.type.name}
+                        title={message.title}
+                        status="Invitation"
+                        time={moment(message.updatedAt).fromNow()}
+                        authors={message.authors}
+                      />
+                    </li>
+                    <span
+                      onClick={() => {
+                        setModule(message)
+                        Router.push("/invitations", { query: { suffix: message.suffix } })
+                      }}
+                    >
+                      <Disclosure.Button
+                        as="li"
+                        key={message.id + "-disclosure" + index}
+                        className={`sm:hidden relative focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-600 ${
+                          currentModule === message ? "bg-indigo-300" : "bg-white"
+                        }`}
+                      >
+                        <ModuleCard
+                          type={message.type.name}
+                          title={message.title}
+                          status="Draft"
+                          time={moment(message.updatedAt).fromNow()}
+                          authors={message.authors}
+                        />
+                      </Disclosure.Button>
+                    </span>
+                  </>
+                ))}
+              </ul>
+            </Suspense>
+          </Disclosure.Panel>
+          <Disclosure.Button className="hidden sm:inline inherit top-0 left-0 justify-between px-1 py-2 text-sm font-medium text-left text-gray-900 bg-gray-300 hover:bg-gray-200 focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+            <ChevronRightIcon
+              className={`${open ? "transform rotate-180" : ""} w-5 h-5 text-purple-500 `}
+            />
+          </Disclosure.Button>
+          <div
+            className={`${
+              open ? "bg-gray-300 hidden" : "bg-gray-300"
+            } float-right  sm:inline overflow-y-auto`}
+            style={{
+              top: 0,
+              width: "100%",
+              height: "calc(100vh - 78.233333px)",
+            }}
+          >
+            <div className="max-w-5xl my-16 sm:my-6  mx-auto text-xl">
+              <Disclosure.Button className="inline sm:hidden">x</Disclosure.Button>
+              {currentModule ? (
+                <Suspense
+                  fallback={
+                    <div className="mx-auto my-auto">
+                      <ProgressBarRound32 className="animate-spin" />
+                    </div>
+                  }
+                >
+                  <ModuleEdit user={user} module={currentModule} isAuthor={true} />
+                </Suspense>
+              ) : (
+                ""
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </Disclosure>
+  )
+}
+
+const InvitationsPage: BlitzPage = () => {
+  return (
+    <>
+      <Navbar />
+      <main className="flex relative">
+        <Suspense fallback="Loading...">
+          <Invitations />
+        </Suspense>
+      </main>
+    </>
+  )
+}
+
+InvitationsPage.authenticate = true
+InvitationsPage.getLayout = (page) => <Layout title="Invitations">{page}</Layout>
+
+export default InvitationsPage

--- a/app/pages/invitations.tsx
+++ b/app/pages/invitations.tsx
@@ -7,11 +7,10 @@ import { ProgressBarRound32 } from "@carbon/icons-react"
 import moment from "moment"
 
 import Navbar from "../core/components/Navbar"
-import getDrafts from "../core/queries/getDrafts"
-import ModuleEdit from "../modules/components/ModuleEdit"
 import { useCurrentUser } from "../core/hooks/useCurrentUser"
 import ModuleCard from "../core/components/ModuleCard"
 import getInvitedModules from "app/workspaces/queries/getInvitedModules"
+import ModuleInvitation from "../modules/components/ModuleInvitation"
 
 const Invitations = () => {
   const session = useSession()
@@ -106,7 +105,7 @@ const Invitations = () => {
                     </div>
                   }
                 >
-                  <ModuleEdit user={user} module={currentModule} isAuthor={true} />
+                  <ModuleInvitation user={user} module={currentModule} isAuthor={true} />
                 </Suspense>
               ) : (
                 ""

--- a/app/pages/invitations.tsx
+++ b/app/pages/invitations.tsx
@@ -1,24 +1,34 @@
-import { BlitzPage, useSession, useQuery, useRouterQuery, Router } from "blitz"
+import { BlitzPage, useSession, useQuery, useRouterQuery, Router, useMutation } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { Disclosure } from "@headlessui/react"
 import { ChevronRightIcon } from "@heroicons/react/solid"
 import { Suspense, useState } from "react"
 import { ProgressBarRound32 } from "@carbon/icons-react"
 import moment from "moment"
+import toast, { Toaster } from "react-hot-toast"
 
 import Navbar from "../core/components/Navbar"
 import { useCurrentUser } from "../core/hooks/useCurrentUser"
 import ModuleCard from "../core/components/ModuleCard"
 import getInvitedModules from "app/workspaces/queries/getInvitedModules"
 import ModuleInvitation from "../modules/components/ModuleInvitation"
+import acceptInvitation from "../authorship/mutations/acceptInvitation"
+import removeInvitation from "../authorship/mutations/removeInvitation"
+import { useCurrentWorkspace } from "../core/hooks/useCurrentWorkspace"
 
 const Invitations = () => {
   const session = useSession()
   const [currentModule, setModule] = useState<any>(undefined)
-  const [invitations] = useQuery(getInvitedModules, { session })
+  const currentWorkspace = useCurrentWorkspace()
+  const [invitations, { refetch }] = useQuery(getInvitedModules, { session })
   const user = useCurrentUser()
   // TODO: Actualy use routerquery for setmodule
   const query = useRouterQuery()
+  const [acceptMutation] = useMutation(acceptInvitation)
+  const [declineMutation] = useMutation(removeInvitation)
+  // todo: uses author ID and suffix
+  // requires us to match the current workspace to the author id for this module
+  // find author id in invitations by filtering for workspace id
 
   return (
     <Disclosure defaultOpen={true}>
@@ -95,6 +105,54 @@ const Invitations = () => {
               height: "calc(100vh - 78.233333px)",
             }}
           >
+            {/* TODO: Add invitation accept/decline */}
+            {currentModule ? (
+              <div className="w-full sm:flex p-2 bg-gray-400">
+                <div className="flex-grow text-middle align-middle">
+                  <span className="inline-block h-full align-middle text-sm leading-4"></span>
+                  You are invited to co-author this module. Do you accept the invitation?
+                </div>
+                <div>
+                  <button
+                    className="m-2 sm:my-0 py-2 px-4 border border-gray-500 bg-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    onClick={async () => {
+                      await acceptMutation({
+                        id: currentModule.authors.filter(
+                          (author) => author.workspaceId === currentWorkspace!.id
+                        )[0].id,
+                        suffix: currentModule.suffix,
+                      })
+                      refetch()
+                      // TODO: Move to next invitation on the list
+                      setModule(undefined)
+
+                      toast.success("Accepted invitation")
+                    }}
+                  >
+                    Accept
+                  </button>
+                  <button
+                    className="mx-2 py-2 px-4 border border-gray-500 bg-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    onClick={async () => {
+                      await declineMutation({
+                        id: currentModule.authors.filter(
+                          (author) => author.workspaceId === currentWorkspace!.id
+                        )[0].id,
+                        suffix: currentModule.suffix,
+                      })
+                      refetch()
+                      setModule(undefined)
+
+                      toast("Declined invitation", { icon: "👋" })
+                    }}
+                  >
+                    Decline
+                  </button>
+                </div>
+              </div>
+            ) : (
+              ""
+            )}
             <div className="max-w-5xl my-16 sm:my-6  mx-auto text-xl">
               <Disclosure.Button className="inline sm:hidden">x</Disclosure.Button>
               {currentModule ? (
@@ -121,6 +179,7 @@ const Invitations = () => {
 const InvitationsPage: BlitzPage = () => {
   return (
     <>
+      <Toaster position="bottom-center" reverseOrder={false} />
       <Navbar />
       <main className="flex relative">
         <Suspense fallback="Loading...">

--- a/app/workspaces/queries/getInvitedModules.ts
+++ b/app/workspaces/queries/getInvitedModules.ts
@@ -17,14 +17,15 @@ export default async function getInvitedModules({ session }) {
       },
     ],
     include: {
+      type: true,
       authors: {
-        where: {
-          workspaceId: session.workspaceId,
-          acceptedInvitation: null,
+        include: {
+          workspace: true,
         },
       },
     },
   })
 
+  console.log(invitedModules)
   return invitedModules
 }

--- a/app/workspaces/queries/getInvitedModules.ts
+++ b/app/workspaces/queries/getInvitedModules.ts
@@ -26,6 +26,5 @@ export default async function getInvitedModules({ session }) {
     },
   })
 
-  console.log(invitedModules)
   return invitedModules
 }

--- a/app/workspaces/queries/getInvitedModules.ts
+++ b/app/workspaces/queries/getInvitedModules.ts
@@ -1,0 +1,30 @@
+import db from "db"
+
+export default async function getInvitedModules({ session }) {
+  const invitedModules = await db.module.findMany({
+    where: {
+      published: false,
+      authors: {
+        some: {
+          workspaceId: session.workspaceId,
+          acceptedInvitation: null,
+        },
+      },
+    },
+    orderBy: [
+      {
+        updatedAt: "desc",
+      },
+    ],
+    include: {
+      authors: {
+        where: {
+          workspaceId: session.workspaceId,
+          acceptedInvitation: null,
+        },
+      },
+    },
+  })
+
+  return invitedModules
+}


### PR DESCRIPTION
This PR adds a tab to deal with invitations and a popover menu for the bell icon 🔔 

This (finally) gives people the capacity to deal with invitations for co-authorship. This is not readily extensible in its current format to other invitations (e.g., review, reproduce), but it's also not impossible to retrofit later. 

As often - a few seconds of video explains the implementation better than 10 minutes of writing.

https://user-images.githubusercontent.com/2946344/144110325-306aafea-08dc-4304-b001-3af9fa366db6.mov

