### PR TITLE
Improve logic for cookie

### DIFF
--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -21,7 +21,7 @@ type LayoutProps = {
 
 const Layout = ({ title, children }: LayoutProps) => {
   useEffect(() => {
-    if (getCookieConsentValue("web-app-tbd-website-cookie")) {
+    if (getCookieConsentValue("researchequals-website-cookie") === "true") {
       Chatra("init", config)
     }
   }, [])
@@ -47,7 +47,7 @@ const Layout = ({ title, children }: LayoutProps) => {
         }}
         buttonText="Accept"
         declineButtonText="Decline"
-        cookieName="web-app-tbd-website-cookie"
+        cookieName="researchequals-website-cookie"
         buttonStyle={{
           backgroundColor: "#059669",
           color: "#fff",


### PR DESCRIPTION
This PR improves the logic for the cookie.

![](https://media.giphy.com/media/1ngQorBCDcUFy/giphy.gif)

Apparently the cookie returns a string value, instead of a boolean, by default. This was why #189 manifested itself. 

Fixes #189.