### PR TITLE
Integrate parent management, style draft editing

### DIFF
--- a/app/authorship/mutations/updateAuthorRank.ts
+++ b/app/authorship/mutations/updateAuthorRank.ts
@@ -23,6 +23,26 @@ export default resolver.pipe(resolver.authorize(), async ({ id, rank, suffix }) 
       },
       license: true,
       type: true,
+      parents: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+      children: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
     },
   })
 

--- a/app/core/components/SearchResultModule.tsx
+++ b/app/core/components/SearchResultModule.tsx
@@ -1,5 +1,3 @@
-import { Blog32 } from "@carbon/icons-react"
-
 const SearchResultModule = ({ item }) => {
   return (
     <>
@@ -9,7 +7,7 @@ const SearchResultModule = ({ item }) => {
             width="32"
             height="32"
             viewBox="0 0 32 32"
-            className="stroke-current fill-current stroke-2 text-gray-300 dark:text-gray-400 inline-block h-full align-middle"
+            className="stroke-current fill-current stroke-2 text-indigo-600 dark:text-indigo-600 inline-block h-full align-middle"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path d="M23.852 31.5H0.5V0.500011L31.5 0.500695V23.8532L23.852 31.5Z" />

--- a/app/modules/components/FollowsFromSearch.tsx
+++ b/app/modules/components/FollowsFromSearch.tsx
@@ -1,0 +1,80 @@
+import { useMutation } from "blitz"
+import Autocomplete from "../../core/components/Autocomplete"
+import addParent from "../mutations/addParent"
+import { getAlgoliaResults } from "@algolia/autocomplete-js"
+import algoliasearch from "algoliasearch"
+import SearchResultModule from "../../core/components/SearchResultModule"
+import { useState } from "react"
+import ManageParents from "./ManageParents"
+
+const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
+
+const FollowsFromSearch = ({ module, setQueryData }) => {
+  const [addParentMutation] = useMutation(addParent)
+  const [parentsOpen, setParentsOpen] = useState(false)
+
+  return (
+    <div className="flex w-full text-xs leading-4 font-normal text-gray-900 dark:text-gray-200">
+      <button
+        className="px-2 border dark:bg-gray-800 border-gray-300 dark:border-gray-600 dark:hover:border-gray-400 text-gray-700 dark:text-gray-200 rounded text-xs leading-4 font-normal shadow-sm mx-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:bg-gray-100 dark:hover:bg-gray-700 "
+        onClick={() => {
+          setParentsOpen(true)
+        }}
+        disabled={module.parents.length === 0}
+      >
+        <span className="flex">
+          <span>Follows from:</span>
+          <span>
+            <span className="inline-block h-full align-middle"></span>
+            <span className="bg-indigo-100 text-indigo-800 dark:bg-gray-700 dark:text-gray-200 dark:border dark:border-gray-600 px-2 rounded-full text-xs font-medium inline-block align-middle">
+              {module?.parents ? module?.parents.length : "0"}
+            </span>
+          </span>
+        </span>
+      </button>
+      <ManageParents
+        open={parentsOpen}
+        setOpen={setParentsOpen}
+        moduleEdit={module}
+        setQueryData={setQueryData}
+      />
+      <Autocomplete
+        className="h-full"
+        openOnFocus={true}
+        defaultActiveItemId="0"
+        getSources={({ query }) => [
+          {
+            sourceId: "products",
+            async onSelect(params) {
+              const { item, setQuery } = params
+              const updatedMod = await addParentMutation({
+                currentId: module?.id,
+                connectId: item.objectID,
+              })
+              setQueryData(updatedMod)
+            },
+            getItems() {
+              return getAlgoliaResults({
+                searchClient,
+                queries: [
+                  {
+                    indexName: `${process.env.ALGOLIA_PREFIX}_modules`,
+                    query,
+                  },
+                ],
+              })
+            },
+            templates: {
+              item({ item, components }) {
+                // TODO: Need to update search results per Algolia index
+                return <SearchResultModule item={item} />
+              },
+            },
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+export default FollowsFromSearch

--- a/app/modules/components/ManageParents.tsx
+++ b/app/modules/components/ManageParents.tsx
@@ -1,0 +1,149 @@
+import { Fragment, useState } from "react"
+import { Dialog, Transition } from "@headlessui/react"
+import { CheckIcon, XIcon } from "@heroicons/react/outline"
+import { DragDropContext, Droppable, DroppableProvided } from "react-beautiful-dnd"
+import { Link, Routes, useMutation } from "blitz"
+import { TrashCan24 } from "@carbon/icons-react"
+
+import updateAuthorRank from "../../authorship/mutations/updateAuthorRank"
+import AuthorList from "../../core/components/AuthorList"
+import ModuleCard from "app/core/components/ModuleCard"
+import moment from "moment"
+import deleteParent from "../mutations/deleteParent"
+import toast from "react-hot-toast"
+
+// https://www.npmjs.com/package/array-move
+function arrayMoveMutable(array, fromIndex, toIndex) {
+  const startIndex = fromIndex < 0 ? array.length + fromIndex : fromIndex
+
+  if (startIndex >= 0 && startIndex < array.length) {
+    const endIndex = toIndex < 0 ? array.length + toIndex : toIndex
+
+    const [item] = array.splice(fromIndex, 1)
+    array.splice(endIndex, 0, item)
+  }
+}
+
+function arrayMoveImmutable(array, fromIndex, toIndex) {
+  array = [...array]
+  arrayMoveMutable(array, fromIndex, toIndex)
+  return array
+}
+
+const ManageParents = ({ open, setOpen, moduleEdit, setQueryData }) => {
+  const [parentState, setParentState] = useState(moduleEdit!.parents)
+  const [deleteParentMutation] = useMutation(deleteParent)
+
+  console.log(moduleEdit)
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 overflow-hidden" onClose={setOpen}>
+        <div className="absolute inset-0 overflow-hidden">
+          <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-25 transition-opacity" />
+
+          <div className="fixed inset-y-0 right-0 pl-10 max-w-full flex">
+            <Transition.Child
+              as={Fragment}
+              enter="transform transition ease-in-out duration-500 sm:duration-700"
+              enterFrom="translate-x-full"
+              enterTo="translate-x-0"
+              leave="transform transition ease-in-out duration-500 sm:duration-700"
+              leaveFrom="translate-x-0"
+              leaveTo="translate-x-full"
+            >
+              <div className="w-screen max-w-xs">
+                <div className="min-h-0 flex-1 flex flex-col pt-6 overflow-y-auto h-full dark:divide-gray-600 bg-white dark:bg-gray-900 shadow-xl">
+                  <div className="px-4 sm:px-6">
+                    <div className="flex items-start justify-between">
+                      <Dialog.Title className="text-lg font-medium text-gray-900 dark:text-white">
+                        Manage parent modules
+                      </Dialog.Title>
+                      <div className="ml-3 h-7 flex items-center">
+                        <button
+                          type="button"
+                          className="rounded-md text-gray-400 dark:text-gray-200 hover:text-gray-500 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          onClick={() => setOpen(false)}
+                        >
+                          <span className="sr-only">Close panel</span>
+                          <XIcon className="h-6 w-6" aria-hidden="true" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-6 px-4 sm:px-6 text-sm leading-5 font-normal border-b border-gray-400 dark:border-gray-600 pb-4 dark:text-white">
+                    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Phasellus hendrerit.
+                    Pellentesque aliquet nibh nec urna. In nisi neque, aliquet vel, dapibus id,
+                    mattis vel, nisi.
+                  </div>
+                  {/* Replace with your content */}
+
+                  <ul className="relative flex-1 divide-y divide-gray-400 dark:divide-gray-600">
+                    {moduleEdit.parents.map((module) => (
+                      <>
+                        <div className="flex">
+                          <button
+                            className="px-2 hover:bg-gray-50 dark:hover:bg-gray-800"
+                            onClick={async () => {
+                              const updatedMod = await deleteParentMutation({
+                                currentId: moduleEdit.id,
+                                disconnectId: module.id,
+                              })
+                              setQueryData(updatedMod)
+                              toast(`Removed parent: ${module.title}`, { icon: "🗑" })
+                              if (updatedMod.parents.length === 0) {
+                                setOpen(false)
+                              }
+                            }}
+                          >
+                            <TrashCan24 className="w-4 h-4 fill-current text-red-500 inline-block align-middle" />
+                          </button>
+                          <Link href={Routes.ModulePage({ suffix: module.suffix })}>
+                            <a target="_blank">
+                              <ModuleCard
+                                type={module.type.name}
+                                title={module.title}
+                                status={`${module.prefix}/${module.suffix}`}
+                                time={moment(module.publishedAt).fromNow()}
+                                timeText="Published"
+                                authors={module.authors}
+                              />
+                            </a>
+                          </Link>
+                        </div>
+                      </>
+                    ))}
+                  </ul>
+                  {/* /End replace */}
+                  <div className="flex-shrink-0 px-4 py-4 flex justify-end border-t border-gray-400 dark:border-gray-600">
+                    <button
+                      type="button"
+                      className="flex mx-4 py-2 px-4 bg-red-50 dark:bg-gray-800 text-red-700 dark:text-red-500 hover:bg-red-200 dark:hover:bg-gray-700 dark:border dark:border-gray-600 dark:hover:border-gray-400 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-red-500"
+                      onClick={() => {
+                        setOpen(false)
+                      }}
+                    >
+                      <XIcon className="w-4 h-4 fill-current text-red-500 pt-1" />
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      className="flex py-2 px-4 bg-green-50 dark:bg-gray-800 text-green-700 dark:text-green-500 hover:bg-green-200 dark:hover:bg-gray-700 dark:border dark:border-gray-600 dark:hover:border-gray-400 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-green-500"
+                      onClick={() => {
+                        setOpen(false)
+                      }}
+                    >
+                      <CheckIcon className="w-4 h-4 stroke-current text-green-500 pt-1" />
+                      Save
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}
+
+export default ManageParents

--- a/app/modules/components/MetadataEdit.tsx
+++ b/app/modules/components/MetadataEdit.tsx
@@ -75,17 +75,19 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
             DOI upon publish:{" "}
             <span className="text-gray-300 dark:text-gray-600">{`${module.prefix}/${module.suffix}`}</span>
           </div>
-          <div className="flex-grow py-2">
+          <div className="flex-grow py-1">
             <label htmlFor="license">License: </label>
             <select
-              className="rounded my-1 bg-gray-300 dark:bg-gray-300"
+              className="rounded bg-transparent text-xs leading-4 font-normal border border-gray-300 dark:border-gray-600"
               id="license"
               {...formik.getFieldProps("license")}
             >
-              <option value="">--Please choose a license--</option>
+              <option value="" className="text-gray-900">
+                --Please choose a license--
+              </option>
               {licenses.map((license) => (
                 <>
-                  <option value={license.id}>
+                  <option value={license.id} className="text-gray-900">
                     {license.name} ({license.price > 0 ? `${license.price / 100}EUR` : "Free"})
                   </option>
                 </>
@@ -106,14 +108,18 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
               Module type
             </label>
             <select
-              className="rounded my-1 bg-gray-300 dark:bg-gray-300"
+              className="border-gray-300 dark:border-gray-600 rounded bg-transparent text-xs leading-4 font-normal"
               id="type"
               {...formik.getFieldProps("type")}
             >
-              <option value="">--Please choose a module type--</option>
+              <option value="" className="text-gray-900">
+                --Please choose a module type--
+              </option>
               {moduleTypes.map((type) => (
                 <>
-                  <option value={type.id}>{type.name}</option>
+                  <option value={type.id} className="text-gray-900">
+                    {type.name}
+                  </option>
                 </>
               ))}
             </select>
@@ -123,11 +129,11 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
             <label htmlFor="title" className="sr-only block text-sm font-medium text-gray-700">
               Title
             </label>
-            <div className="mt-1">
+            <div className="mt-1 ">
               <textarea
                 rows={2}
                 id="title"
-                className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-500 bg-gray-300 dark:bg-gray-300 rounded-md"
+                className="border border-gray-300 dark:border-gray-600 bg-transparent shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border  rounded-md"
                 {...formik.getFieldProps("title")}
               />
               {formik.touched.title && formik.errors.title ? (
@@ -237,7 +243,7 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
             <textarea
               rows={8}
               id="description"
-              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-500  bg-gray-300 dark:bg-gray-300 rounded-md"
+              className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border border-gray-300 dark:border-gray-600 bg-transparent rounded-md"
               {...formik.getFieldProps("description")}
             />
             {formik.touched.description && formik.errors.description ? (
@@ -245,13 +251,23 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
             ) : null}
           </div>
         </div>
-        <button
-          type="submit"
-          className="my-2 inline-flex items-center px-3 py-2 text-sm leading-4 font-medium rounded-md bg-gray-300 dark:bg-gray-300 text-gray-900 dark:text-gray-900  hover:bg-indigo-300 border border-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        >
-          Save
-          <Save32 className="ml-2 -mr-0.5 h-4 w-4" aria-hidden="true" />
-        </button>
+        <div className="px-2 py-2 flex">
+          <button
+            type="submit"
+            className="flex py-2 px-4 bg-green-50 dark:bg-gray-800 text-green-700 dark:text-green-500 hover:bg-green-200 dark:hover:bg-gray-700 dark:border dark:border-gray-600 dark:hover:border-gray-400 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-green-500"
+          >
+            Save changes
+          </button>
+          <button
+            type="button"
+            className="flex mx-2 py-2 px-4 bg-red-50 dark:bg-gray-800 text-red-700 dark:text-red-500 hover:bg-red-200 dark:hover:bg-gray-700 dark:border dark:border-gray-600 dark:hover:border-gray-400 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-red-500"
+            onClick={() => {
+              setIsEditing(false)
+            }}
+          >
+            Cancel changes
+          </button>
+        </div>
       </form>
     </div>
   )

--- a/app/modules/components/MetadataEdit.tsx
+++ b/app/modules/components/MetadataEdit.tsx
@@ -16,6 +16,7 @@ import { z } from "zod"
 import editModuleScreen from "../mutations/editModuleScreen"
 import getTypes from "../../core/queries/getTypes"
 import getLicenses from "app/core/queries/getLicenses"
+import FollowsFromSearch from "./FollowsFromSearch"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -95,6 +96,10 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
             ) : null}
           </div>
         </div>
+        <div className="py-1 px-2 bg-white dark:bg-gray-800">
+          <FollowsFromSearch module={module} setQueryData={setQueryData} />
+        </div>
+
         <div className="py-4 px-2 min-h-32">
           <p className="text-xs leading-4 font-normal text-gray-500 dark:text-white">
             <label htmlFor="type" className="sr-only">

--- a/app/modules/components/MetadataView.tsx
+++ b/app/modules/components/MetadataView.tsx
@@ -11,6 +11,7 @@ import SearchResultWorkspace from "../../core/components/SearchResultWorkspace"
 import { PlusSmIcon } from "@heroicons/react/solid"
 import { useState } from "react"
 import ManageAuthors from "./ManageAuthors"
+import FollowsFromSearch from "./FollowsFromSearch"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -33,6 +34,9 @@ const MetadataView = ({ module, addAuthors, setQueryData, setAddAuthors }) => {
               <a target="_blank">{module.license!.name}</a>
             </Link>
           </div>
+        </div>
+        <div className="py-1 px-2 bg-white dark:bg-gray-800">
+          <FollowsFromSearch module={module} setQueryData={setQueryData} />
         </div>
         <div className="py-4 px-2 min-h-32">
           <p className="text-xs leading-4 font-normal text-gray-500 dark:text-white">

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -142,49 +142,6 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
         </div>
       </div>
 
-      {/* <div className="flex w-full max-h-8 my-2">
-        <span>
-          Follows from:{" "}
-          <span className="bg-gray-200 sgroup-hover:bg-gray-200 ml-auto inline-block py-0.5 px-3 text-xs rounded-full">
-            {moduleEdit?.parents ? moduleEdit?.parents.length : "0"}
-          </span>
-        </span>
-        <Autocomplete
-          className="h-full"
-          openOnFocus={true}
-          defaultActiveItemId="0"
-          getSources={({ query }) => [
-            {
-              sourceId: "products",
-              async onSelect(params) {
-                const { item, setQuery } = params
-                const updatedMod = await addParentMutation({
-                  currentId: moduleEdit?.id,
-                  connectId: item.objectID,
-                })
-                setQueryData(updatedMod)
-              },
-              getItems() {
-                return getAlgoliaResults({
-                  searchClient,
-                  queries: [
-                    {
-                      indexName: `${process.env.ALGOLIA_PREFIX}_modules`,
-                      query,
-                    },
-                  ],
-                })
-              },
-              templates: {
-                item({ item, components }) {
-                  // TODO: Need to update search results per Algolia index
-                  return <SearchResultModule item={item} />
-                },
-              },
-            },
-          ]}
-        />
-      </div> */}
       {/* Display editable form or display content */}
       {isEditing ? (
         <MetadataEdit

--- a/app/modules/mutations/deleteParent.ts
+++ b/app/modules/mutations/deleteParent.ts
@@ -1,12 +1,12 @@
 import { resolver } from "blitz"
 import db from "db"
 
-export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId }) => {
+export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnectId }) => {
   const module = await db.module.update({
     where: { id: currentId },
     data: {
       parents: {
-        connect: { id: parseInt(connectId) },
+        disconnect: { id: parseInt(disconnectId) },
       },
     },
     include: {


### PR DESCRIPTION
This PR integrates parent management for draft modules and adds styling to the draft editing.

## Parent management

![Screenshot 2021-12-30 at 10 52 31](https://user-images.githubusercontent.com/2946344/147741138-3ffccbc1-459d-40c1-9628-7aee2763db25.png)
![Screenshot 2021-12-30 at 10 52 34](https://user-images.githubusercontent.com/2946344/147741144-8353f953-f8a2-4319-b564-ef0af080599b.png)

## Draft editing

![Screenshot 2021-12-30 at 10 51 46](https://user-images.githubusercontent.com/2946344/147741159-1ca80ab9-2c5d-43c9-9271-93ae649b2666.png)
![Screenshot 2021-12-30 at 10 51 53](https://user-images.githubusercontent.com/2946344/147741164-0472707c-bc5a-4d2d-a836-83f66d56f035.png)
