### PR TITLE
Add `displayColor` to module

### DIFF
--- a/app/core/components/ModuleBoxFeed.tsx
+++ b/app/core/components/ModuleBoxFeed.tsx
@@ -27,11 +27,8 @@ const ModuleBoxFeed = ({ modules, fetchNextPage, hasNextPage, isFetchingNextPage
                     <>
                       <Link href={Routes.ModulePage({ suffix: module.suffix })}>
                         <a
-                          className={`flex flex-col module ${
-                            i % 2 === 0
-                              ? "bg-indigo-600 dark:bg-indigo-600"
-                              : "bg-purple-600 dark:bg-indigo-50"
-                          } cursor-pointer p-4 text-white`}
+                          className="flex flex-col module cursor-pointer p-4 text-white"
+                          style={{ backgroundColor: module.displayColor }}
                         >
                           <h2 className="text-base font-normal leading-5 flex-grow mb-2">
                             {module.title}

--- a/app/modules/components/MetadataEdit.tsx
+++ b/app/modules/components/MetadataEdit.tsx
@@ -33,6 +33,7 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
       title: module.title,
       description: module.description,
       license: module.license?.id.toString(),
+      displayColor: module.displayColor,
     },
     validate: validateZodSchema(
       z.object({
@@ -40,6 +41,7 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
         title: z.string().max(300),
         description: z.string(),
         license: z.string().min(1),
+        displayColor: z.string().min(1),
       })
     ),
     onSubmit: async (values) => {
@@ -49,6 +51,7 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
         title: values.title,
         description: values.description,
         licenseId: parseInt(values.license),
+        displayColor: values.displayColor,
       })
       setQueryData(updatedModule)
       setIsEditing(false)
@@ -60,6 +63,7 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
     formik.setFieldValue("title", module.title)
     formik.setFieldValue("description", module.description)
     formik.setFieldValue("license", module.license!.id.toString())
+    formik.setFieldValue("displayColor", module.displayColor)
   }, [module])
 
   return (
@@ -263,7 +267,7 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
         {/* Description section */}
         <div className="text-sm leading-4 font-normal pt-4 pl-2 pr-4 pb-2">
           <label htmlFor="description" className="sr-only block text-sm font-medium text-gray-700">
-            Description
+            Summary
           </label>
           <div className="mt-1">
             <textarea
@@ -275,6 +279,35 @@ const MetadataEdit = ({ module, addAuthors, setQueryData, setAddAuthors, setIsEd
             {formik.touched.description && formik.errors.description ? (
               <div>{formik.errors.description}</div>
             ) : null}
+          </div>
+        </div>
+        <div className="px-2 py-2">
+          <label
+            htmlFor="displayColor"
+            className="flex my-1 text-sm leading-5 font-medium text-gray-700 dark:text-gray-200"
+          >
+            Display color{" "}
+            {formik.touched.displayColor && formik.errors.displayColor
+              ? " - " + formik.errors.displayColor
+              : null}
+          </label>
+          <div className="mt-1">
+            <select
+              id="displayColor"
+              required
+              className="appearance-none block w-full px-3 py-2 border border-gray-400 bg-white dark:bg-transparent dark:border-gray-600 dark:text-gray-200 rounded-md shadow-sm placeholder-gray-400 placeholder-font-normal focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500 font-normal text-sm"
+              {...formik.getFieldProps("displayColor")}
+            >
+              <option value="#574cfa" className="text-white" style={{ backgroundColor: "#574cfa" }}>
+                Purple
+              </option>
+              <option value="#059669" className="text-white" style={{ backgroundColor: "#059669" }}>
+                Green
+              </option>
+              <option value="#db2777" className="text-white" style={{ backgroundColor: "#db2777" }}>
+                Red
+              </option>
+            </select>
           </div>
         </div>
         <div className="px-2 py-2 flex">

--- a/app/modules/components/MetadataImmutable.tsx
+++ b/app/modules/components/MetadataImmutable.tsx
@@ -36,7 +36,11 @@ const MetadataImmutable = ({ module }) => {
           </Link>
         </div>
       </div>
-      <div className="module bg-indigo-600 text-white my-4 py-2 px-4" id="moduleCurrent">
+      <div
+        className="module text-white my-4 py-2 px-4"
+        id="moduleCurrent"
+        style={{ backgroundColor: module.displayColor }}
+      >
         <div className="py-4 px-2 min-h-32">
           <p className="text-sm leading-4 font-normal ">{module.type.name}</p>
           <h1 className="text-xl leading-6 font-medium ">{module.title}</h1>

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -21,6 +21,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
       main: "",
       type: "",
       license: "",
+      displayColor: "#574cfa",
     },
     validate: validateZodSchema(
       z.object({
@@ -28,6 +29,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
         description: z.string(),
         type: z.string().min(1),
         license: z.string().min(1),
+        displayColor: z.string().min(1),
       })
     ),
     onSubmit: async (values) => {
@@ -38,6 +40,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
           typeId: parseInt(values.type),
           licenseId: parseInt(values.license),
           authors: [],
+          displayColor: values.displayColor,
         })
         refetchFn()
         setCreateOpen(false)
@@ -54,6 +57,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
     formik.setFieldValue("main", "")
     formik.setFieldValue("type", "")
     formik.setFieldValue("license", "")
+    formik.setFieldValue("displayColor", "#574cfa")
   }
 
   return (
@@ -106,13 +110,11 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                         </div>
                       </div>
                       <div className="mt-6 px-4 sm:px-6 text-sm leading-5 font-normal border-b border-gray-500 dark:border-gray-500 pb-4 dark:text-white">
-                        Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Phasellus
-                        hendrerit. Pellentesque aliquet nibh nec urna. In nisi neque, aliquet vel,
-                        dapibus id, mattis vel, nisi.
+                        What are you working on right now? Anything you create here, you can change
+                        before publishing.
                       </div>
-                      <div className="mt-6 relative flex-1 px-4 sm:px-6">
+                      <div className="relative flex-1 px-4 sm:px-6">
                         {/* Replace with your content */}
-
                         <div className="my-4">
                           <label
                             htmlFor="title"
@@ -138,7 +140,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                             htmlFor="description"
                             className="my-1 block text-sm leading-5 font-medium text-gray-700 dark:text-gray-200"
                           >
-                            Description{" "}
+                            Summary{" "}
                             {formik.touched.description && formik.errors.description
                               ? " - " + formik.errors.description
                               : null}
@@ -162,6 +164,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                             {formik.touched.type && formik.errors.type
                               ? " - " + formik.errors.type
                               : null}
+                            <p className="text-xs">Missing something? Let us know in the chat!</p>
                           </label>
                           <div className="mt-1">
                             <select
@@ -208,6 +211,47 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                                   </option>
                                 </>
                               ))}
+                            </select>
+                          </div>
+                        </div>
+                        <div className="my-4">
+                          <label
+                            htmlFor="displayColor"
+                            className="flex my-1 text-sm leading-5 font-medium text-gray-700 dark:text-gray-200"
+                          >
+                            Display color{" "}
+                            {formik.touched.displayColor && formik.errors.displayColor
+                              ? " - " + formik.errors.displayColor
+                              : null}
+                          </label>
+                          <div className="mt-1">
+                            <select
+                              id="displayColor"
+                              required
+                              className="appearance-none block w-full px-3 py-2 border border-gray-400 bg-white dark:bg-transparent dark:border-gray-600 dark:text-gray-200 rounded-md shadow-sm placeholder-gray-400 placeholder-font-normal focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500 font-normal text-sm"
+                              {...formik.getFieldProps("displayColor")}
+                            >
+                              <option
+                                value="#574cfa"
+                                className="text-white"
+                                style={{ backgroundColor: "#574cfa" }}
+                              >
+                                Purple
+                              </option>
+                              <option
+                                value="#059669"
+                                className="text-white"
+                                style={{ backgroundColor: "#059669" }}
+                              >
+                                Green
+                              </option>
+                              <option
+                                value="#db2777"
+                                className="text-white"
+                                style={{ backgroundColor: "#db2777" }}
+                              >
+                                Red
+                              </option>
                             </select>
                           </div>
                         </div>

--- a/app/modules/mutations/createModule.ts
+++ b/app/modules/mutations/createModule.ts
@@ -4,7 +4,7 @@ import generateSuffix from "./generateSuffix"
 
 export default resolver.pipe(
   resolver.authorize(),
-  async ({ title, description, typeId, licenseId, authors }, ctx) => {
+  async ({ title, description, typeId, licenseId, authors, displayColor }, ctx) => {
     const authorInvitations = authors.map((author) => {
       return {
         workspaceId: author,
@@ -22,6 +22,7 @@ export default resolver.pipe(
       data: {
         prefix: process.env.DOI_PREFIX,
         suffix: await generateSuffix(undefined),
+        displayColor,
         title,
         description,
         type: {

--- a/app/modules/mutations/editModuleScreen.ts
+++ b/app/modules/mutations/editModuleScreen.ts
@@ -3,7 +3,7 @@ import db from "db"
 
 export default resolver.pipe(
   resolver.authorize(),
-  async ({ id, typeId, title, description, licenseId }) => {
+  async ({ id, typeId, title, description, licenseId, displayColor }) => {
     const module = await db.module.update({
       where: { id },
       data: {
@@ -14,6 +14,7 @@ export default resolver.pipe(
         },
         title,
         description,
+        displayColor,
         license: {
           connect: {
             id: licenseId,

--- a/db/migrations/20220125095733_add_module_color/migration.sql
+++ b/db/migrations/20220125095733_add_module_color/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Module" ADD COLUMN     "displayColor" TEXT NOT NULL DEFAULT E'#574cfa';

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -16,6 +16,7 @@ model Module {
   id             Int       @id @default(autoincrement())
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
+  displayColor   String    @default("#574cfa")
   published      Boolean   @default(false)
   publishedAt    DateTime?
   publishedWhere String?


### PR DESCRIPTION
This PR adds a color selection of three primary ResearchEquals colors for modules.

This helps create a bit more personalisation as suggested originally by @nsunami 😊 