### PR TITLE
Add sign ups to `/browse`

### DIFF
--- a/app/core/queries/getBrowseWorkspaceData.ts
+++ b/app/core/queries/getBrowseWorkspaceData.ts
@@ -1,0 +1,29 @@
+import { paginate, resolver } from "blitz"
+import db, { Prisma } from "db"
+
+export default async function getBrowseWorkspaceData({ skip = 0, take = 100 }) {
+  const {
+    items: workspaces,
+    hasMore,
+    nextPage,
+    count,
+  } = await paginate({
+    skip,
+    take,
+    count: () => db.workspace.count({}),
+    query: (paginateArgs) =>
+      db.workspace.findMany({
+        ...paginateArgs,
+        orderBy: {
+          createdAt: "desc",
+        },
+      }),
+  })
+
+  return {
+    workspaces,
+    nextPage,
+    hasMore,
+    count,
+  }
+}

--- a/app/core/queries/getBrowseWorkspaceGraphData.ts
+++ b/app/core/queries/getBrowseWorkspaceGraphData.ts
@@ -1,0 +1,38 @@
+import db from "db"
+
+const itemCounter = (array, item) =>
+  array.flat(Infinity).filter((currentItem) => currentItem == item).length
+
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index
+}
+
+export default async function getSignature() {
+  const workspaces = await db.workspace.findMany({
+    orderBy: [
+      {
+        createdAt: "asc",
+      },
+    ],
+  })
+
+  const dates = workspaces.map((workspace) => {
+    return workspace.createdAt?.toISOString().substr(0, 10)
+  })
+
+  let data = [] as any
+  const uniqDates = dates.filter(onlyUnique)
+  uniqDates.forEach((date, index) => {
+    const epochTime = new Date(date!)
+    data.push({
+      time: epochTime.getTime(),
+      workspaces:
+        index !== 0
+          ? itemCounter(dates, date) + data[index - 1].workspaces
+          : itemCounter(dates, date),
+    })
+  })
+  console.log(data)
+
+  return data
+}

--- a/app/pages/browse.jsx
+++ b/app/pages/browse.jsx
@@ -14,6 +14,8 @@ import { useCurrentUser } from "app/core/hooks/useCurrentUser"
 import { useCurrentWorkspace } from "app/core/hooks/useCurrentWorkspace"
 import getDrafts from "app/core/queries/getDrafts"
 import getInvitedModules from "app/workspaces/queries/getInvitedModules"
+import getBrowseWorkspaceData from "../core/queries/getBrowseWorkspaceData"
+import getBrowseWorkspaceGraphData from "../core/queries/getBrowseWorkspaceGraphData"
 
 const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
@@ -21,6 +23,19 @@ const CustomTooltip = ({ active, payload, label }) => {
       <div className="custom-tooltip bg-white dark:bg-gray-900 shadow-xl border dark:border-gray-600 rounded p-2 border-b bgborder-gray-400">
         <p className="label">{`${moment(label).format("YYYY-MM-DD")}`}</p>
         <p>Total modules: {`${payload[0].value}`}</p>
+      </div>
+    )
+  }
+
+  return null
+}
+
+const CustomTooltipWorkspace = ({ active, payload, label }) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="custom-tooltip bg-white dark:bg-gray-900 shadow-xl border dark:border-gray-600 rounded p-2 border-b bgborder-gray-400">
+        <p className="label">{`${moment(label).format("YYYY-MM-DD")}`}</p>
+        <p>Total signups: {`${payload[0].value}`}</p>
       </div>
     )
   }
@@ -37,7 +52,7 @@ const BrowseContent = () => {
 
   return (
     <div className="max-w-7xl text-gray-900 dark:text-gray-200 py-16 mx-4 xl:mx-auto">
-      <h1 className="text-3xl text-center font-extrabold ">Browse modules</h1>
+      <h1 className="text-3xl text-center font-extrabold ">Browse recent modules</h1>
       <div className="mx-auto text-center">
         <ResponsiveContainer width="100%" height={250}>
           <AreaChart
@@ -121,10 +136,112 @@ const BrowseContent = () => {
           className="whitespace-nowrap text-sm leading-5 font-normal text-indigo-700 dark:text-gray-200 bg-indigo-100 hover:bg-indigo-200 dark:bg-gray-800 dark:hover:bg-gray-700 border-0 dark:border dark:border-gray-600 px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500"
         >
           {isFetchingNextPage
-            ? "Loading more..."
+            ? "Loading more modules..."
             : hasNextPage
-            ? "Load More"
-            : "Nothing more to load"}
+            ? "Load more modules"
+            : "No more modules to load"}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const BrowseWorkspaces = () => {
+  const [workspacePages, { isFetching, isFetchingNextPage, fetchNextPage, hasNextPage }] =
+    useInfiniteQuery(getBrowseWorkspaceData, (page = { take: 20, skip: 0 }) => page, {
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+    })
+  const [graphData] = useQuery(getBrowseWorkspaceGraphData, undefined)
+
+  return (
+    <div className="max-w-7xl text-gray-900 dark:text-gray-200 py-16 mx-4 xl:mx-auto">
+      <h1 className="text-3xl text-center font-extrabold ">Browse recent signups</h1>
+      <div className="mx-auto text-center">
+        <ResponsiveContainer width="100%" height={250}>
+          <AreaChart
+            width={1280}
+            height={250}
+            data={graphData}
+            margin={{ top: 10, right: 0, left: 0, bottom: 0 }}
+          >
+            <defs>
+              <linearGradient id="colorWorkspaces" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#574cfa" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="#574cfa" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="time"
+              domain={["dataMin", "dataMax"]}
+              name="Time"
+              tickFormatter={(unixTime) => moment(unixTime).format("YYYY-MM-DD")}
+              type="number"
+              tickLine={false}
+              axisLine={false}
+              style={{
+                fontSize: "0.8rem",
+              }}
+              // hide={true}
+            />
+            <YAxis
+              dataKey="workspaces"
+              name="Workspaces"
+              tickLine={false}
+              axisLine={false}
+              style={{
+                fontSize: "0.8rem",
+              }}
+              orientation="right"
+              // hide={true}
+            />
+            <Tooltip content={<CustomTooltipWorkspace />} />
+            <Area
+              type="monotone"
+              dataKey="workspaces"
+              stroke="#574cfa"
+              fillOpacity={1}
+              fill="url(#colorWorkspaces)"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+      {workspacePages.map((page, i) => (
+        <React.Fragment key={i}>
+          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 gap-y-10 my-4">
+            {page.workspaces.map((workspace) => (
+              <>
+                <>
+                  <Link href={Routes.HandlePage({ handle: workspace.handle })}>
+                    <a className="mx-auto text-center">
+                      <img
+                        src={workspace.avatar}
+                        alt={`Avatar of ${workspace.handle}`}
+                        className="h-28 w-28 rounded-full mx-auto"
+                      />
+                      <p className="mx-auto text-center my-2">
+                        {workspace.firstName && workspace.lastName
+                          ? `${workspace.firstName} ${workspace.lastName}`
+                          : `@${workspace.handle}`}{" "}
+                      </p>
+                    </a>
+                  </Link>
+                </>
+              </>
+            ))}
+          </div>
+        </React.Fragment>
+      ))}
+      <div className="text-center my-4">
+        <button
+          onClick={() => fetchNextPage()}
+          disabled={!hasNextPage || !!isFetchingNextPage}
+          className="whitespace-nowrap text-sm leading-5 font-normal text-indigo-700 dark:text-gray-200 bg-indigo-100 hover:bg-indigo-200 dark:bg-gray-800 dark:hover:bg-gray-700 border-0 dark:border dark:border-gray-600 px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500"
+        >
+          {isFetchingNextPage
+            ? "Loading more authors..."
+            : hasNextPage
+            ? "Load more authors"
+            : "No more authors to load"}
         </button>
       </div>
     </div>
@@ -151,6 +268,7 @@ const Browse = () => {
         refetchFn={refetch}
       />
       <BrowseContent />
+      <BrowseWorkspaces />
       <Footer />
     </>
   )


### PR DESCRIPTION
This PR adds a way to browse the people who've signed up.

It allows for a bit more window shopping on the platform, and informs people about the development over time as a way of social proof (if successful 😉 )

https://user-images.githubusercontent.com/2946344/149329482-38517ba6-2122-4499-a02b-ba6f81584616.mov


