### PR TITLE
Add URL for All rights reserved

### DIFF
--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -88,7 +88,7 @@ const seed = async () => {
           price_id: "price_1KCTCcLmgtJbKHNGbu2vXiYR",
         },
         {
-          url: "",
+          url: "https://en.wikipedia.org/wiki/All_rights_reserved",
           name: "All rights reserved",
           price: 54999,
           price_id: "price_1KCTBbLmgtJbKHNGQSZHsNO0",
@@ -144,7 +144,7 @@ const seed = async () => {
           price_id: "price_1KCMOZLmgtJbKHNGvjMirRp0",
         },
         {
-          url: "",
+          url: "https://en.wikipedia.org/wiki/All_rights_reserved ",
           name: "All rights reserved",
           price: 54999,
           price_id: "price_1KCRbjLmgtJbKHNGLa8TS0aH",


### PR DESCRIPTION
This PR adds a URL for the All rights reserved license.

Given that there is no generic legal text, I opted to link to the Wikipedia page for now. The code change is purely in the seeding script for the database, so for any currently running instances to be fixed, the database needs to be updated.

![](https://media.giphy.com/media/10Semkr8IesDe0/giphy.gif)

Fixes #186 