### PR TITLE
QA `/login`

### DIFF
--- a/app/auth/components/LoginForm.tsx
+++ b/app/auth/components/LoginForm.tsx
@@ -3,6 +3,7 @@ import login from "app/auth/mutations/login"
 import { useFormik } from "formik"
 import { z } from "zod"
 import ResearchEqualsLogo from "app/core/components/ResearchEqualsLogo"
+import toast from "react-hot-toast"
 
 type LoginFormProps = {
   onSuccess?: () => void
@@ -19,19 +20,15 @@ export const LoginForm = (props: LoginFormProps) => {
     validate: validateZodSchema(
       z.object({
         email: z.string().email(),
-        password: z.string(),
+        password: z.string().min(10),
       })
     ),
     onSubmit: async (values) => {
-      try {
-        await loginMutation(values)
-      } catch (error) {
-        if (error instanceof AuthenticationError) {
-          alert("Sorry, those credentials are invalid")
-        } else {
-          alert(error.toString())
-        }
-      }
+      toast.promise(loginMutation(values), {
+        loading: "Logging in...",
+        success: "Logged in!",
+        error: "Please check your log in credentials",
+      })
     },
   })
   return (
@@ -43,14 +40,15 @@ export const LoginForm = (props: LoginFormProps) => {
           </a>
         </Link>
         <h1 className="mt-6 text-center text-3xl font-extrabold ">Log in to ResearchEquals</h1>
-        <div className="bg-white dark:bg-gray-800 shadow rounded py-4 px-6 my-8  mx-auto">
+        <div className="bg-white dark:bg-gray-800 shadow rounded py-4 px-6 my-8 mx-auto">
           <form onSubmit={formik.handleSubmit}>
-            <div className="my-4">
+            <div className="">
               <label
                 htmlFor="email"
                 className=" my-1 block text-sm font-medium text-gray-700 dark:text-gray-100"
               >
-                Email address
+                Email address{" "}
+                {formik.touched.email && formik.errors.email ? " - " + formik.errors.email : null}
               </label>
               <div className="mt-1">
                 <input
@@ -62,9 +60,6 @@ export const LoginForm = (props: LoginFormProps) => {
                   placeholder="you@email.com"
                   {...formik.getFieldProps("email")}
                 />
-                {formik.touched.email && formik.errors.email ? (
-                  <div className="font-normal text-sm">{formik.errors.email}</div>
-                ) : null}
               </div>
             </div>
             {/* Password */}
@@ -73,7 +68,10 @@ export const LoginForm = (props: LoginFormProps) => {
                 htmlFor="password"
                 className="my-1 block text-sm font-medium text-gray-700 dark:text-gray-100"
               >
-                Password
+                Password{" "}
+                {formik.touched.password && formik.errors.password
+                  ? " - " + formik.errors.password
+                  : null}
               </label>
               <div className="">
                 <input
@@ -83,14 +81,13 @@ export const LoginForm = (props: LoginFormProps) => {
                   className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:text-gray-100 dark:bg-gray-800 dark:border-gray-500"
                   {...formik.getFieldProps("password")}
                 />
-                {formik.touched.password && formik.errors.password ? (
-                  <div className="font-normal text-sm">{formik.errors.password}</div>
-                ) : null}
               </div>
             </div>
-            <div className="text-indigo-600 text-center my-4 font-medium text-sm">
+            <div className="text-indigo-600 dark:text-gray-200 text-center my-4 font-medium text-sm">
               <Link href={Routes.ForgotPasswordPage()}>
-                <a>Forgot your password?</a>
+                <a className="underline focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500">
+                  Forgot your password?
+                </a>
               </Link>
             </div>
             <button
@@ -100,10 +97,12 @@ export const LoginForm = (props: LoginFormProps) => {
               Log in
             </button>
           </form>
-          <div className="text-gray-900 dark:text-white text-center my-4 font-medium text-sm">
+          <div className="text-gray-900 dark:text-white text-center mt-4 font-medium text-sm">
             Do not have an account?{" "}
             <Link href={Routes.SignupPage()}>
-              <a className="text-indigo-600">Sign up</a>
+              <a className="text-indigo-600 dark:text-gray-200 underline focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500">
+                Sign up
+              </a>
             </Link>
           </div>
         </div>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -6,13 +6,12 @@ import {
   AuthorizationError,
   ErrorFallbackProps,
   useQueryErrorResetBoundary,
-  Routes,
+  Router,
 } from "blitz"
 import LoginForm from "app/auth/components/LoginForm"
 
 import "app/core/styles/index.css"
 import "app/core/styles/algolia.css"
-import router, { Router } from "next/router"
 
 export default function App({ Component, pageProps }: AppProps) {
   const getLayout = Component.getLayout || ((page) => page)
@@ -29,7 +28,10 @@ export default function App({ Component, pageProps }: AppProps) {
 
 function RootErrorFallback({ error, resetErrorBoundary }: ErrorFallbackProps) {
   if (error instanceof AuthenticationError) {
-    return <LoginForm onSuccess={resetErrorBoundary} />
+    Router.push("/login")
+    resetErrorBoundary()
+
+    return null
   } else if (error instanceof AuthorizationError) {
     return (
       <ErrorComponent


### PR DESCRIPTION
This PR continues the #206 work.

The main difference in these changes is the handling of `AuthenticationError`. Previously it would need a refresh to show the logged in state - a UX nuisance if you ask me.

Now an `AuthenticationError` redirects to `/login` instead of presenting the `LoginForm` on the route it came from.