### PR TITLE
Add linked data JSON to headChildren

### DIFF
--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -1,8 +1,8 @@
 import { Prisma } from "prisma"
 import { Link, NotFoundError, Routes, useMutation, useQuery, useRouter, useSession } from "blitz"
-import { AddAlt32, Undo32, NextFilled32, PreviousFilled32 } from "@carbon/icons-react"
+import { AddAlt32, NextFilled32, PreviousFilled32 } from "@carbon/icons-react"
 import Xarrows from "react-xarrows"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import Layout from "../../core/layouts/Layout"
 import db from "db"
@@ -348,6 +348,16 @@ const ModulePage = ({ module }) => {
       title={`R= ${module.title}`}
       headChildren={
         <>
+          <script type="application/ld+json">{`
+           {
+             "@context": "https://schema.org",
+             "identifier": "${module.prefix}/${module.suffix}",
+             "@type": "CreativeWork",
+             "title": "${module.title}",
+             "description": "${module.description}",
+             "url": "https://doi.org/${module.prefix}/${module.suffix}"
+           }
+          `}</script>
           <meta property="og:title" content={module.title} />
           <meta property="og:url" content={`https://doi.org/${module.prefix}/${module.suffix}`} />
           {module.description ? (


### PR DESCRIPTION
This PR adds the linked data JSON to the head for published modules.

There is ample room to include more information, but here we choose to implement a first version now rather than more extensive functionality much later. We can still add layers to this as needs arise, so feel free to share those as they come up.

Fixes #294.﻿
