### PR TITLE
Minor tweaks to the quick draft panel

### DIFF
--- a/app/core/queries/getLicenses.ts
+++ b/app/core/queries/getLicenses.ts
@@ -7,7 +7,7 @@ export default async function getLicenses() {
         price: "asc",
       },
       {
-        name: "desc",
+        name: "asc",
       },
     ],
   })

--- a/app/core/queries/getLicenses.ts
+++ b/app/core/queries/getLicenses.ts
@@ -7,7 +7,7 @@ export default async function getLicenses() {
         price: "asc",
       },
       {
-        name: "asc",
+        name: "desc",
       },
     ],
   })

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -190,12 +190,12 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                           >
                             License{" "}
                             <HelpFilled32
+                              className="ml-1 fill-current text-gray-700 dark:text-gray-200 w-4 h-4"
                               data-tip
                               data-for="licenseTip"
-                              className="ml-1 fill-current text-gray-700 dark:text-gray-200 w-4 h-4"
                             />
                             <ReactTooltip id="licenseTip" place="top" effect="solid">
-                              You can change your license until you publish.
+                              You can change the license before publishing.
                             </ReactTooltip>
                           </label>
                           <div className="mt-1">

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -7,7 +7,6 @@ import { useFormik } from "formik"
 import { Fragment, useState } from "react"
 import { z } from "zod"
 import { HelpFilled32 } from "@carbon/icons-react"
-import ReactTooltip from "react-tooltip"
 
 import createModule from "../mutations/createModule"
 
@@ -188,15 +187,7 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                             htmlFor="license"
                             className="flex my-1 text-sm leading-5 font-medium text-gray-700 dark:text-gray-200"
                           >
-                            License{" "}
-                            <HelpFilled32
-                              className="ml-1 fill-current text-gray-700 dark:text-gray-200 w-4 h-4"
-                              data-tip
-                              data-for="licenseTip"
-                            />
-                            <ReactTooltip id="licenseTip" place="top" effect="solid">
-                              You can change the license before publishing.
-                            </ReactTooltip>
+                            License
                           </label>
                           <div className="mt-1">
                             <select

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -7,6 +7,8 @@ import { useFormik } from "formik"
 import { Fragment, useState } from "react"
 import { z } from "zod"
 import { HelpFilled32 } from "@carbon/icons-react"
+import ReactTooltip from "react-tooltip"
+
 import createModule from "../mutations/createModule"
 
 const QuickDraft = ({ buttonText, buttonStyle }) => {
@@ -169,7 +171,9 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                               <option className="text-gray-900" value=""></option>
                               {moduleTypes.map((type) => (
                                 <>
-                                  <option value={type.id}>{type.name}</option>
+                                  <option value={type.id} className="text-gray-900">
+                                    {type.name}
+                                  </option>
                                 </>
                               ))}
                             </select>
@@ -185,7 +189,14 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                             className="flex my-1 text-sm leading-5 font-medium text-gray-700 dark:text-gray-200"
                           >
                             License{" "}
-                            <HelpFilled32 className="ml-1 fill-current text-gray-700 dark:text-gray-200 w-4 h-4" />
+                            <HelpFilled32
+                              data-tip
+                              data-for="licenseTip"
+                              className="ml-1 fill-current text-gray-700 dark:text-gray-200 w-4 h-4"
+                            />
+                            <ReactTooltip id="licenseTip" place="top" effect="solid">
+                              You can change your license until you publish.
+                            </ReactTooltip>
                           </label>
                           <div className="mt-1">
                             <select
@@ -197,7 +208,7 @@ const QuickDraft = ({ buttonText, buttonStyle }) => {
                               <option className="text-gray-900" value=""></option>
                               {licenses.map((license) => (
                                 <>
-                                  <option value={license.id}>
+                                  <option value={license.id} className="text-gray-900">
                                     {license.name} (
                                     {license.price > 0 ? `${license.price / 100}EUR` : "Free"})
                                   </option>


### PR DESCRIPTION
This PR contains some minor tweaks to the quick draft:

- Improve ordering of license options
- Ensure dropdown options are readable in darkmode
- Add a tooltip to the license help button