### PR TITLE
Add api route to remove unverified accounts

### DIFF
--- a/app/api/remove-unverified-accounts.ts
+++ b/app/api/remove-unverified-accounts.ts
@@ -1,0 +1,50 @@
+import db from "db"
+import { CronJob } from "quirrel/blitz"
+import { subDays } from "date-fns"
+
+export default CronJob(
+  "api/remove-unverified-accounts", // 👈 the route that it's reachable on
+  "0 0 * * 0",
+  async () => {
+    const users = await db.user.findMany({
+      where: {
+        createdAt: {
+          lt: subDays(Date.now(), 30),
+        },
+        updatedAt: {
+          lt: subDays(Date.now(), 30),
+        },
+        emailIsVerified: false,
+      },
+      include: {
+        memberships: {
+          include: {
+            workspace: {
+              include: {
+                authorships: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    users.map(async (user) => {
+      // delete memberships
+      await db.membership.deleteMany({
+        where: {
+          userId: user.id,
+        },
+      })
+      // delete user
+      await db.user.delete({
+        where: {
+          id: user.id,
+        },
+      })
+      // TODO: Remove remnant sessions
+    })
+
+    //  TODO: Remove workspaces without memberships and authorships
+  }
+)

--- a/app/auth/mutations/resendVerification.ts
+++ b/app/auth/mutations/resendVerification.ts
@@ -16,7 +16,7 @@ export default resolver.pipe(async (_, ctx) => {
   await Promise.all([
     sendEmailWithTemplate(user!.email!, "welcome", {
       handle: user!.email!,
-      days: 14,
+      days: 30,
       verify_email_url: url`/verifyEmail/${emailCode}`,
     }),
   ])

--- a/app/users/mutations/changeEmail.ts
+++ b/app/users/mutations/changeEmail.ts
@@ -19,7 +19,7 @@ export default resolver.pipe(resolver.authorize(), async ({ email }, ctx) => {
   await Promise.all([
     sendEmailWithTemplate(email, "welcome", {
       handle: "test",
-      days: 14,
+      days: 30,
       verify_email_url: url`/verifyEmail/${emailCode}`,
     }),
   ])


### PR DESCRIPTION
This PR adds a cron job through Quirrel to remove old (30 days now) user accounts whose email hasn't been verified yet.

The emails now also include the 30 days notice. 