### PR TITLE
Add database seeding of licenses

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: npx blitz prisma migrate deploy
+release: npx blitz prisma migrate deploy && npx blitz db seed
 web: npm rebuild blitz && quirrel ci && npm run start:production

--- a/db/migrations/20211216094959_constrain_url_name_combo/migration.sql
+++ b/db/migrations/20211216094959_constrain_url_name_combo/migration.sql
@@ -1,0 +1,56 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[url,name]` on the table `License` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Authorship" DROP CONSTRAINT "Authorship_moduleId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Membership" DROP CONSTRAINT "Membership_workspaceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Module" DROP CONSTRAINT "Module_moduleTypeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Token" DROP CONSTRAINT "Token_userId_fkey";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "License_url_name_key" ON "License"("url", "name");
+
+-- AddForeignKey
+ALTER TABLE "Module" ADD CONSTRAINT "Module_moduleTypeId_fkey" FOREIGN KEY ("moduleTypeId") REFERENCES "ModuleType"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Authorship" ADD CONSTRAINT "Authorship_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Token" ADD CONSTRAINT "Token_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "Authorship.moduleId_workspaceId_unique" RENAME TO "Authorship_moduleId_workspaceId_key";
+
+-- RenameIndex
+ALTER INDEX "Membership.workspaceId_invitedEmail_unique" RENAME TO "Membership_workspaceId_invitedEmail_key";
+
+-- RenameIndex
+ALTER INDEX "Module.suffix_unique" RENAME TO "Module_suffix_key";
+
+-- RenameIndex
+ALTER INDEX "Session.handle_unique" RENAME TO "Session_handle_key";
+
+-- RenameIndex
+ALTER INDEX "Token.hashedToken_type_unique" RENAME TO "Token_hashedToken_type_key";
+
+-- RenameIndex
+ALTER INDEX "User.email_unique" RENAME TO "User_email_key";
+
+-- RenameIndex
+ALTER INDEX "Workspace.handle_unique" RENAME TO "Workspace_handle_key";
+
+-- RenameIndex
+ALTER INDEX "Workspace.orcid_unique" RENAME TO "Workspace_orcid_key";

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -41,6 +41,8 @@ model License {
   name      String
   price     Int      @default(0)
   Module    Module[]
+
+  @@unique([url, name])
 }
 
 model ModuleType {

--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -1,4 +1,4 @@
-// import db from "./index"
+import db from "db"
 
 /*
  * This seed function is executed when you run `blitz db seed`.
@@ -8,9 +8,51 @@
  * realistic data.
  */
 const seed = async () => {
-  // for (let i = 0; i < 5; i++) {
-  //   await db.project.create({ data: { name: "Project " + i } })
-  // }
+  await db.license.createMany({
+    data: [
+      {
+        url: "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+        name: "CC0 Public Domain Dedication",
+        price: 0,
+      },
+      {
+        url: "https://creativecommons.org/licenses/by/4.0/legalcode",
+        name: "CC BY 4.0",
+        price: 0,
+      },
+      {
+        url: "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode",
+        name: "CC BY-NC-ND 4.0",
+        price: 42999,
+      },
+      {
+        url: "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+        name: "CC BY-NC-SA 4.0",
+        price: 32999,
+      },
+      {
+        url: "https://creativecommons.org/licenses/by-nd/4.0/legalcode",
+        name: "CC BY-ND 4.0",
+        price: 24999,
+      },
+      {
+        url: "https://creativecommons.org/licenses/by-nc/4.0/legalcode",
+        name: "CC BY-NC 4.0",
+        price: 19499,
+      },
+      {
+        url: "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
+        name: "CC BY-SA 4.0",
+        price: 14999,
+      },
+      {
+        url: "",
+        name: "All rights reserved",
+        price: 54999,
+      },
+    ],
+    skipDuplicates: true,
+  })
 }
 
 export default seed


### PR DESCRIPTION
This PR adds automated addition of the licenses to the database.

The seed script currently only creates the licenses and doesn't update based on changes made to the file. For this, we'll need to update `db/seed.ts` to do an [`upsert`](https://www.prisma.io/docs/concepts/components/prisma-client/crud#update-or-create-records) to create or update. Will create an issue for that in a moment.

## Pay to close

The pricing for the licenses is also a bit more thought out now. Under the pay to close model more restrictive licenses cost more. The following rank order is currently applied (from least to most restrictive)

1. CC0 Public Domain Dedication
2. CC BY 4.0
3. CC BY-SA 4.0
4. CC BY-NC 4.0
5. CC BY-ND 4.0
6. CC BY-NC-SA 4.0
7. CC BY-NC-ND 4.0
8. All rights reserved

The pricing for these is done under approximately a 30% increase per step, starting with the rate of 150 euro for CC BY-SA 4.0

<img width="1031" alt="Screenshot 2021-12-16 at 11 00 48" src="https://user-images.githubusercontent.com/2946344/146350448-2b5b8c9f-d096-4492-b371-1a245f6c1f2d.png">

```R
x = c(0, 0, 149.99, 194.99, 249.99, 329.99, 429.99, 549.99)
plot(x, type='o')
```

I'll blog about this model soon 😊 
