### PR TITLE
Upgrade `/invitations`

### DIFF
--- a/app/core/components/InvitationNotification.tsx
+++ b/app/core/components/InvitationNotification.tsx
@@ -4,7 +4,7 @@ import moment from "moment"
 const InvitationNotification = ({ invited }) => {
   return (
     <>
-      <Link href="/invitations">
+      <Link href={`/invitations?suffix=${invited.suffix}`}>
         <li className="cursor-pointer p-2">
           <p className="text-xs leading-4 text-gray-400">{moment(invited.updatedAt).fromNow()}</p>
           <p className="text-sm leading-4 font-bold text-gray-900 dark:text-gray-200 mt-2 mb-1">

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -10,14 +10,14 @@ import getSignature from "../../auth/queries/getSignature"
 import QuickDraft from "../../modules/components/QuickDraft"
 import resendVerification from "../../auth/mutations/resendVerification"
 
-const OnboardingQuests = ({ data, expire, signature }) => {
+const OnboardingQuests = ({ data, expire, signature, refetch }) => {
   return (
     <>
       <OnboardingEmail data={data.user.emailIsVerified} />
       {/* <OnboardingOrcid data={data.workspace.orcid} /> */}
       <OnboardingAvatar data={data.workspace} expire={expire} signature={signature} />
       <OnboardingProfile data={data} />
-      <OnboardingDraft data={data.workspace} />
+      <OnboardingDraft data={data.workspace} refetch={refetch} />
     </>
   )
 }
@@ -236,7 +236,7 @@ const OnboardingAvatar = ({ data, expire, signature }) => {
   )
 }
 
-const OnboardingDraft = ({ data }) => {
+const OnboardingDraft = ({ data, refetch }) => {
   return (
     <>
       {!data.authorships.length > 0 ? (
@@ -270,6 +270,7 @@ const OnboardingDraft = ({ data }) => {
                   </>
                 }
                 buttonStyle="whitespace-nowrap font-medium hover:text-blue-600 underline"
+                refetchFn={refetch}
               />
             </p>
           </div>

--- a/app/modules/components/MetadataInvite.tsx
+++ b/app/modules/components/MetadataInvite.tsx
@@ -1,0 +1,61 @@
+import { Link } from "blitz"
+import moment from "moment"
+
+import AuthorAvatarsNew from "./AuthorAvatarsNew"
+import ViewAuthors from "./ViewAuthors"
+import { Suspense } from "react"
+
+const MetadataInvite = ({ module }) => {
+  return (
+    <>
+      <div
+        className="module bg-gray-100 dark:bg-gray-600 my-4"
+        style={{ padding: "1px" }}
+        id="moduleCurrent"
+      >
+        <div className="module bg-white dark:bg-gray-900 border-0 border-gray-100 dark:border-gray-600 divide-y divide-gray-100 dark:divide-gray-600">
+          <div className="lg:flex text-center divide-y lg:divide-y-0 lg:divide-x divide-gray-100 dark:divide-gray-600 text-gray-500 dark:text-gray-200 dark:bg-gray-800 text-sm leading-4 font-normal">
+            <div className="flex-grow py-2">Last updated: {moment(module.updatedAt).fromNow()}</div>
+            <div className="flex-grow py-2">
+              DOI upon publish:{" "}
+              <span className="text-gray-300 dark:text-gray-600">{`${module.prefix}/${module.suffix}`}</span>
+            </div>
+            <div className="flex-grow py-2">
+              License:{" "}
+              <Link href={module.license!.url!}>
+                <a target="_blank">{module.license!.name}</a>
+              </Link>
+            </div>
+          </div>
+          <div className="py-4 px-2 min-h-32">
+            <p className="text-sm leading-4 font-normal text-gray-500 dark:text-white">
+              {module.type.name}
+            </p>
+            <p className="text-xl leading-6 font-medium  text-gray-900 dark:text-white">
+              {module.title}
+            </p>
+          </div>
+          {/* Authors section */}
+          <div className="px-1 py-1 sm:flex place-items-center sm:place-items-left">
+            <div className="flex sm:inline">
+              <span className="flex-grow"></span>
+
+              <AuthorAvatarsNew authors={module.authors} size="h-12 w-12" toDisplay={4} />
+              <span className="flex-grow"></span>
+            </div>
+            <span className="sm:flex-grow"></span>
+            <div className="flex sm:contents">
+              <ViewAuthors module={module} button={<>test</>} />
+            </div>
+          </div>
+          {/* Description section */}
+          <div className="text-base leading-6 font-normal pt-4 pl-2 pr-4 pb-2">
+            {module.description}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default MetadataInvite

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -104,7 +104,7 @@ const ModuleEdit = ({
       {/* Publish module */}
       {(moduleEdit!.authors.filter((author) => author.readyToPublish !== true).length === 0 &&
         Object.keys(moduleEdit!.main!).length !== 0) ||
-      moduleEdit!.authors.length === 1 ? (
+      (moduleEdit!.authors.length === 1 && moduleEdit!.main!["name"]) ? (
         <PublishModuleModal module={moduleEdit} user={user} workspace={workspace} />
       ) : (
         <></>

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -83,7 +83,7 @@ const DashboardContent = ({
           <div className="p-4">
             <div className="my-0">
               <h1 className="text-4xl font-medium text-center">
-                Welcome back,{" "}
+                Welcome,{" "}
                 {data.workspace.firstName && data.workspace.lastName
                   ? `${data.workspace.firstName} ${data.workspace.lastName}`
                   : `@${data.workspace!.handle}`}

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -91,7 +91,12 @@ const DashboardContent = ({
               </h1>
             </div>
             <div className="lg:flex w-full mt-4 gap-2">
-              <OnboardingQuests data={data} expire={expire} signature={signature} />
+              <OnboardingQuests
+                data={data}
+                expire={expire}
+                signature={signature}
+                refetch={refetchWorkspace}
+              />
             </div>
             <dl className="mt-2 flex text-gray-900 dark:text-gray-200  overflow-hidden shadow dark:border rounded border-gray-100 dark:border-gray-600 divide-gray-100 dark:divide-gray-600 md:grid-cols-3 divide-x">
               {stats.map((item) => (

--- a/app/pages/invitations.tsx
+++ b/app/pages/invitations.tsx
@@ -14,10 +14,9 @@ import { useMediaPredicate } from "react-media-hook"
 import LayoutLoader from "app/core/components/LayoutLoader"
 import getDrafts from "app/core/queries/getDrafts"
 
-const Invitations = () => {
+const Invitations = ({ currentWorkspace }) => {
   const session = useSession()
   const [currentModule, setModule] = useState<any>(undefined)
-  const currentWorkspace = useCurrentWorkspace()
   const [inboxOpen, setInboxOpen] = useState(true)
   const biggerWindow = useMediaPredicate("(min-width: 1024px)")
   const [invitations, { refetch }] = useQuery(getInvitedModules, { session })
@@ -35,12 +34,16 @@ const Invitations = () => {
   }, [])
 
   return (
-    <div className="w-screen flex divide-x divide-gray-100 dark:divide-gray-600">
+    <div
+      className="w-screen flex divide-x divide-gray-100 dark:divide-gray-600"
+      style={{
+        height: biggerWindow ? "calc(100vh - 73px - 55px)" : "100%",
+      }}
+    >
       <div
         className={`${
           !inboxOpen ? "hidden" : "inline"
-        } w-full lg:w-80 divide-y-0 divide-gray-100 dark:divide-gray-600`}
-        style={{ minHeight: "calc(100vh - 74px - 54px)" }}
+        } float-left w-full lg:w-80 divide-y-0 divide-gray-100 dark:divide-gray-600 overflow-y-auto`}
       >
         <h1 className="lg:hidden text-lg leading-7 font-medium text-gray-900 dark:text-gray-200 px-4 sm:px-6 lg:px-8 py-4 border-b lg:border-b-0 border-gray-100 dark:border-gray-600">
           Invitations
@@ -132,7 +135,7 @@ const InvitationsPage: BlitzPage = () => {
         refetchFn={refetch}
       />
       <main className="flex relative">
-        <Invitations />
+        <Invitations currentWorkspace={currentWorkspace} />
       </main>
     </>
   )


### PR DESCRIPTION
This PR continues the work from #250 - now for `/invitations`.

![Screenshot 2022-01-19 at 23 23 32](https://user-images.githubusercontent.com/2946344/150225749-0b641d4a-3a6c-466d-ad4e-1f2456663d02.png)

The hard work was done in `/drafts` so this was more straightforward to implement. Definitely can use a bit more cleanup, as there's ample duplicate code right now (e.g., with respect to the reference lists). There's some work for another time.
