### PR TITLE
Add OpenGraph images

### DIFF
--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -214,6 +214,18 @@ const HandlePage = ({ workspace, expire, signature }) => {
         <>
           <meta property="og:title" content={workspace.firstName || workspace.handle} />
           {workspace.bio ? <meta property="og:description" content={workspace.bio} /> : ""}
+          <meta
+            property="og:image"
+            content={`https://og-images.herokuapp.com/api/workspace?title=${
+              workspace.firstName || ""
+            } ${workspace.lastName || ""}&avatar=${workspace.avatar}&handle=${
+              workspace.handle
+            }&orcid=${workspace.orcid || ""}`}
+          />
+          <meta
+            property="og:image:alt"
+            content={`Social media sharing image of the profile for ${workspace.handle}, including the avatar, name, handle, and ORCID.`}
+          />
         </>
       }
     >

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -234,6 +234,28 @@ const HandlePage = ({ workspace, expire, signature }) => {
             property="og:image:alt"
             content={`Social media sharing image of the profile for ${workspace.handle}, including the avatar, name, handle, and ORCID.`}
           />
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta property="twitter:domain" content="researchequals.com" />
+          <meta property="twitter:url" content={`https://researchequals.com/${workspace.handle}`} />
+          <meta
+            name="twitter:title"
+            content={
+              workspace.firstName && workspace.lastName
+                ? `${workspace.firstName} ${workspace.lastName}`
+                : workspace.handle
+            }
+          />
+          {workspace.bio ? <meta name="twitter:description" content={workspace.bio} /> : ""}
+          <meta
+            name="twitter:image"
+            content={`http://og-images.herokuapp.com/api/workspace?title=${
+              workspace.firstName && workspace.lastName
+                ? encodeURIComponent(workspace.firstName + " " + workspace.lastName)
+                : ""
+            }&avatar=${encodeURIComponent(workspace.avatar)}&handle=${workspace.handle}&orcid=${
+              workspace.orcid
+            }`}
+          />
         </>
       }
     >

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -216,7 +216,15 @@ const HandlePage = ({ workspace, expire, signature }) => {
           {workspace.bio ? <meta property="og:description" content={workspace.bio} /> : ""}
           <meta
             property="og:image"
-            content={`https://og-images.herokuapp.com/api/workspace?title=${
+            content={`http://og-images.herokuapp.com/api/workspace?title=${
+              encodeURIComponent(workspace.firstName) || ""
+            } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
+              workspace.avatar
+            )}&handle=${encodeURIComponent(workspace.handle)}&orcid=${workspace.orcid || ""}`}
+          />
+          <meta
+            property="og:image:secure_url"
+            content={`http://og-images.herokuapp.com/api/workspace?title=${
               encodeURIComponent(workspace.firstName) || ""
             } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
               workspace.avatar

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -249,12 +249,10 @@ const HandlePage = ({ workspace, expire, signature }) => {
           <meta
             name="twitter:image"
             content={`http://og-images.herokuapp.com/api/workspace?title=${
-              workspace.firstName && workspace.lastName
-                ? encodeURIComponent(workspace.firstName + " " + workspace.lastName)
-                : ""
-            }&avatar=${encodeURIComponent(workspace.avatar)}&handle=${workspace.handle}&orcid=${
-              workspace.orcid
-            }`}
+              encodeURIComponent(workspace.firstName) || ""
+            } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
+              workspace.avatar
+            )}&handle=${encodeURIComponent(workspace.handle)}&orcid=${workspace.orcid || ""}`}
           />
         </>
       }

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -217,10 +217,10 @@ const HandlePage = ({ workspace, expire, signature }) => {
           <meta
             property="og:image"
             content={`https://og-images.herokuapp.com/api/workspace?title=${
-              workspace.firstName || ""
-            } ${workspace.lastName || ""}&avatar=${workspace.avatar}&handle=${
-              workspace.handle
-            }&orcid=${workspace.orcid || ""}`}
+              encodeURIComponent(workspace.firstName) || ""
+            } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
+              workspace.avatar
+            )}&handle=${encodeURIComponent(workspace.handle)}&orcid=${workspace.orcid || ""}`}
           />
           <meta
             property="og:image:alt"

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -345,6 +345,8 @@ const ModulePage = ({ module }) => {
   const mainFile = module!.main as Prisma.JsonObject
   const supportingRaw = module!.supporting as Prisma.JsonObject
 
+  const authorsOG = module.authors.map((author) => author.workspace.avatar)
+
   return (
     <Layout
       title={`R= ${module.title}`}
@@ -367,6 +369,20 @@ const ModulePage = ({ module }) => {
           ) : (
             <meta name="tdm-reservation" content="0" />
           )}
+          <meta
+            property="og:image"
+            content={`https://og-images.herokuapp.com/api/module?title=${module.title}&type=${
+              module.type.name
+            }&doi=${module.prefix}/${module.suffix}&publishedAt=${module.publishedAt
+              .toISOString()
+              .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
+              module.license.name
+            }`}
+          />
+          <meta
+            property="og:image:alt"
+            content={`Social media sharing image of the research module titled ${module.title}. It includes the type of module, ${module.type.name}, the DOI, ${module.prefix}/${module.suffix}, the license, ${module.license.name}, and a set of avatars for the ${module.authors.length} authors.`}
+          />
         </>
       }
     >

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -397,6 +397,26 @@ const ModulePage = ({ module }) => {
             property="og:image:alt"
             content={`Social media sharing image of the research module titled ${module.title}. It includes the type of module, ${module.type.name}, the DOI, ${module.prefix}/${module.suffix}, the license, ${module.license.name}, and a set of avatars for the ${module.authors.length} authors.`}
           />
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta property="twitter:domain" content="researchequals.com" />
+          <meta
+            property="twitter:url"
+            content={`https://doi.org/${module.prefix}/${module.suffix}`}
+          />
+          <meta name="twitter:title" content={module.title} />
+          <meta name="twitter:description" content={module.description} />
+          <meta
+            name="twitter:image"
+            content={`http://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
+              module.title
+            )}&type=${module.type.name}&doi=${module.prefix}/${
+              module.suffix
+            }&publishedAt=${module.publishedAt
+              .toISOString()
+              .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
+              module.license.name
+            }`}
+          />
         </>
       }
     >

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -371,7 +371,19 @@ const ModulePage = ({ module }) => {
           )}
           <meta
             property="og:image"
-            content={`https://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
+            content={`http://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
+              module.title
+            )}&type=${module.type.name}&doi=${module.prefix}/${
+              module.suffix
+            }&publishedAt=${module.publishedAt
+              .toISOString()
+              .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
+              module.license.name
+            }`}
+          />
+          <meta
+            property="og:image:secure_url"
+            content={`http://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
               module.title
             )}&type=${module.type.name}&doi=${module.prefix}/${
               module.suffix

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -371,9 +371,11 @@ const ModulePage = ({ module }) => {
           )}
           <meta
             property="og:image"
-            content={`https://og-images.herokuapp.com/api/module?title=${module.title}&type=${
-              module.type.name
-            }&doi=${module.prefix}/${module.suffix}&publishedAt=${module.publishedAt
+            content={`https://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
+              module.title
+            )}&type=${module.type.name}&doi=${module.prefix}/${
+              module.suffix
+            }&publishedAt=${module.publishedAt
               .toISOString()
               .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
               module.license.name


### PR DESCRIPTION
This PR adds the OpenGraph images to the workspaces and published modules 🙌 

Here are some example images from [`og-images`](https://github.com/libscie/og-images).

## Workspace 

![](https://og-images.herokuapp.com/api/workspace?title=test&avatar=https://avatars.githubusercontent.com/u/2946344?v=4&handle=chartgerink&orcid=1234-1234-1234-1234)

## Published module

![](https://og-images.herokuapp.com/api/module?title=Hic%20consectetur%20consectetur%20quis%20ab%20quia.&type=Plan&doi=10.53962/sxqk-njgv&publishedAt=2021-07-22&avatars=https%3A%2F%2Fucarecdn.com%2F77fbcf7c-0f01-4e7b-85c7-884b61e6dd6e%2F-%2Fcrop%2F158x158%2F191%2C167%2F-%2Fpreview%2F%3Bhttps%3A%2F%2Feu.ui-avatars.com%2Fapi%2F%3Frounded%3Dtrue%26background%3D3257d%26name%3Dchartgerink%3Bhttp%3A%2F%2Fplaceimg.com%2F640%2F480%2Fabstract%3Bhttp%3A%2F%2Fplaceimg.com%2F640%2F480%2Fabstract%3Bhttp%3A%2F%2Fplaceimg.com%2F640%2F480%2Fabstract%3Bhttp%3A%2F%2Fplaceimg.com%2F640%2F480%2Fabstract%3Bhttp%3A%2F%2Fplaceimg.com%2F640%2F480%2Fabstract&license=CC0%20Public%20Domain%20Dedication)