### PR TITLE
(RE)enable secure uploading

### DIFF
--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -1,9 +1,6 @@
-import { CheckmarkOutline32 } from "@carbon/icons-react"
 import { useMutation, useQuery } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
-import { useRef, Fragment, useState } from "react"
-import { Dialog, Listbox, Menu, Transition } from "@headlessui/react"
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid"
+import { useRef } from "react"
 import { MailIcon, UserCircleIcon, UserIcon, VariableIcon, XIcon } from "@heroicons/react/outline"
 import { Formik, Form } from "formik"
 
@@ -13,12 +10,12 @@ import getSignature from "../../auth/queries/getSignature"
 import QuickDraft from "../../modules/components/QuickDraft"
 import resendVerification from "../../auth/mutations/resendVerification"
 
-const OnboardingQuests = ({ data }) => {
+const OnboardingQuests = ({ data, expire, signature }) => {
   return (
     <>
       <OnboardingEmail data={data.user.emailIsVerified} />
       <OnboardingOrcid data={data.workspace.orcid} />
-      <OnboardingAvatar data={data.workspace} />
+      <OnboardingAvatar data={data.workspace} expire={expire} signature={signature} />
       <OnboardingProfile data={data} />
       <OnboardingDraft data={data.workspace} />
     </>
@@ -172,7 +169,7 @@ const OnboardingProfile = ({ data }) => {
   )
 }
 
-const OnboardingAvatar = ({ data }) => {
+const OnboardingAvatar = ({ data, expire, signature }) => {
   const [changeAvatarMutation] = useMutation(changeAvatar)
   const [uploadSecret] = useQuery(getSignature, undefined)
   const widgetApi = useRef()
@@ -210,8 +207,8 @@ const OnboardingAvatar = ({ data }) => {
               </button>
               <Widget
                 publicKey={process.env.UPLOADCARE_PUBLIC_KEY ?? ""}
-                // secureSignature={uploadSecret.signature}
-                // secureExpire={uploadSecret.expire}
+                secureSignature={signature}
+                secureExpire={expire}
                 crop="1:1"
                 ref={widgetApi}
                 imageShrink="480x480"

--- a/app/modules/components/EditMainFile.jsx
+++ b/app/modules/components/EditMainFile.jsx
@@ -1,8 +1,7 @@
-import { useQuery, useMutation } from "blitz"
+import { useMutation } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 
-import getSignature from "../../auth/queries/getSignature"
 import addMain from "../mutations/addMain"
 import EditMainFileDisplay from "../../core/components/EditMainFileDisplay"
 import { PlusSmIcon } from "@heroicons/react/solid"
@@ -10,8 +9,15 @@ import { fileSizeLimit, fileTypeLimit } from "../../core/utils/fileTypeLimit"
 
 const validators = [fileTypeLimit, fileSizeLimit]
 
-const EditMainFile = ({ mainFile, setQueryData, moduleEdit, user, workspace }) => {
-  const [uploadSecret] = useQuery(getSignature, undefined)
+const EditMainFile = ({
+  mainFile,
+  setQueryData,
+  moduleEdit,
+  user,
+  workspace,
+  expire,
+  signature,
+}) => {
   const widgetApi = useRef()
   const [addMainMutation] = useMutation(addMain)
 
@@ -38,8 +44,8 @@ const EditMainFile = ({ mainFile, setQueryData, moduleEdit, user, workspace }) =
             <PlusSmIcon className="w-4 h-4" aria-hidden="true" /> Add Main File
             <Widget
               publicKey={process.env.UPLOADCARE_PUBLIC_KEY ?? ""}
-              // secureSignature={uploadSecret.signature}
-              // secureExpire={uploadSecret.expire}
+              secureSignature={signature}
+              secureExpire={expire}
               ref={widgetApi}
               previewStep
               validators={validators}

--- a/app/modules/components/EditSupportingFiles.jsx
+++ b/app/modules/components/EditSupportingFiles.jsx
@@ -1,18 +1,15 @@
-import { Download32, TrashCan32 } from "@carbon/icons-react"
-import { useQuery, useMutation } from "blitz"
+import { useMutation } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 import { PlusSmIcon } from "@heroicons/react/solid"
 
-import getSignature from "../../auth/queries/getSignature"
 import addSupporting from "../mutations/addSupporting"
 import getSupportingFiles from "../mutations/getSupportingFiles"
 import { fileSizeLimit, fileTypeLimit } from "../../core/utils/fileTypeLimit"
 
 const validators = [fileTypeLimit, fileSizeLimit]
 
-const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace }) => {
-  const [uploadSecret] = useQuery(getSignature, undefined)
+const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace, expire, signature }) => {
   const widgetApi = useRef()
   const [addSupportingMutation] = useMutation(addSupporting)
   const [getSupportingFilesMutation] = useMutation(getSupportingFiles)
@@ -45,8 +42,8 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace }) => {
             {moduleEdit.supporting ? (
               <Widget
                 publicKey={process.env.UPLOADCARE_PUBLIC_KEY ?? ""}
-                // secureSignature={uploadSecret.signature}
-                // secureExpire={uploadSecret.expire}
+                secureSignature={signature}
+                secureExpire={expire}
                 ref={widgetApi}
                 validators={validators}
                 previewStep
@@ -58,8 +55,8 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace }) => {
             ) : (
               <Widget
                 publicKey={process.env.UPLOADCARE_PUBLIC_KEY ?? ""}
-                // secureSignature={uploadSecret.signature}
-                // secureExpire={uploadSecret.expire}
+                secureSignature={signature}
+                secureExpire={expire}
                 ref={widgetApi}
                 validators={validators}
                 previewStep

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -1,6 +1,5 @@
 import { useQuery, useMutation, Link, validateZodSchema, Routes } from "blitz"
 import { useState, useEffect } from "react"
-import moment from "moment"
 import algoliasearch from "algoliasearch"
 import { z } from "zod"
 import { getAlgoliaResults } from "@algolia/autocomplete-js"
@@ -9,29 +8,19 @@ import { Prisma } from "prisma"
 import { useFormik } from "formik"
 import { Maximize24, TrashCan24 } from "@carbon/icons-react"
 import toast from "react-hot-toast"
-import router from "next/router"
 
 import EditMainFile from "./EditMainFile"
-import ManageAuthors from "./ManageAuthors"
 import EditSupportingFiles from "./EditSupportingFiles"
 
 import DeleteModuleModal from "../../core/modals/DeleteModuleModal"
 import useCurrentModule from "../queries/useCurrentModule"
 import Autocomplete from "../../core/components/Autocomplete"
 import PublishModuleModal from "../../core/modals/PublishModuleModal"
-import addParent from "../mutations/addParent"
-import getTypes from "../../core/queries/getTypes"
-import getLicenses from "app/core/queries/getLicenses"
 import editModuleScreen from "../mutations/editModuleScreen"
 import EditSupportingFileDisplay from "../../core/components/EditSupportingFileDisplay"
 import MetadataView from "./MetadataView"
-import AuthorAvatars from "./AuthorAvatars"
 import SearchResultModule from "../../core/components/SearchResultModule"
-import { ArrowNarrowLeftIcon, PlusSmIcon } from "@heroicons/react/solid"
-import AuthorAvatarsNew from "./AuthorAvatarsNew"
-import SearchResultWorkspace from "../../core/components/SearchResultWorkspace"
-import addAuthor from "../mutations/addAuthor"
-import EditMainFileDisplay from "../../core/components/EditMainFileDisplay"
+import { ArrowNarrowLeftIcon } from "@heroicons/react/solid"
 import MetadataEdit from "./MetadataEdit"
 import { useCurrentWorkspace } from "app/core/hooks/useCurrentWorkspace"
 import addReference from "../mutations/addReference"
@@ -40,19 +29,25 @@ import deleteReference from "../mutations/deleteReference"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
-const ModuleEdit = ({ user, workspace, module, isAuthor, setInboxOpen, inboxOpen }) => {
+const ModuleEdit = ({
+  user,
+  workspace,
+  module,
+  isAuthor,
+  setInboxOpen,
+  inboxOpen,
+  expire,
+  signature,
+}) => {
   const [isEditing, setIsEditing] = useState(false)
   const [addAuthors, setAddAuthors] = useState(false)
   const currentWorkspace = useCurrentWorkspace()
 
-  const [manageAuthorsOpen, setManageAuthorsOpen] = useState(false)
   const [moduleEdit, { refetch, setQueryData }] = useQuery(
     useCurrentModule,
     { suffix: module.suffix },
     { refetchOnWindowFocus: true }
   )
-  const [moduleTypes] = useQuery(getTypes, undefined)
-  const [licenses] = useQuery(getLicenses, undefined)
 
   const mainFile = moduleEdit!.main as Prisma.JsonObject
   const supportingRaw = moduleEdit!.supporting as Prisma.JsonObject
@@ -61,7 +56,6 @@ const ModuleEdit = ({ user, workspace, module, isAuthor, setInboxOpen, inboxOpen
   const [deleteReferenceMutation] = useMutation(deleteReference)
   const [createReferenceMutation] = useMutation(createReferenceModule)
   const [editModuleScreenMutation] = useMutation(editModuleScreen)
-  const [addAuthorMutation] = useMutation(addAuthor)
 
   const formik = useFormik({
     initialValues: {
@@ -183,6 +177,8 @@ const ModuleEdit = ({ user, workspace, module, isAuthor, setInboxOpen, inboxOpen
           moduleEdit={moduleEdit}
           user={user}
           workspace={currentWorkspace}
+          expire={expire}
+          signature={signature}
         />
       </div>
 
@@ -214,6 +210,8 @@ const ModuleEdit = ({ user, workspace, module, isAuthor, setInboxOpen, inboxOpen
           moduleEdit={moduleEdit}
           user={user}
           workspace={currentWorkspace}
+          expire={expire}
+          signature={signature}
         />
       </div>
 


### PR DESCRIPTION
This PR re-enables secure uploading in a way that works in a way that does not recreate #116.

The main thing here was that the signature kept getting regenerated on the page, resulting in the widget closing. 

Now, the signature gets generated on the server upon page load using `getServerSideProps` - this prevents the repeated regeneration and its subsequent issues.

Fixes #138 