### PR TITLE
Extend module metadata

### DIFF
--- a/app/core/components/EditMainFileDisplay.tsx
+++ b/app/core/components/EditMainFileDisplay.tsx
@@ -3,7 +3,7 @@ import { useMutation } from "blitz"
 
 import deleteMainFile from "../../modules/mutations/deleteMainFile"
 
-const EditFileDisplay = ({ name, size, url, uuid, suffix, setQueryData }) => {
+const EditFileDisplay = ({ name, size, url, uuid, moduleId, setQueryData }) => {
   const [deleteMainMutation] = useMutation(deleteMainFile)
   return (
     <div className="flex my-2">
@@ -18,7 +18,7 @@ const EditFileDisplay = ({ name, size, url, uuid, suffix, setQueryData }) => {
         <TrashCan32
           className="cursor-pointer"
           onClick={async () => {
-            const updatedModule = await deleteMainMutation({ suffix, uuid })
+            const updatedModule = await deleteMainMutation({ id: moduleId, uuid })
             setQueryData(updatedModule)
           }}
         />

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -3,7 +3,7 @@ import { useMutation } from "blitz"
 
 import deleteSupportingFile from "../../modules/mutations/deleteSupportingFile"
 
-const EditSupportingFileDisplay = ({ name, size, url, uuid, suffix, setQueryData }) => {
+const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryData }) => {
   const [deleteMutation] = useMutation(deleteSupportingFile)
   return (
     <div className="flex my-2">
@@ -18,7 +18,7 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, suffix, setQueryData
         <TrashCan32
           className="cursor-pointer"
           onClick={async () => {
-            const updatedModule = await deleteMutation({ suffix, uuid })
+            const updatedModule = await deleteMutation({ id: moduleId, uuid })
             setQueryData(updatedModule)
           }}
         />

--- a/app/modules/components/EditMainFile.jsx
+++ b/app/modules/components/EditMainFile.jsx
@@ -13,13 +13,13 @@ const EditMainFile = ({ mainFile, setQueryData, moduleEdit }) => {
 
   return (
     <>
-      {mainFile ? (
+      {Object.keys(mainFile).length > 0 ? (
         <EditMainFileDisplay
           name={mainFile.name}
           size={mainFile.size}
           url={mainFile.cdnUrl}
           uuid={mainFile.uuid}
-          suffix={moduleEdit.suffix}
+          moduleId={moduleEdit.id}
           setQueryData={setQueryData}
         />
       ) : (
@@ -43,7 +43,7 @@ const EditMainFile = ({ mainFile, setQueryData, moduleEdit }) => {
                 try {
                   // TODO: Only store upon save
                   const updatedModule = await addMainMutation({
-                    suffix: moduleEdit?.suffix,
+                    id: moduleEdit?.id,
                     json: info,
                   })
                   setQueryData(updatedModule)

--- a/app/modules/components/EditSupportingFiles.jsx
+++ b/app/modules/components/EditSupportingFiles.jsx
@@ -17,7 +17,7 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit }) => {
     try {
       const newFiles = await getSupportingFilesMutation({ groupUuid: info.uuid })
       const updatedModule = await addSupportingMutation({
-        suffix: moduleEdit.suffix,
+        id: moduleEdit.id,
         newFiles: newFiles.files,
       })
       setQueryData(updatedModule)

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -61,7 +61,7 @@ const ModuleEdit = ({ user, module, isAuthor }) => {
     ),
     onSubmit: async (values) => {
       const updatedModule = await editModuleScreenMutation({
-        suffix: moduleEdit?.suffix,
+        id: moduleEdit?.id,
         typeId: parseInt(values.type),
         title: values.title,
         description: values.description,

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -286,7 +286,7 @@ const ModuleEdit = ({ user, module, isAuthor }) => {
                   size={file.size}
                   url={file.original_file_url}
                   uuid={file.uuid}
-                  suffix={moduleEdit!.suffix}
+                  moduleId={moduleEdit!.id}
                   setQueryData={setQueryData}
                 />
               </>

--- a/app/modules/mutations/addMain.ts
+++ b/app/modules/mutations/addMain.ts
@@ -2,14 +2,14 @@ import { NotFoundError, resolver } from "blitz"
 import db from "db"
 import { Prisma } from "prisma"
 
-export default resolver.pipe(resolver.authorize(), async ({ suffix, json }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, json }) => {
   const module = await db.module.update({
-    where: { suffix },
+    where: { id },
     data: { main: json as Prisma.JsonObject },
   })
 
   const updatedModule = await db.module.findFirst({
-    where: { suffix },
+    where: { id },
     include: {
       authors: {
         include: {

--- a/app/modules/mutations/addSupporting.ts
+++ b/app/modules/mutations/addSupporting.ts
@@ -2,10 +2,10 @@ import { NotFoundError, resolver } from "blitz"
 import db from "db"
 import { Prisma } from "prisma"
 
-export default resolver.pipe(resolver.authorize(), async ({ suffix, newFiles }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
   // 1. Get module supporting files JSON
   const oldModule = await db.module.findFirst({
-    where: { suffix },
+    where: { id },
   })
   let supportingFiles = oldModule?.supporting as Prisma.JsonObject
   // 2. Map the array to push each files object into supporting files
@@ -14,7 +14,7 @@ export default resolver.pipe(resolver.authorize(), async ({ suffix, newFiles }) 
   })
   // 3. write the data into the module
   const updatedModule = await db.module.update({
-    where: { suffix },
+    where: { id },
     data: { supporting: supportingFiles as Prisma.JsonObject },
     include: {
       authors: {

--- a/app/modules/mutations/changeAbstract.ts
+++ b/app/modules/mutations/changeAbstract.ts
@@ -1,9 +1,9 @@
 import { NotFoundError, resolver } from "blitz"
 import db from "db"
 
-export default resolver.pipe(resolver.authorize(), async ({ suffix, description }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, description }) => {
   const module = await db.module.update({
-    where: { suffix },
+    where: { id },
     data: { description },
   })
 
@@ -18,7 +18,7 @@ export default resolver.pipe(resolver.authorize(), async ({ suffix, description 
   })
 
   const updatedModule = await db.module.findFirst({
-    where: { suffix },
+    where: { id },
     include: {
       authors: {
         include: {

--- a/app/modules/mutations/changeTitle.ts
+++ b/app/modules/mutations/changeTitle.ts
@@ -1,9 +1,9 @@
 import { NotFoundError, resolver } from "blitz"
 import db from "db"
 
-export default resolver.pipe(resolver.authorize(), async ({ suffix, title }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, title }) => {
   const module = await db.module.update({
-    where: { suffix },
+    where: { id },
     data: { title },
   })
 
@@ -18,7 +18,7 @@ export default resolver.pipe(resolver.authorize(), async ({ suffix, title }) => 
   })
 
   const updatedModule = await db.module.findFirst({
-    where: { suffix },
+    where: { id },
     include: {
       authors: {
         include: {

--- a/app/modules/mutations/createModule.ts
+++ b/app/modules/mutations/createModule.ts
@@ -19,6 +19,7 @@ export default resolver.pipe(
 
     const module = await db.module.create({
       data: {
+        prefix: process.env.DOI_PREFIX,
         suffix: await generateSuffix(undefined),
         title,
         description,

--- a/app/modules/mutations/deleteMainFile.ts
+++ b/app/modules/mutations/deleteMainFile.ts
@@ -2,10 +2,10 @@ import { NotFoundError, resolver } from "blitz"
 import db from "db"
 import axios from "axios"
 
-export default resolver.pipe(resolver.authorize(), async ({ suffix, uuid }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
   const module = await db.module.update({
-    where: { suffix },
-    data: { main: null },
+    where: { id },
+    data: { main: {} },
   })
 
   // Force all authors to reapprove for publishing
@@ -30,7 +30,7 @@ export default resolver.pipe(resolver.authorize(), async ({ suffix, uuid }) => {
   })
 
   const updatedModule = await db.module.findFirst({
-    where: { suffix },
+    where: { id },
     include: {
       authors: {
         include: {

--- a/app/modules/mutations/deleteSupportingFile.ts
+++ b/app/modules/mutations/deleteSupportingFile.ts
@@ -3,15 +3,15 @@ import db from "db"
 import axios from "axios"
 import { Prisma } from "prisma"
 
-export default resolver.pipe(resolver.authorize(), async ({ suffix, uuid }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
   const module = await db.module.findFirst({
-    where: { suffix },
+    where: { id },
   })
   let supportingFiles = module!.supporting as Prisma.JsonObject
   supportingFiles.files = supportingFiles.files.filter((file) => file.uuid !== uuid)
 
   const updatedModule = await db.module.update({
-    where: { suffix: suffix },
+    where: { id },
     data: {
       supporting: supportingFiles,
     },

--- a/app/modules/mutations/editModuleScreen.ts
+++ b/app/modules/mutations/editModuleScreen.ts
@@ -3,9 +3,9 @@ import db from "db"
 
 export default resolver.pipe(
   resolver.authorize(),
-  async ({ suffix, typeId, title, description, licenseId }) => {
+  async ({ id, typeId, title, description, licenseId }) => {
     const module = await db.module.update({
-      where: { suffix },
+      where: { id },
       data: {
         type: {
           connect: {
@@ -33,7 +33,7 @@ export default resolver.pipe(
     })
 
     const updatedModule = await db.module.findFirst({
-      where: { suffix },
+      where: { id },
       include: {
         authors: {
           include: {

--- a/app/modules/mutations/publishModule.ts
+++ b/app/modules/mutations/publishModule.ts
@@ -51,6 +51,8 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }, ctx) =
     data: {
       published: true,
       publishedAt: moment(datetime).format(),
+      publishedWhere: "ResearchEquals",
+      url: `https://doi.org/${process.env.DOI_PREFIX}/${module!.suffix}`,
     },
     include: {
       license: true,
@@ -60,8 +62,7 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }, ctx) =
 
   await index.saveObject({
     objectID: publishedModule.id,
-    suffix: publishedModule.suffix,
-    doi: `10.53962/${publishedModule.suffix}`,
+    doi: `${process.env.DOI_PREFIX}/${publishedModule.suffix}`,
     license: publishedModule.license?.url,
     type: publishedModule.type.name,
     // It's called name and not title to improve Algolia search

--- a/blitz.config.ts
+++ b/blitz.config.ts
@@ -18,6 +18,7 @@ const config: BlitzConfig = {
     ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
     ALGOLIA_API_SEARCH_KEY: process.env.ALGOLIA_API_SEARCH_KEY,
     ALGOLIA_PREFIX: process.env.ALGOLIA_PREFIX,
+    DOI_PREFIX: process.env.DOI_PREFIX,
   },
   pageExtensions: ["md", "mdx", "tsx", "ts", "jsx", "js"],
   webpack(config, options) {

--- a/db/migrations/20211216140100_extend_module_metadata/migration.sql
+++ b/db/migrations/20211216140100_extend_module_metadata/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[prefix,suffix]` on the table `Module` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Module_suffix_key";
+
+-- AlterTable
+ALTER TABLE "Module" ADD COLUMN     "authorsRaw" JSONB,
+ADD COLUMN     "isbn" TEXT,
+ADD COLUMN     "prefix" TEXT,
+ADD COLUMN     "publishedWhere" TEXT,
+ADD COLUMN     "referencesRaw" JSONB,
+ADD COLUMN     "url" TEXT,
+ALTER COLUMN "suffix" DROP NOT NULL,
+ALTER COLUMN "title" SET DATA TYPE TEXT;
+
+-- CreateTable
+CREATE TABLE "_ModuleReference" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ModuleReference_AB_unique" ON "_ModuleReference"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ModuleReference_B_index" ON "_ModuleReference"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Module_prefix_suffix_key" ON "Module"("prefix", "suffix");
+
+-- AddForeignKey
+ALTER TABLE "_ModuleReference" ADD FOREIGN KEY ("A") REFERENCES "Module"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ModuleReference" ADD FOREIGN KEY ("B") REFERENCES "Module"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/db/migrations/20211216140205_add_default_json/migration.sql
+++ b/db/migrations/20211216140205_add_default_json/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Module" ALTER COLUMN "main" SET DEFAULT E'{}',
+ALTER COLUMN "authorsRaw" SET DEFAULT E'{}',
+ALTER COLUMN "referencesRaw" SET DEFAULT E'{}';

--- a/db/migrations/20211216142926_remove_default_main/migration.sql
+++ b/db/migrations/20211216142926_remove_default_main/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Module" ALTER COLUMN "main" DROP DEFAULT;

--- a/db/migrations/20211216143626_return_of_the_default/migration.sql
+++ b/db/migrations/20211216143626_return_of_the_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Module" ALTER COLUMN "main" SET DEFAULT E'{}';

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -13,25 +13,38 @@ generator client {
 // --------------------------------------
 
 model Module {
-  id          Int       @id @default(autoincrement())
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  published   Boolean   @default(false)
-  publishedAt DateTime?
-  suffix      String    @unique
-  title       String    @db.VarChar(300)
-  description String?
-  license     License?  @relation(fields: [licenseId], references: [id])
-  licenseId   Int?
+  id             Int       @id @default(autoincrement())
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  published      Boolean   @default(false)
+  publishedAt    DateTime?
+  publishedWhere String?
+  url            String?
+  isbn           String?
+  prefix         String?
+  suffix         String?
+  title          String
+  description    String? // Could rename to abstract/summary
+  license        License?  @relation(fields: [licenseId], references: [id])
+  licenseId      Int?
 
   type         ModuleType @relation(fields: [moduleTypeId], references: [id])
   moduleTypeId Int
 
-  main       Json?
-  supporting Json?        @default("{\"files\": []}")
+  main       Json? @default("{}")
+  supporting Json? @default("{\"files\": []}")
+
   authors    Authorship[]
-  parents    Module[]     @relation("ModuleToModule", references: [id])
-  children   Module[]     @relation("ModuleToModule", references: [id])
+  authorsRaw Json?        @default("{}")
+
+  parents  Module[] @relation("ModuleToModule", references: [id])
+  children Module[] @relation("ModuleToModule", references: [id])
+
+  references    Module[] @relation("ModuleReference", references: [id])
+  referencedBy  Module[] @relation("ModuleReference", references: [id])
+  referencesRaw Json?    @default("{}")
+
+  @@unique([prefix, suffix])
 }
 
 model License {


### PR DESCRIPTION
This PR extends the module metadata to be able to handle more traditional outputs (e.g., articles, books).

This pretty much means any output can be seen as a module - and that allows future extension to allow linking between modules published on R= to outputs published elsewhere. It also simplifies the creation of reference lists using the database of modules.