### PR TITLE
Redirect to `/dashboard` upon email verification

### DIFF
--- a/app/auth/pages/verifyEmail/[code].tsx
+++ b/app/auth/pages/verifyEmail/[code].tsx
@@ -16,11 +16,11 @@ const VerifyMail: BlitzPage = () => {
       return
     }
 
-    Router.prefetch("/")
+    Router.prefetch("/dashboard")
 
     verifyEmail({ code, userId }).then((success) => {
       if (success) {
-        Router.replace("/")
+        Router.replace("/dashboard")
       } else {
         setError(true)
       }


### PR DESCRIPTION
This PR fixes #224. Instead of redirecting to `/` it now redirects to `/dashboard`, which automatically redirects to `/login` if not logged in.

