### PR TITLE
Fix typo, improve db query

### DIFF
--- a/app/modules/components/MetadataImmutable.tsx
+++ b/app/modules/components/MetadataImmutable.tsx
@@ -41,7 +41,7 @@ const MetadataImmutable = ({ module }) => {
             </Link>
           </div>
         </div>
-        {module.parents.length > 0 || module.children.lenght > 0 ? (
+        {module.parents.length > 0 || module.children.length > 0 ? (
           <ParentChildView module={module} />
         ) : (
           ""

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -15,6 +15,9 @@ export async function getServerSideProps(context) {
     },
     include: {
       parents: {
+        where: {
+          published: true,
+        },
         include: {
           type: true,
           authors: {
@@ -25,6 +28,9 @@ export async function getServerSideProps(context) {
         },
       },
       children: {
+        where: {
+          published: true,
+        },
         include: {
           type: true,
           authors: {


### PR DESCRIPTION
This PR fixes #147, by improving the database query to include only children (and parents) that are published by default.