### PR TITLE
Robustify logic for logged out state

### DIFF
--- a/app/modules/components/HandlePanel.tsx
+++ b/app/modules/components/HandlePanel.tsx
@@ -91,14 +91,18 @@ const AuthorPanel = ({ buttonText, title, authors }) => {
                                 </a>
                               </Link>
                             </div>
-                            {ownWorkspace!.handle === author.handle ? (
-                              ""
-                            ) : ownWorkspace!.following.filter(
-                                (follow) => follow.handle === author.handle
-                              ).length > 0 ? (
-                              <UnfollowButton author={author} refetchFn={refetch} />
+                            {ownWorkspace ? (
+                              ownWorkspace!.handle === author.handle ? (
+                                ""
+                              ) : ownWorkspace!.following.filter(
+                                  (follow) => follow.handle === author.handle
+                                ).length > 0 ? (
+                                <UnfollowButton author={author} refetchFn={refetch} />
+                              ) : (
+                                <FollowButton author={author} refetchFn={refetch} />
+                              )
                             ) : (
-                              <FollowButton author={author} refetchFn={refetch} />
+                              ""
                             )}
                           </li>
                         </>

--- a/app/modules/components/ViewAuthors.tsx
+++ b/app/modules/components/ViewAuthors.tsx
@@ -89,14 +89,18 @@ const ViewAuthors = ({ button, module }) => {
                                 </a>
                               </Link>
                             </div>
-                            {ownWorkspace!.handle === author.handle ? (
-                              ""
-                            ) : ownWorkspace!.following.filter(
-                                (follow) => follow.handle === author.workspace.handle
-                              ).length > 0 ? (
-                              <UnfollowButton author={author.workspace} refetchFn={refetch} />
+                            {ownWorkspace ? (
+                              ownWorkspace!.handle === author.handle ? (
+                                ""
+                              ) : ownWorkspace!.following.filter(
+                                  (follow) => follow.handle === author.workspace.handle
+                                ).length > 0 ? (
+                                <UnfollowButton author={author.workspace} refetchFn={refetch} />
+                              ) : (
+                                <FollowButton author={author.workspace} refetchFn={refetch} />
+                              )
                             ) : (
-                              <FollowButton author={author.workspace} refetchFn={refetch} />
+                              ""
                             )}
                           </li>
                         </>


### PR DESCRIPTION
This PR fixes #179.

There was a piece of missing logic in the author popover panel, where follow buttons were attempted to be rendered, but not catching the logged out state.

This was quick to fix once detected. Please keep the bugs 🐛 🐞 coming!