### PR TITLE
Add OpenGraph meta tags

### DIFF
--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -17,9 +17,10 @@ let config = {
 type LayoutProps = {
   title?: string
   children: ReactNode
+  headChildren?: ReactNode
 }
 
-const Layout = ({ title, children }: LayoutProps) => {
+const Layout = ({ title, children, headChildren }: LayoutProps) => {
   useEffect(() => {
     if (getCookieConsentValue("researchequals-website-cookie") === "true") {
       Chatra("init", config)
@@ -33,6 +34,7 @@ const Layout = ({ title, children }: LayoutProps) => {
         <title>{title || "ResearchEquals"}</title>
         <link rel="icon" href="/favicon-32.png" />
         <script data-respect-dnt data-no-cookie async src="https://cdn.splitbee.io/sb.js"></script>
+        {headChildren}
       </Head>
       <div className="min-h-screen flex flex-col bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
         <div className="flex-grow">{children}</div>

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -52,7 +52,15 @@ export const getServerSideProps = async ({ params }) => {
 
 const HandlePage = ({ workspace }) => {
   return (
-    <Layout title={`R=${workspace.name || workspace.handle}`}>
+    <Layout
+      title={`R=${workspace.name || workspace.handle}`}
+      headChildren={
+        <>
+          <meta property="og:title" content={workspace.name || workspace.handle} />
+          {workspace.bio ? <meta property="og:description" content={workspace.bio} /> : ""}
+        </>
+      }
+    >
       <div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-200 h-full">
         <Navbar />
         <div className="lg:flex max-w-full mx-4">

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -93,10 +93,10 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
     <>
       <Navbar />
       <main className="lg:relative bg-white dark:bg-gray-900">
-        <div className="">
+        <div className="" id="hero">
           <div className="pt-8 overflow-hidden sm:pt-12 lg:relative lg:py-32">
             <div className="mx-auto max-w-md px-4 sm:max-w-3xl sm:px-6 lg:px-8 lg:max-w-7xl lg:grid lg:grid-cols-2 lg:gap-24">
-              <div id="hero">
+              <div>
                 <div className="mt-20">
                   <div>
                     <a href="#" className="inline-flex space-x-4">

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -96,7 +96,7 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
         <div className="">
           <div className="pt-8 overflow-hidden sm:pt-12 lg:relative lg:py-32">
             <div className="mx-auto max-w-md px-4 sm:max-w-3xl sm:px-6 lg:px-8 lg:max-w-7xl lg:grid lg:grid-cols-2 lg:gap-24">
-              <div>
+              <div id="hero">
                 <div className="mt-20">
                   <div>
                     <a href="#" className="inline-flex space-x-4">
@@ -556,6 +556,26 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
 }
 
 Home.suppressFirstRenderFlicker = true
-Home.getLayout = (page) => <Layout title="Home">{page}</Layout>
+Home.getLayout = (page) => (
+  <Layout
+    title="Home"
+    headChildren={
+      <>
+        <meta property="og:title" content="ResearchEquals.com" />
+        <meta
+          property="og:description"
+          content="Step by step publishing of your research, with a new publishing format: Research modules."
+        />
+        <meta property="og:image" content="https://og-images.herokuapp.com/researchequals" />
+        <meta
+          property="og:image:alt"
+          content="Screenshot of the homepage of ResearchEquals.com, including the description and a sign up button for release updates."
+        />
+      </>
+    }
+  >
+    {page}
+  </Layout>
+)
 
 export default Home

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -566,7 +566,7 @@ Home.getLayout = (page) => (
           property="og:description"
           content="Step by step publishing of your research, with a new publishing format: Research modules."
         />
-        <meta property="og:image" content="https://og-images.herokuapp.com/researchequals" />
+        <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" />
         <meta
           property="og:image:alt"
           content="Screenshot of the homepage of ResearchEquals.com, including the description and a sign up button for release updates."

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -74,7 +74,20 @@ const ModulePage = ({ module }) => {
   const supportingRaw = module!.supporting as Prisma.JsonObject
 
   return (
-    <Layout title={`R=${module.title}`}>
+    <Layout
+      title={`R=${module.title}`}
+      headChildren={
+        <>
+          <meta property="og:title" content={module.title} />
+          <meta property="og:url" content={`https://doi.org/${module.prefix}/${module.suffix}`} />
+          {module.description ? (
+            <meta property="og:description" content={module.description} />
+          ) : (
+            ""
+          )}
+        </>
+      }
+    >
       <NavbarApp />
       <main className="max-w-7xl sm:mx-auto my-4 mx-4">
         <div className="w-full flex">


### PR DESCRIPTION
This PR adds OpenGraph meta tags to some of the core pages.

This is not yet optimized for [Google Scholar inclusion](https://scholar.google.com/intl/en/scholar/publishers.html) - it is primarily optimized to start including social media images.

Supercedes #31.