### PR TITLE
Enable email verification without logging in

### DIFF
--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -48,7 +48,7 @@ export default resolver.pipe(
       sendEmailWithTemplate(email, "welcome", {
         handle: handle,
         days: 14,
-        verify_email_url: url`/verifyEmail/${emailCode}`,
+        verify_email_url: url`/verifyEmail/${emailCode}?userId=${user.id}`,
       }),
       ctx.session.$create({
         userId: user.id,

--- a/app/auth/mutations/verify-email.ts
+++ b/app/auth/mutations/verify-email.ts
@@ -9,11 +9,11 @@ const client = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_AP
 const index = client.initIndex(`${process.env.ALGOLIA_PREFIX}_workspaces`)
 
 export default resolver.pipe(
-  resolver.zod(z.object({ code: z.string() })),
-  resolver.authorize(),
-  async ({ code }, ctx: Ctx) => {
+  resolver.zod(z.object({ code: z.string(), userId: z.any() })),
+  // resolver.authorize(),
+  async ({ code, userId }, ctx: Ctx) => {
     const user = await db.user.findUnique({
-      where: { id: ctx.session.userId! },
+      where: { id: parseInt(userId) },
       include: {
         memberships: {
           include: {
@@ -26,7 +26,7 @@ export default resolver.pipe(
 
     const isValid = await verifyCode(code, hashedPassword)
     if (isValid) {
-      await db.user.update({ where: { id: ctx.session.userId! }, data: { emailIsVerified: true } })
+      await db.user.update({ where: { id: parseInt(userId) }, data: { emailIsVerified: true } })
 
       user!.memberships!.map(async (membership) => {
         await index.saveObject({

--- a/app/auth/pages/verifyEmail/[code].tsx
+++ b/app/auth/pages/verifyEmail/[code].tsx
@@ -7,6 +7,9 @@ const VerifyMail: BlitzPage = () => {
   const code = useParam("code", "string")
   const [verifyEmail] = useMutation(verifyEmailMutation)
   const [error, setError] = useState(false)
+  const userId = useRouterQuery().userId
+
+  console.log(userId)
 
   useEffect(() => {
     if (!code) {
@@ -15,7 +18,7 @@ const VerifyMail: BlitzPage = () => {
 
     Router.prefetch("/")
 
-    verifyEmail({ code }).then((success) => {
+    verifyEmail({ code, userId }).then((success) => {
       if (success) {
         Router.replace("/")
       } else {
@@ -54,7 +57,6 @@ const VerifyMail: BlitzPage = () => {
   )
 }
 
-VerifyMail.authenticate = true
 VerifyMail.getLayout = (page) => <Layout title="Verifying Email ...">{page}</Layout>
 
 export default VerifyMail


### PR DESCRIPTION
This PR enables email verification without logging in.

As flagged by several people over time, described in #213, there are ample use cases where the device one wants to verify on is not the device one is logged into at that moment. 

With this fix, you can verify the email anywhere you open the link. The code is specific to the password of the `userId`, so it cannot be used to verify other emails.