### PR TITLE
Update license sorting

### DIFF
--- a/app/core/queries/getLicenses.ts
+++ b/app/core/queries/getLicenses.ts
@@ -4,11 +4,13 @@ export default async function getLicenses() {
   const licenses = await db.license.findMany({
     orderBy: [
       {
-        name: "desc",
+        price: "asc",
+      },
+      {
+        name: "asc",
       },
     ],
   })
 
-  console.log(licenses)
   return licenses
 }


### PR DESCRIPTION
This PR updates the license sorting to have the free versions first, and then sorts by name too. 

It creates the (arbitrarily) desired ordering.

![Screenshot 2021-12-01 at 11 52 41](https://user-images.githubusercontent.com/2946344/144221673-00c9d15f-8b61-4ed3-a09f-e81f23a430a6.png)

Note: These prices are not final. Feel free to leave a comment in the discussion on license options #73  if you have thoughts/ideas! 🌶️ 