### PR TITLE
Error when not ready to publish

### DIFF
--- a/app/core/components/AuthorList.tsx
+++ b/app/core/components/AuthorList.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react"
-import { useMutation, useSession } from "blitz"
+import { Link, useMutation, useSession } from "blitz"
 import toast from "react-hot-toast"
 import { Draggable } from "react-beautiful-dnd"
 
@@ -136,12 +136,16 @@ function AuthorList({
                   <button
                     className="bg-green-500 rounded text-white px-4 py-2 hover:bg-green-600"
                     onClick={async () => {
-                      const updatedModule = await approveAuthorshipMutation({
-                        id: author.id,
-                        suffix,
-                      })
-                      toast.success("Version approved for publication")
-                      setAuthorState(updatedModule)
+                      if (!author.workspace.orcid || !author.workspace.name) {
+                        toast.error("You cannot publish until you link your ORCID")
+                      } else {
+                        const updatedModule = await approveAuthorshipMutation({
+                          id: author.id,
+                          suffix,
+                        })
+                        toast.success("Version approved for publication")
+                        setAuthorState(updatedModule)
+                      }
                       // alert("This will approve to publish")
                     }}
                   >


### PR DESCRIPTION
This PR adds an error when somebody tries to approve a module for publication from a workspace that is not adequately set up.

This means they get an error and are prevented from approving the module when either (1) the workspace doesn't have a name and (2) no linked ORCID to the workspace.

Note that this will no longer work when we allow people to set up group workspaces, e.g., for lab groups.

Fixes #98 