### PR TITLE
`[handle]` styling

### DIFF
--- a/app/core/components/ModuleCard.tsx
+++ b/app/core/components/ModuleCard.tsx
@@ -1,29 +1,43 @@
 const ModuleCard = ({ type, title, status, time, authors }) => {
   return (
-    <div className="flex flex-col h-32 w-full bg-gray-300 hover:bg-gray-100 text-base text-black p-2">
+    <div className="flex flex-col h-32 w-full hover:bg-gray-50 dark:hover:bg-gray-800 px-4 py-2">
       <div className="flex-grow">
-        <p className="text-xs text-gray-500">{type}</p>
-        <h2 className="text-base line-clamp-2">{title}</h2>
+        <p className="text-xs leading-4 font-normal text-gray-500 dark:text-gray-400">{type}</p>
+        <h2 className="text-sm leading-5 font-medium text-gray-900 dark:text-gray-200 line-clamp-2">
+          {title}
+        </h2>
       </div>
       <div className="flex">
-        <div className="flex-grow text-xs text-gray-500">
+        <div className="flex-grow text-xs leading-4 font-normal text-gray-500 dark:text-gray-400">
           <p>{status}</p>
-          <p>{time}</p>
+          <p>Published: {time}</p>
         </div>
-        <div className="flex -space-x-1 relative z-0 overflow-hidden">
-          <div className="inline-block h-full align-middle">
-            <span className="inline-block h-full align-middle"> </span>
-
-            {authors.map((author) => (
-              <>
+        <div className="flex -space-x-1 relative z-0 overflow-hidden p-1">
+          {authors.map((author, index) => (
+            <>
+              {index < 4 ? (
                 <img
-                  className="relative z-30 inline-block h-6 w-6 rounded-full"
+                  className="relative inline-block h-6 w-6 rounded-full ring-1 ring-white dark:ring-gray-800"
                   src={author.workspace.avatar}
                   alt={`Avatar of ${author.workspace.handle}`}
+                  style={{ zIndex: 100 - index }}
                 />
-              </>
-            ))}
-          </div>
+              ) : (
+                ""
+              )}
+            </>
+          ))}
+          {/* </div> */}
+          {authors.length >= 4 ? (
+            <>
+              <span className="inline-block h-full align-middle"> </span>
+              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs leading-4 font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 ring-1 ring-gray-300 dark:ring-gray-600 max-h-6 shadow-sm dark:shadow-none">
+                + {authors.length}
+              </span>
+            </>
+          ) : (
+            ""
+          )}
         </div>
       </div>
     </div>

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -8,7 +8,7 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
 }
 
-export default function SettingsModal({ button, styling, user, workspace, state = false }) {
+export default function SettingsModal({ button, styling, user, workspace }) {
   let [isOpen, setIsOpen] = useState(false)
   let [categories] = useState(["Workspace", "Account", "Billing"])
 

--- a/app/modules/components/HandlePanel.tsx
+++ b/app/modules/components/HandlePanel.tsx
@@ -1,0 +1,118 @@
+import { Dialog, Transition } from "@headlessui/react"
+import { CheckIcon, XIcon } from "@heroicons/react/solid"
+import FollowButton from "app/workspaces/components/FollowButton"
+import UnfollowButton from "app/workspaces/components/UnfollowButton"
+import followWorkspace from "app/workspaces/mutations/followWorkspace"
+import unfollowWorkspace from "app/workspaces/mutations/unfollowWorkspace"
+import getCurrentWorkspace from "app/workspaces/queries/getCurrentWorkspace"
+import { useMutation, useQuery } from "blitz"
+import { Fragment, useState } from "react"
+import toast from "react-hot-toast"
+
+const AuthorPanel = ({ buttonText, title, authors }) => {
+  const [openPanel, setPanelOpen] = useState(false)
+  // Used to display the follow / unfollow button
+  const [ownWorkspace, { refetch }] = useQuery(getCurrentWorkspace, null)
+  const [followWorkspaceMutation] = useMutation(followWorkspace)
+  const [unfollowWorkspaceMutation] = useMutation(unfollowWorkspace)
+
+  return (
+    <>
+      <span
+        onClick={() => {
+          setPanelOpen(true)
+        }}
+      >
+        <button>
+          {buttonText}
+          {/* Create module */}
+        </button>
+      </span>
+      <Transition.Root show={openPanel} as={Fragment}>
+        <Dialog as="div" className="fixed inset-0 overflow-hidden" onClose={setPanelOpen}>
+          <div className="absolute inset-0 overflow-hidden">
+            <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-25 transition-opacity" />
+
+            <div className="fixed inset-y-0 right-0 pl-10 max-w-full flex">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <div className="w-screen max-w-xs">
+                  <div className="min-h-0 flex-1 flex flex-col py-6 overflow-y-auto h-full dark:divide-gray-600 bg-white dark:bg-gray-900 shadow-xl">
+                    <div className="px-4 sm:px-6">
+                      <div className="flex items-start justify-between">
+                        <Dialog.Title className="text-lg font-medium text-gray-900 dark:text-white">
+                          {title}
+                        </Dialog.Title>
+                        <div className="ml-3 h-7 flex items-center">
+                          <button
+                            type="button"
+                            className="rounded-md text-gray-400 dark:text-gray-200 hover:text-gray-500 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            onClick={() => setPanelOpen(false)}
+                          >
+                            <span className="sr-only">Close panel</span>
+                            <XIcon className="h-6 w-6" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="mt-6 px-4 sm:px-6 text-sm leading-5 font-normal border-b border-gray-400 dark:border-gray-600 pb-4 dark:text-white">
+                      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Phasellus hendrerit.
+                      Pellentesque aliquet nibh nec urna. In nisi neque, aliquet vel, dapibus id,
+                      mattis vel, nisi.
+                    </div>
+                    {/* <div className="relative flex-1"> */}
+                    {/* Replace with your content */}
+                    <ul className="relative flex-1 divide-y divide-gray-400 dark:divide-gray-600">
+                      {authors.map((author) => (
+                        <>
+                          <li className="py-2 px-2 flex">
+                            <div className="mr-2">
+                              <img
+                                src={author.avatar}
+                                alt={`Avatar of ${author.name}`}
+                                className="w-10 h-10 rounded-full inline-block h-full align-middle"
+                              />
+                            </div>
+                            <div className="flex-grow">
+                              <span className="inline-block h-full align-middle"></span>
+                              <p className="text-gray-700 dark:text-gray-200 text-sm leading-4 font-normal my-auto inline-block align-middle">
+                                {author.name}
+                                <p className="text-gray-500 dark:text-gray-400 text-xs leading-4 font-normal">
+                                  @{author.handle}
+                                </p>
+                              </p>
+                            </div>
+                            {ownWorkspace!.handle === author.handle ? (
+                              ""
+                            ) : ownWorkspace!.following.filter(
+                                (follow) => follow.handle === author.handle
+                              ).length > 0 ? (
+                              <UnfollowButton author={author} refetchFn={refetch} />
+                            ) : (
+                              <FollowButton author={author} refetchFn={refetch} />
+                            )}
+                          </li>
+                        </>
+                      ))}
+                    </ul>
+                    {/* /End replace */}
+                  </div>
+                </div>
+                {/* </div> */}
+              </Transition.Child>
+            </div>
+          </div>
+        </Dialog>
+      </Transition.Root>
+    </>
+  )
+}
+
+export default AuthorPanel

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -105,13 +105,14 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                           </div>
                         </div>
                       </div>
+                      <div className="mt-6 px-4 sm:px-6 text-sm leading-5 font-normal border-b border-gray-500 dark:border-gray-500 pb-4 dark:text-white">
+                        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Phasellus
+                        hendrerit. Pellentesque aliquet nibh nec urna. In nisi neque, aliquet vel,
+                        dapibus id, mattis vel, nisi.
+                      </div>
                       <div className="mt-6 relative flex-1 px-4 sm:px-6">
                         {/* Replace with your content */}
-                        <div className="text-sm leading-5 font-normal border-b border-gray-500 dark:border-gray-500 pb-4 dark:text-white">
-                          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Phasellus
-                          hendrerit. Pellentesque aliquet nibh nec urna. In nisi neque, aliquet vel,
-                          dapibus id, mattis vel, nisi.
-                        </div>
+
                         <div className="my-4">
                           <label
                             htmlFor="title"

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -225,7 +225,7 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                         Cancel
                       </button>
                       <button
-                        type="button"
+                        type="submit"
                         className="flex py-2 px-4 bg-green-50 dark:bg-gray-800 text-green-700 dark:text-green-500 hover:bg-green-200 dark:hover:bg-gray-700 dark:border dark:border-gray-600 dark:hover:border-gray-400 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-green-500"
                       >
                         <CheckIcon className="w-4 h-4 fill-current text-green-500 pt-1" />

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -20,6 +20,9 @@ import ModuleCard from "../core/components/ModuleCard"
 import getCurrentWorkspace from "app/workspaces/queries/getCurrentWorkspace"
 import SettingsModal from "../core/modals/settings"
 import getCurrentUser from "app/users/queries/getCurrentUser"
+import HandlePanel from "../modules/components/HandlePanel"
+import UnfollowButton from "../workspaces/components/UnfollowButton"
+import FollowButton from "../workspaces/components/FollowButton"
 
 const ITEMS_PER_PAGE = 10
 
@@ -47,6 +50,7 @@ export const getServerSideProps = async ({ params }) => {
 }
 
 const HandlePage = ({ workspace }) => {
+  console.log(workspace.following)
   return (
     <Layout title={`R=${workspace.name || workspace.handle}`}>
       <div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-200 h-full">
@@ -74,7 +78,7 @@ const HandlePage = ({ workspace }) => {
               {workspace ? (
                 <div>
                   <Suspense fallback="Loading...">
-                    <FollowButton workspace={workspace} />
+                    <FollowHandleButton workspace={workspace} />
                   </Suspense>
                 </div>
               ) : (
@@ -140,13 +144,22 @@ const HandlePage = ({ workspace }) => {
               ) : (
                 <></>
               )}
-              <p className="flex my-2 text-sm leading-4 font-normal text-gray-500 dark:text-gray-200">
-                <p>
-                  <span className="inline-block h-full align-middle"> </span>
-                  <UserAddIcon className="w-4 h-4 inline-block align-middle mr-1 text-gray-700 dark:text-gray-400" />
-                  Following <Suspense fallback="Loading...">{workspace.following.length}</Suspense>
-                </p>
-              </p>
+              <Suspense fallback="">
+                <HandlePanel
+                  buttonText={
+                    <p className="flex my-2 text-sm leading-4 font-normal text-gray-500 dark:text-gray-200">
+                      <p>
+                        <span className="inline-block h-full align-middle"> </span>
+                        <UserAddIcon className="w-4 h-4 inline-block align-middle mr-1 text-gray-700 dark:text-gray-400" />
+                        Following{" "}
+                        <Suspense fallback="Loading...">{workspace.following.length}</Suspense>
+                      </p>
+                    </p>
+                  }
+                  title="Following"
+                  authors={workspace.following}
+                />
+              </Suspense>
             </div>
           </div>
           <div className="w-full ">
@@ -162,13 +175,10 @@ const HandlePage = ({ workspace }) => {
 
 export default HandlePage
 
-const FollowButton = ({ workspace }) => {
+const FollowHandleButton = ({ workspace }) => {
   const params = useParams()
   const [currentUser] = useQuery(getCurrentUser, null)
   const [ownWorkspace, { refetch }] = useQuery(getCurrentWorkspace, null)
-
-  const [followWorkspaceMutation] = useMutation(followWorkspace)
-  const [unfollowWorkspaceMutation] = useMutation(unfollowWorkspace)
 
   return (
     <>
@@ -185,41 +195,9 @@ const FollowButton = ({ workspace }) => {
           </>
         ) : ownWorkspace?.following.filter((follows) => follows.handle === params.handle).length ===
           0 ? (
-          <>
-            <span className="inline-block h-full align-middle"></span>
-            <button
-              className="py-2 px-4 shadow-sm text-sm leading-4 font-medium bg-indigo-100 dark:bg-gray-800 hover:bg-indigo-200 dark:hover:bg-gray-700 text-indigo-700 dark:text-gray-200 rounded dark:border dark:border-gray-600 inline-block align-middle focus:outline-none focus:ring-2 focus:ring-offset-0   focus:ring-indigo-500"
-              onClick={async () => {
-                // TODO: Add action
-
-                await followWorkspaceMutation({
-                  followedId: workspace.id,
-                })
-                refetch()
-
-                toast.success("Following!")
-              }}
-            >
-              Follow
-            </button>
-          </>
+          <FollowButton author={workspace.id} refetchFn={refetch} />
         ) : (
-          <>
-            <span className="inline-block h-full align-middle"></span>
-
-            <button
-              className="py-2 px-4 shadow-sm text-sm leading-4 font-medium bg-indigo-100 dark:bg-gray-800 hover:bg-indigo-200 dark:hover:bg-gray-700 text-indigo-700 dark:text-gray-200 rounded dark:border dark:border-gray-600 inline-block align-middle focus:outline-none focus:ring-2 focus:ring-offset-0   focus:ring-indigo-500"
-              onClick={async () => {
-                await unfollowWorkspaceMutation({
-                  followedId: workspace.id,
-                })
-                refetch()
-                toast("Unfollowed", { icon: "👋" })
-              }}
-            >
-              Unfollow
-            </button>
-          </>
+          <UnfollowButton author={workspace} refetchFn={refetch} />
         )
       ) : (
         ""

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -18,6 +18,8 @@ import followWorkspace from "../workspaces/mutations/followWorkspace"
 import unfollowWorkspace from "../workspaces/mutations/unfollowWorkspace"
 import ModuleCard from "../core/components/ModuleCard"
 import getCurrentWorkspace from "app/workspaces/queries/getCurrentWorkspace"
+import SettingsModal from "../core/modals/settings"
+import getCurrentUser from "app/users/queries/getCurrentUser"
 
 const ITEMS_PER_PAGE = 10
 
@@ -108,7 +110,10 @@ const HandlePage = ({ workspace }) => {
                       />
                     </svg>
                     <Link href={`https://orcid.org/${workspace.orcid}`}>
-                      <a target="_blank" className="underline">
+                      <a
+                        target="_blank"
+                        className="underline text-sm leading-4 font-normal text-gray-500 dark:text-gray-200"
+                      >
                         {workspace.orcid}
                       </a>
                     </Link>
@@ -123,7 +128,10 @@ const HandlePage = ({ workspace }) => {
                     <span className="inline-block h-full align-middle"> </span>
                     <LinkIcon className="w-4 h-4 inline-block align-middle mr-1 text-gray-700 dark:text-gray-400" />
                     <Link href={workspace.url}>
-                      <a target="_blank" className="underline">
+                      <a
+                        target="_blank"
+                        className="underline text-sm leading-4 font-normal text-gray-500 dark:text-gray-200"
+                      >
                         {workspace.url}
                       </a>
                     </Link>
@@ -156,6 +164,7 @@ export default HandlePage
 
 const FollowButton = ({ workspace }) => {
   const params = useParams()
+  const [currentUser] = useQuery(getCurrentUser, null)
   const [ownWorkspace, { refetch }] = useQuery(getCurrentWorkspace, null)
 
   const [followWorkspaceMutation] = useMutation(followWorkspace)
@@ -165,7 +174,15 @@ const FollowButton = ({ workspace }) => {
     <>
       {ownWorkspace ? (
         ownWorkspace!.handle === params.handle ? (
-          <></>
+          <>
+            <span className="inline-block h-full align-middle"></span>
+            <SettingsModal
+              button="Edit Profile"
+              styling="py-2 px-4 shadow-sm text-sm leading-4 font-medium bg-indigo-100 dark:bg-gray-800 hover:bg-indigo-200 dark:hover:bg-gray-700 text-indigo-700 dark:text-gray-200 rounded dark:border dark:border-gray-600 inline-block align-middle focus:outline-none focus:ring-2 focus:ring-offset-0   focus:ring-indigo-500"
+              user={currentUser}
+              workspace={ownWorkspace}
+            />
+          </>
         ) : ownWorkspace?.following.filter((follows) => follows.handle === params.handle).length ===
           0 ? (
           <>
@@ -226,31 +243,36 @@ const HandleFeed = ({ handle }) => {
   return (
     <>
       {modules.length > 0 ? (
-        <div>
-          <ul role="list" className="divide-y divide-gray-200 border border-gray-500">
-            {modules.map((module) => (
-              <>
-                <li
-                  onClick={() => {
-                    router.push(`/modules/${module.suffix}`)
-                  }}
-                  className="cursor-pointer"
-                >
-                  <ModuleCard
-                    type={module.type}
-                    title={module.title}
-                    status={`DOI: 10.53962/${module.suffix}`}
-                    time={moment(module.publishedAt).fromNow()}
-                    authors={module.authors}
-                  />
-                </li>
-              </>
-            ))}
-          </ul>
+        <>
+          <div className="rounded-t-md border border-gray-300 dark:border-gray-600 mt-8 divide-y divide-gray-300 dark:divide-gray-600">
+            <h1 className="text-xs leading-4 font-medium mx-4 my-2 text-gray-500 dark:text-gray-400 ">
+              Published modules
+            </h1>
+            <ul role="list" className="divide-y divide-gray-300 dark:divide-gray-600">
+              {modules.map((module) => (
+                <>
+                  <li
+                    onClick={() => {
+                      router.push(`/modules/${module.suffix}`)
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <ModuleCard
+                      type={module.type.name}
+                      title={module.title}
+                      status={`DOI: 10.53962/${module.suffix}`}
+                      time={moment(module.publishedAt).fromNow()}
+                      authors={module.authors}
+                    />
+                  </li>
+                </>
+              ))}
+            </ul>
+          </div>
           {/* TODO: Put into one component - also used in dashboard.tsx */}
           <div className="flex my-1">
             <div className="flex-1 flex items-center justify-between">
-              <p className="text-sm text-gray-700">
+              <p className="text-sm leading-5 font-normal text-gray-700 dark:text-gray-200">
                 Showing <span className="font-medium">{ITEMS_PER_PAGE * page + 1}</span> to{" "}
                 <span className="font-medium">
                   {ITEMS_PER_PAGE + page > count ? count : ITEMS_PER_PAGE + page}
@@ -259,11 +281,11 @@ const HandleFeed = ({ handle }) => {
               </p>
             </div>
             <nav
-              className="relative z-0 inline-flex rounded-md -space-x-px"
+              className="relative z-0 inline-flex rounded-md border border-gray-300 dark:border-gray-600 -space-x-px divide-x divide-gray-300 dark:divide-gray-600"
               aria-label="Pagination"
             >
               <button
-                className="relative inline-flex items-center px-2 py-2 bg-gray-300 text-sm font-medium text-gray-500 hover:bg-gray-400"
+                className="relative inline-flex items-center rounded-l-md px-2 py-2 text-sm font-medium text-gray-500 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
                 disabled={page === 0}
                 onClick={goToPreviousPage}
               >
@@ -274,7 +296,11 @@ const HandleFeed = ({ handle }) => {
                 (pageNr) => (
                   <button
                     key={`page-nav-feed-${pageNr}`}
-                    className="relative inline-flex items-center px-2 py-2 bg-gray-300 text-sm font-medium text-gray-500 hover:bg-gray-400"
+                    className={
+                      page == pageNr
+                        ? "relative inline-flex items-center px-2 py-2 text-sm font-medium text-indigo-600 dark:text-gray-200 bg-indigo-50 dark:bg-gray-700 ring-1 ring-indigo-600 z-10 dark:ring-0"
+                        : "relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    }
                     disabled={page === pageNr}
                     onClick={() => {
                       goToPage(pageNr)
@@ -288,7 +314,7 @@ const HandleFeed = ({ handle }) => {
                 )
               )}
               <button
-                className="relative inline-flex items-center px-2 py-2 bg-gray-300 text-sm font-medium text-gray-500 hover:bg-gray-400"
+                className="relative inline-flex items-center rounded-r-md px-2 py-2 text-sm font-medium text-gray-500 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
                 disabled={!hasMore}
                 onClick={goToNextPage}
               >
@@ -297,7 +323,7 @@ const HandleFeed = ({ handle }) => {
               </button>
             </nav>
           </div>
-        </div>
+        </>
       ) : (
         <div className="flex mt-8 flex-col flex-grow relative w-full border-2 border-gray-500 dark:border-gray-400 border-dashed rounded-lg text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 h-28">
           <div className="table flex-grow w-full">

--- a/app/workspaces/components/FollowButton.tsx
+++ b/app/workspaces/components/FollowButton.tsx
@@ -1,0 +1,28 @@
+import { useMutation } from "blitz"
+import toast from "react-hot-toast"
+import followWorkspace from "../mutations/followWorkspace"
+
+const UnfollowButton = ({ author, refetchFn }) => {
+  const [followWorkspaceMutation] = useMutation(followWorkspace)
+
+  return (
+    <>
+      <span className="inline-block h-full align-middle"></span>
+      <button
+        className="py-2 px-4 shadow-sm text-sm leading-4 font-medium bg-indigo-100 dark:bg-gray-800 hover:bg-indigo-200 dark:hover:bg-gray-700 text-indigo-700 dark:text-gray-200 rounded dark:border dark:border-gray-600 inline-block align-middle focus:outline-none focus:ring-2 focus:ring-offset-0   focus:ring-indigo-500"
+        onClick={async () => {
+          await followWorkspaceMutation({
+            followedId: author.id,
+          })
+          refetchFn()
+
+          toast.success("Following!")
+        }}
+      >
+        Follow
+      </button>
+    </>
+  )
+}
+
+export default UnfollowButton

--- a/app/workspaces/components/UnfollowButton.tsx
+++ b/app/workspaces/components/UnfollowButton.tsx
@@ -1,0 +1,28 @@
+import { useMutation } from "blitz"
+import toast from "react-hot-toast"
+import unfollowWorkspace from "../mutations/unfollowWorkspace"
+
+const UnfollowButton = ({ author, refetchFn }) => {
+  const [unfollowWorkspaceMutation] = useMutation(unfollowWorkspace)
+
+  return (
+    <>
+      <span className="inline-block h-full align-middle"></span>
+
+      <button
+        className="py-2 px-4 shadow-sm text-sm leading-4 font-medium bg-indigo-100 dark:bg-gray-800 hover:bg-indigo-200 dark:hover:bg-gray-700 text-indigo-700 dark:text-gray-200 rounded dark:border dark:border-gray-600 inline-block align-middle focus:outline-none focus:ring-2 focus:ring-offset-0   focus:ring-indigo-500"
+        onClick={async () => {
+          await unfollowWorkspaceMutation({
+            followedId: author.id,
+          })
+          refetchFn()
+          toast("Unfollowed", { icon: "👋" })
+        }}
+      >
+        Unfollow
+      </button>
+    </>
+  )
+}
+
+export default UnfollowButton

--- a/app/workspaces/queries/getHandleFeed.ts
+++ b/app/workspaces/queries/getHandleFeed.ts
@@ -49,6 +49,7 @@ export default resolver.pipe(async ({ handle, orderBy, skip = 0, take = 100 }, c
           authors: {
             include: { workspace: true },
           },
+          type: true,
         },
       }),
   })


### PR DESCRIPTION
This PR adds a bunch of styling to the `[handle]` pages.

![Screenshot 2021-12-23 at 14 38 36](https://user-images.githubusercontent.com/2946344/147250796-9b590d64-693e-4193-b3e2-e2d214e6cff7.png)
![Screenshot 2021-12-23 at 15 01 58](https://user-images.githubusercontent.com/2946344/147250836-0ccc4995-d815-48de-bfa9-95962e6004f2.png)

Still missing is the popover panel for the people they're following, but that'll be added still.
