### PR TITLE
Add reference feature

### DIFF
--- a/app/api/stripe_webhook.ts
+++ b/app/api/stripe_webhook.ts
@@ -63,6 +63,15 @@ const webhook = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
               workspace: true,
             },
           },
+          references: {
+            include: {
+              authors: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
         },
       })
 
@@ -80,7 +89,37 @@ const webhook = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
 
           return js
         }),
-        citations: [],
+        citations: module?.references.map((reference) => {
+          const refJs = {
+            publishedWhere: reference.publishedWhere,
+            authors:
+              reference.publishedWhere === "ResearchEquals"
+                ? reference.authors.map((author) => {
+                    const authJs = {
+                      name: author.workspace?.name,
+                      orcid: `https://orcid.org/${author!.workspace!.orcid}`,
+                    }
+
+                    return authJs
+                  })
+                : reference!.authorsRaw!["object"].map((author) => {
+                    const authJs = {
+                      name:
+                        author.given && author.family
+                          ? `${author.given} ${author.family}`
+                          : `${author.name}`,
+                    }
+
+                    return authJs
+                  }),
+            publishedAt: reference.publishedAt,
+            prefix: reference.prefix,
+            suffix: reference.suffix,
+            isbn: reference.isbn,
+            title: reference.title,
+          }
+          return refJs
+        }),
         abstractText: module!.description,
         license: module!.license!.name,
         license_url: module!.license!.url,

--- a/app/authorship/mutations/acceptInvitation.ts
+++ b/app/authorship/mutations/acceptInvitation.ts
@@ -17,6 +17,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/authorship/mutations/acceptInvitation.ts
+++ b/app/authorship/mutations/acceptInvitation.ts
@@ -16,6 +16,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
       suffix,
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/authorship/mutations/approveAuthorship.ts
+++ b/app/authorship/mutations/approveAuthorship.ts
@@ -17,6 +17,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/authorship/mutations/approveAuthorship.ts
+++ b/app/authorship/mutations/approveAuthorship.ts
@@ -16,6 +16,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
       suffix,
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/authorship/mutations/removeInvitation.ts
+++ b/app/authorship/mutations/removeInvitation.ts
@@ -19,6 +19,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
       suffix,
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/authorship/mutations/removeInvitation.ts
+++ b/app/authorship/mutations/removeInvitation.ts
@@ -20,6 +20,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/authorship/mutations/updateAuthorRank.ts
+++ b/app/authorship/mutations/updateAuthorRank.ts
@@ -17,6 +17,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, rank, suffix }) 
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/authorship/mutations/updateAuthorRank.ts
+++ b/app/authorship/mutations/updateAuthorRank.ts
@@ -16,6 +16,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, rank, suffix }) 
       suffix,
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/core/components/Navbar.tsx
+++ b/app/core/components/Navbar.tsx
@@ -63,7 +63,7 @@ const Navbar = () => {
                             },
                             {
                               indexName: `${process.env.ALGOLIA_PREFIX}_modules`,
-                              query,
+                              query: `${query} ${process.env.DOI_PREFIX}`,
                             },
                           ],
                         })

--- a/app/core/crossref/citation_list.tsx
+++ b/app/core/crossref/citation_list.tsx
@@ -5,6 +5,7 @@ const citation_list = ({ citations, authors }) => {
     type: "element",
     name: "citation_list",
     elements: citations.map((citation, index) => {
+      const datetime = new Date(citation.publishedAt)
       const citationJs = {
         type: "element",
         name: "citation",
@@ -29,7 +30,7 @@ const citation_list = ({ citations, authors }) => {
             elements: [
               {
                 type: "text",
-                text: authors[0].name,
+                text: citation.authors[0].name,
               },
             ],
           },
@@ -39,7 +40,7 @@ const citation_list = ({ citations, authors }) => {
             elements: [
               {
                 type: "text",
-                text: citation.publishedAt,
+                text: datetime.getUTCFullYear(),
               },
             ],
           },
@@ -53,16 +54,16 @@ const citation_list = ({ citations, authors }) => {
               },
             ],
           },
-          {
-            type: "element",
-            name: "isbn",
-            elements: [
-              {
-                type: "text",
-                text: citation.isbn,
-              },
-            ],
-          },
+          // {
+          //   type: "element",
+          //   name: "isbn",
+          //   elements: [
+          //     {
+          //       type: "text",
+          //       text: citation.isbn,
+          //     },
+          //   ],
+          // },
           {
             type: "element",
             name: "article_title",

--- a/app/core/queries/getLicenses.ts
+++ b/app/core/queries/getLicenses.ts
@@ -2,6 +2,9 @@ import db from "db"
 
 export default async function getLicenses() {
   const licenses = await db.license.findMany({
+    where: {
+      source: "ResearchEquals",
+    },
     orderBy: [
       {
         price: "asc",

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -273,22 +273,23 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
                       {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
                       {query.match(/^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
                         <>
-                          {/* <SearchResultDoi query={query} /> */}
                           <button
+                            className="text-gray-900 dark:text-gray-200 text-sm leading-4 font-normal"
                             onClick={async () => {
-                              // alert(query)
                               toast.promise(createReferenceMutation({ doi: query }), {
                                 loading: "Searching...",
-                                success: <b>Reference added!</b>,
-                                error: <b>Could not find the reference.</b>,
+                                success: "Reference added!",
+                                error: "Could not add reference.",
                               })
                             }}
                           >
-                            Find and add {query} to ResearchEquals reference database
+                            Click here to add {query} to ResearchEquals database
                           </button>
                         </>
                       ) : (
-                        "Input a DOI you'd like to reference."
+                        <p className="text-gray-900 dark:text-gray-200 text-sm leading-4 font-normal">
+                          Input a DOI to add
+                        </p>
                       )}
                     </>
                   )
@@ -315,7 +316,7 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
                     aria-label="Delete reference"
                   />
                 </button>
-                {reference.authors ? (
+                {reference.publishedWhere === "ResearchEquals" ? (
                   <>
                     {reference.authors.map((author, index) => (
                       <>
@@ -327,7 +328,30 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
                     ))}
                   </>
                 ) : (
-                  "no"
+                  <>
+                    {reference!.authorsRaw!["object"] ? (
+                      <>
+                        {reference!.authorsRaw!["object"].map((author, index) => (
+                          <>
+                            {index === 3
+                              ? "[...]"
+                              : index > 3
+                              ? ""
+                              : author.given && author.family
+                              ? `${author.given} ${author.family}`
+                              : `${author.name}`}
+                            {index === reference!.authorsRaw!["object"].length - 1 || index > 2
+                              ? ""
+                              : ", "}
+                          </>
+                        ))}
+                      </>
+                    ) : (
+                      <>
+                        <p className="italic">{reference.publishedWhere}</p>
+                      </>
+                    )}
+                  </>
                 )}{" "}
                 ({reference.publishedAt?.toISOString().substr(0, 10)}). {reference.title}.{" "}
                 <Link href={reference.url!}>

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, Link, validateZodSchema } from "blitz"
+import { useQuery, useMutation, Link, validateZodSchema, Routes } from "blitz"
 import { useState, useEffect } from "react"
 import moment from "moment"
 import algoliasearch from "algoliasearch"
@@ -317,8 +317,13 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
                 </button>
                 {reference.authors ? (
                   <>
-                    {reference.authors.map((author) => (
-                      <>{author!.workspace!.name}</>
+                    {reference.authors.map((author, index) => (
+                      <>
+                        <Link href={Routes.HandlePage({ handle: author!.workspace!.handle })}>
+                          <a target="_blank">{author!.workspace!.name}</a>
+                        </Link>
+                        {index === reference.authors.length - 1 ? "" : ", "}
+                      </>
                     ))}
                   </>
                 ) : (

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -36,6 +36,7 @@ import MetadataEdit from "./MetadataEdit"
 import { useCurrentWorkspace } from "app/core/hooks/useCurrentWorkspace"
 import addReference from "../mutations/addReference"
 import createReferenceModule from "../mutations/createReferenceModule"
+import deleteReference from "../mutations/deleteReference"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -57,6 +58,7 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
   const supportingRaw = moduleEdit!.supporting as Prisma.JsonObject
 
   const [addReferenceMutation] = useMutation(addReference)
+  const [deleteReferenceMutation] = useMutation(deleteReference)
   const [createReferenceMutation] = useMutation(createReferenceModule)
   const [editModuleScreenMutation] = useMutation(editModuleScreen)
   const [addAuthorMutation] = useMutation(addAuthor)
@@ -303,12 +305,30 @@ const ModuleEdit = ({ user, module, isAuthor, setInboxOpen, inboxOpen }) => {
                   <TrashCan24
                     className="w-6 h-6 fill-current text-red-500 inline-block align-middle"
                     onClick={async () => {
-                      alert(`delete ${reference.title}`)
+                      const updatedModule = await deleteReferenceMutation({
+                        currentId: moduleEdit?.id,
+                        disconnectId: reference.id,
+                      })
+
+                      setQueryData(updatedModule)
                     }}
                     aria-label="Delete reference"
                   />
                 </button>
-                {reference.title}
+                {reference.authors ? (
+                  <>
+                    {reference.authors.map((author) => (
+                      <>{author!.workspace!.name}</>
+                    ))}
+                  </>
+                ) : (
+                  "no"
+                )}{" "}
+                ({reference.publishedAt?.toISOString().substr(0, 10)}). {reference.title}.{" "}
+                <Link href={reference.url!}>
+                  <a target="_blank underline">{reference.url}</a>
+                </Link>
+                . <span className="italic">{reference.publishedWhere}</span>
               </li>
             </>
           ))}

--- a/app/modules/mutations/addAuthor.ts
+++ b/app/modules/mutations/addAuthor.ts
@@ -19,6 +19,13 @@ export default resolver.pipe(
       },
       include: {
         references: {
+          include: {
+            authors: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
           orderBy: {
             title: "asc",
           },

--- a/app/modules/mutations/addAuthor.ts
+++ b/app/modules/mutations/addAuthor.ts
@@ -18,6 +18,11 @@ export default resolver.pipe(
         },
       },
       include: {
+        references: {
+          orderBy: {
+            title: "asc",
+          },
+        },
         authors: {
           include: {
             workspace: true,

--- a/app/modules/mutations/addMain.ts
+++ b/app/modules/mutations/addMain.ts
@@ -12,6 +12,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, json }) => {
     where: { id },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/addMain.ts
+++ b/app/modules/mutations/addMain.ts
@@ -11,6 +11,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, json }) => {
   const updatedModule = await db.module.findFirst({
     where: { id },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/addParent.ts
+++ b/app/modules/mutations/addParent.ts
@@ -11,6 +11,13 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/addParent.ts
+++ b/app/modules/mutations/addParent.ts
@@ -10,6 +10,11 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
       },
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/addReference.ts
+++ b/app/modules/mutations/addReference.ts
@@ -1,0 +1,49 @@
+import { resolver } from "blitz"
+import db from "db"
+
+export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId }) => {
+  const module = await db.module.update({
+    where: { id: currentId },
+    data: {
+      references: {
+        connect: { id: parseInt(connectId) },
+      },
+    },
+    include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
+      authors: {
+        include: {
+          workspace: true,
+        },
+      },
+      license: true,
+      type: true,
+      parents: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+      children: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  return module
+})

--- a/app/modules/mutations/addReference.ts
+++ b/app/modules/mutations/addReference.ts
@@ -11,6 +11,13 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/addSupporting.ts
+++ b/app/modules/mutations/addSupporting.ts
@@ -17,6 +17,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
     where: { id },
     data: { supporting: supportingFiles as Prisma.JsonObject },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/addSupporting.ts
+++ b/app/modules/mutations/addSupporting.ts
@@ -18,6 +18,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
     data: { supporting: supportingFiles as Prisma.JsonObject },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/changeAbstract.ts
+++ b/app/modules/mutations/changeAbstract.ts
@@ -21,6 +21,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, description }) =
     where: { id },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/changeAbstract.ts
+++ b/app/modules/mutations/changeAbstract.ts
@@ -20,6 +20,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, description }) =
   const updatedModule = await db.module.findFirst({
     where: { id },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/changeTitle.ts
+++ b/app/modules/mutations/changeTitle.ts
@@ -21,6 +21,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, title }) => {
     where: { id },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/changeTitle.ts
+++ b/app/modules/mutations/changeTitle.ts
@@ -20,6 +20,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, title }) => {
   const updatedModule = await db.module.findFirst({
     where: { id },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -1,0 +1,57 @@
+import { resolver } from "blitz"
+import db, { Prisma } from "db"
+import axios from "axios"
+
+import generateSuffix from "./generateSuffix"
+
+export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
+  // Info crossref
+  const cr = await axios.get(`https://api.crossref.org/works/${doi}`)
+  const metadata = cr.data.message
+  // Info datacite
+  // Create module
+  console.log(JSON.stringify(metadata))
+  const module = await db.module.create({
+    data: {
+      published: true,
+      publishedAt: metadata,
+      publishedWhere: metadata,
+      prefix: metadata.prefix,
+      url: `https://doi.org/${metadata.DOI}`,
+      title: metadata.title,
+      description: metadata.abstract,
+      type: {
+        connect: {},
+      },
+    },
+  })
+
+  // publishedAt    DateTime?
+  // publishedWhere String?
+  // isbn           String?
+  // prefix         String?
+  // suffix         String?
+  // license        License?  @relation(fields: [licenseId], references: [id])
+  // licenseId      Int?
+
+  // metadata.type
+  // type         ModuleType @relation(fields: [moduleTypeId], references: [id])
+  // moduleTypeId Int
+
+  // main       Json? @default("{}")
+  // supporting Json? @default("{\"files\": []}")
+
+  // authors    Authorship[]
+  // authorsRaw Json?        @default("{}")
+
+  // parents  Module[] @relation("ModuleToModule", references: [id])
+  // children Module[] @relation("ModuleToModule", references: [id])
+
+  // references    Module[] @relation("ModuleReference", references: [id])
+  // referencedBy  Module[] @relation("ModuleReference", references: [id])
+  // referencesRaw
+
+  // TODO: Index into algolia
+
+  return true
+})

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -1,57 +1,83 @@
 import { resolver } from "blitz"
 import db, { Prisma } from "db"
 import axios from "axios"
+import algoliasearch from "algoliasearch"
 
-import generateSuffix from "./generateSuffix"
+const client = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_ADMIN_KEY!)
+const index = client.initIndex(`${process.env.ALGOLIA_PREFIX}_modules`)
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1)
+}
 
 export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
-  // Info crossref
+  // Will auto-throw if resource not found
   const cr = await axios.get(`https://api.crossref.org/works/${doi}`)
   const metadata = cr.data.message
-  // Info datacite
-  // Create module
-  console.log(JSON.stringify(metadata))
+
+  const crType = capitalizeFirstLetter(metadata.type.replace("-", " "))
+  let licenseUrl = undefined
+  if (metadata.license) {
+    const filter = metadata.license.filter((license) => license["content-version"] === "vor")
+    licenseUrl = filter && filter.length > 0 ? filter[0].URL : undefined
+  }
+
   const module = await db.module.create({
     data: {
       published: true,
-      publishedAt: metadata,
-      publishedWhere: metadata,
+      publishedAt: new Date(
+        metadata.published["date-parts"][0].map((y) => y.toString().padStart(2, "0")).join("-")
+      ),
+      publishedWhere: metadata["container-title"][0]
+        ? metadata["container-title"][0]
+        : metadata.publisher,
       prefix: metadata.prefix,
+      suffix: metadata.DOI.replace(`${metadata.prefix}/`, ""),
+      isbn: metadata.ISBN ? metadata.ISBN[0] : undefined,
       url: `https://doi.org/${metadata.DOI}`,
-      title: metadata.title,
+      title: metadata.title[0],
       description: metadata.abstract,
       type: {
-        connect: {},
+        connectOrCreate: {
+          where: {
+            name: crType,
+          },
+          create: {
+            name: crType,
+          },
+        },
       },
+      license: licenseUrl
+        ? {
+            connectOrCreate: {
+              where: { url: licenseUrl },
+              create: {
+                url: licenseUrl,
+                source: "CrossRef",
+              },
+            },
+          }
+        : undefined,
+      authorsRaw: { object: metadata.author },
+      referencesRaw: metadata["reference-count"] > 0 ? { object: metadata.reference } : undefined,
+    },
+    include: {
+      license: true,
+      type: true,
     },
   })
 
-  // publishedAt    DateTime?
-  // publishedWhere String?
-  // isbn           String?
-  // prefix         String?
-  // suffix         String?
-  // license        License?  @relation(fields: [licenseId], references: [id])
-  // licenseId      Int?
-
-  // metadata.type
-  // type         ModuleType @relation(fields: [moduleTypeId], references: [id])
-  // moduleTypeId Int
-
-  // main       Json? @default("{}")
-  // supporting Json? @default("{\"files\": []}")
-
-  // authors    Authorship[]
-  // authorsRaw Json?        @default("{}")
-
-  // parents  Module[] @relation("ModuleToModule", references: [id])
-  // children Module[] @relation("ModuleToModule", references: [id])
-
-  // references    Module[] @relation("ModuleReference", references: [id])
-  // referencedBy  Module[] @relation("ModuleReference", references: [id])
-  // referencesRaw
-
-  // TODO: Index into algolia
+  await index.saveObject({
+    objectID: module.id,
+    doi: `${module.prefix}/${module.suffix}`,
+    suffix: module.suffix,
+    license: module.license?.url,
+    type: module.type.name,
+    // It's called name and not title to improve Algolia search
+    name: module.title,
+    description: module.description,
+    publishedAt: module.publishedAt,
+  })
 
   return true
 })

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -31,8 +31,8 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
       publishedWhere: metadata["container-title"][0]
         ? metadata["container-title"][0]
         : metadata.publisher,
-      prefix: metadata.prefix,
-      suffix: metadata.DOI.replace(`${metadata.prefix}/`, ""),
+      prefix: metadata.DOI.split("/")[0],
+      suffix: metadata.DOI.split("/").slice(1).join("/"),
       isbn: metadata.ISBN ? metadata.ISBN[0] : undefined,
       url: `https://doi.org/${metadata.DOI}`,
       title: metadata.title[0],

--- a/app/modules/mutations/deleteMainFile.ts
+++ b/app/modules/mutations/deleteMainFile.ts
@@ -32,6 +32,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
   const updatedModule = await db.module.findFirst({
     where: { id },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/deleteMainFile.ts
+++ b/app/modules/mutations/deleteMainFile.ts
@@ -33,6 +33,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
     where: { id },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/deleteParent.ts
+++ b/app/modules/mutations/deleteParent.ts
@@ -10,6 +10,11 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnec
       },
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/deleteParent.ts
+++ b/app/modules/mutations/deleteParent.ts
@@ -11,6 +11,13 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnec
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/deleteReference.ts
+++ b/app/modules/mutations/deleteReference.ts
@@ -11,6 +11,13 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnec
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/deleteReference.ts
+++ b/app/modules/mutations/deleteReference.ts
@@ -1,0 +1,49 @@
+import { resolver } from "blitz"
+import db from "db"
+
+export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnectId }) => {
+  const module = await db.module.update({
+    where: { id: currentId },
+    data: {
+      references: {
+        disconnect: { id: parseInt(disconnectId) },
+      },
+    },
+    include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
+      authors: {
+        include: {
+          workspace: true,
+        },
+      },
+      license: true,
+      type: true,
+      parents: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+      children: {
+        include: {
+          type: true,
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  return module
+})

--- a/app/modules/mutations/deleteSupportingFile.ts
+++ b/app/modules/mutations/deleteSupportingFile.ts
@@ -17,6 +17,13 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
     },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/modules/mutations/deleteSupportingFile.ts
+++ b/app/modules/mutations/deleteSupportingFile.ts
@@ -16,6 +16,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
       supporting: supportingFiles,
     },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         include: {
           workspace: true,

--- a/app/modules/mutations/editModuleScreen.ts
+++ b/app/modules/mutations/editModuleScreen.ts
@@ -35,6 +35,11 @@ export default resolver.pipe(
     const updatedModule = await db.module.findFirst({
       where: { id },
       include: {
+        references: {
+          orderBy: {
+            title: "asc",
+          },
+        },
         authors: {
           include: {
             workspace: true,

--- a/app/modules/mutations/editModuleScreen.ts
+++ b/app/modules/mutations/editModuleScreen.ts
@@ -36,11 +36,21 @@ export default resolver.pipe(
       where: { id },
       include: {
         references: {
+          include: {
+            authors: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
           orderBy: {
             title: "asc",
           },
         },
         authors: {
+          orderBy: {
+            authorshipRank: "asc",
+          },
           include: {
             workspace: true,
           },
@@ -70,6 +80,6 @@ export default resolver.pipe(
       },
     })
 
-    return updatedModule!
+    return updatedModule
   }
 )

--- a/app/modules/queries/useCurrentModule.ts
+++ b/app/modules/queries/useCurrentModule.ts
@@ -4,6 +4,11 @@ export default async function getCurrentWorkspace({ suffix }) {
   const module = await db.module.findFirst({
     where: { suffix },
     include: {
+      references: {
+        orderBy: {
+          title: "asc",
+        },
+      },
       authors: {
         orderBy: {
           authorshipRank: "asc",

--- a/app/modules/queries/useCurrentModule.ts
+++ b/app/modules/queries/useCurrentModule.ts
@@ -5,6 +5,13 @@ export default async function getCurrentWorkspace({ suffix }) {
     where: { suffix },
     include: {
       references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
         orderBy: {
           title: "asc",
         },

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -39,6 +39,9 @@ import Footer from "../core/components/Footer"
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const licenses = await db.license.findMany({
+    where: {
+      source: "ResearchEquals",
+    },
     orderBy: [
       {
         price: "asc",

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -12,6 +12,7 @@ export async function getServerSideProps(context) {
     where: {
       suffix: context.params.suffix.toLowerCase(),
       published: true,
+      prefix: "10.53962",
     },
     include: {
       parents: {

--- a/db/migrations/20220105113943_make_module_names_unique_and_wikidata_optional/migration.sql
+++ b/db/migrations/20220105113943_make_module_names_unique_and_wikidata_optional/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `ModuleType` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "ModuleType" ALTER COLUMN "wikidata" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ModuleType_name_key" ON "ModuleType"("name");

--- a/db/migrations/20220105114217_make_license_url_unique/migration.sql
+++ b/db/migrations/20220105114217_make_license_url_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[url]` on the table `License` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "License_url_key" ON "License"("url");

--- a/db/migrations/20220105114653_remove_double_unique_constraint_for_license/migration.sql
+++ b/db/migrations/20220105114653_remove_double_unique_constraint_for_license/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "License_url_name_key";

--- a/db/migrations/20220105120344_add_license_source/migration.sql
+++ b/db/migrations/20220105120344_add_license_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "License" ADD COLUMN     "source" TEXT NOT NULL DEFAULT E'ResearchEquals';

--- a/db/migrations/20220105120928_remove_name_constraint/migration.sql
+++ b/db/migrations/20220105120928_remove_name_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "License" ALTER COLUMN "name" DROP NOT NULL;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -50,23 +50,20 @@ model Module {
 model License {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
-  url       String
-  name      String
+  source    String   @default("ResearchEquals")
+  url       String   @unique
+  name      String?
   price     Int      @default(0)
   price_id  String?
   Module    Module[]
-
-  @@unique([url, name])
 }
 
 model ModuleType {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
-  wikidata  String
-  name      String
+  wikidata  String?
+  name      String   @unique
   Module    Module[]
-
-  // @@unique([wikidata, name])
 }
 
 model Authorship {

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -65,6 +65,8 @@ model ModuleType {
   wikidata  String
   name      String
   Module    Module[]
+
+  // @@unique([wikidata, name])
 }
 
 model Authorship {


### PR DESCRIPTION
This PR introduces the final feature before launch: Reference lists.

References are managed in the same table as modules on the back-end, which will allow us to do some cool stuff in the future. For now, you can add a structured reference list to your modules. If we don't yet have the DOI in our database, people can input a DOI and add it to the database directly (only for CrossRef now).

https://user-images.githubusercontent.com/2946344/148239410-56654d4c-55c0-4c19-97a9-db49a09d6fc0.mov

As a side benefit: You can also link your modules to anything published elsewhere. This means that the parent of a module can be virtually any research output!

There will be some additional required QA on this for design (@psobrakseaton). This feature manifested itself as a necessity for launch during development, so it is a bit unexpected in that sense.