### PR TITLE
Add DOI_PREFIX condition to query

### DIFF
--- a/app/core/queries/getBrowseGraphData.ts
+++ b/app/core/queries/getBrowseGraphData.ts
@@ -11,6 +11,7 @@ export default async function getSignature() {
   const modules = await db.module.findMany({
     where: {
       published: true,
+      prefix: process.env.DOI_PREFIX,
     },
     orderBy: [
       {


### PR DESCRIPTION
This PR adds the DOI_PREFIX environment variable to the graph data query, in order to exclude any references that may have been added to the database.

Note that this works because the DOI_PREFIX isn't being used to publish anything else at the moment. In case that would happen, this would no longer be specific enough (but we control that so all's good).﻿

Fixes #300.
