### PR TITLE
Quality Assurance Uploadcare widget

### DIFF
--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -33,6 +33,10 @@
   display: none;
 }
 
+.uploadcare--powered-by {
+  display: none;
+}
+
 .uploadcare--panel {
   font-family: "Noto Sans Display", sans-serif;
 }

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -40,3 +40,7 @@
 .uploadcare--panel {
   font-family: "Noto Sans Display", sans-serif;
 }
+
+.uploadcare--button_primary {
+  background-color: #574cfa;
+}


### PR DESCRIPTION
This PR does a pass at the Uploadcare widget.

- Enable secure uploading - forgot to enable it on the service itself in #199 😅 still works!

Ended up making minimal visual changes because the lightmode version works decently already, but the darkmode one has limitations... The tabs for e.g., facebook, Gdrive etc are embedded in an `iframe` that I couldn't style 1-2-3. 

Weighed the option of (1) removing those services and having better styling v (2) keeping services and worse styling. For now going with 2.

Here's some CSS in case we'd like to take another try at it later

```css

@media (prefers-color-scheme: dark) {
  .uploadcare--tab {
    background-color: #0f172a;
    color: #e2e8f0;
  }
  .uploadcare--menu__item_tab_camera {
    background: #98afd5;
  }
  .uploadcare--menu__item_current {
    background-color: #0f172a;
    color: #e2e8f0;
  }

  .uploadcare--menu__item {
    background-color: #0f172a;
    color: #e2e8f0;
  }

  .uploadcare--menu__item:hover {
    background-color: #1e293b;
    color: #e2e8f0;
  }

  .uploadcare--input {
    background-color: #1e293b;
    color: #e2e8f0;
  }

  .uploadcare--menu__item_tab_preview {
    background-color: #0f172a;
    color: #e2e8f0;
  }
}
```