### PR TITLE
Add colors to search results

### DIFF
--- a/app/api/stripe_webhook.ts
+++ b/app/api/stripe_webhook.ts
@@ -174,6 +174,7 @@ const webhook = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
         name: publishedModule.title,
         description: publishedModule.description,
         publishedAt: publishedModule.publishedAt,
+        displayColor: publishedModule.displayColor,
       })
       console.log(`[STRIPE WEBHOOK]: Publication complete; type ${event.type}, id: ${event.id}.`)
 

--- a/app/core/components/SearchResultModule.tsx
+++ b/app/core/components/SearchResultModule.tsx
@@ -7,8 +7,9 @@ const SearchResultModule = ({ item }) => {
             width="32"
             height="32"
             viewBox="0 0 32 32"
-            className="stroke-current fill-current stroke-2 text-indigo-600 dark:text-indigo-600 inline-block h-full align-middle"
+            className="inline-block h-full align-middle"
             xmlns="http://www.w3.org/2000/svg"
+            style={{ fill: item.displayColor || "#574cfa" }}
           >
             <path d="M23.852 31.5H0.5V0.500011L31.5 0.500695V23.8532L23.852 31.5Z" />
           </svg>

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -77,6 +77,7 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
     name: module.title,
     description: module.description,
     publishedAt: module.publishedAt,
+    displayColor: module.displayColor,
   })
 
   return module

--- a/app/modules/mutations/publishModule.ts
+++ b/app/modules/mutations/publishModule.ts
@@ -138,6 +138,7 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     name: publishedModule.title,
     description: publishedModule.description,
     publishedAt: publishedModule.publishedAt,
+    displayColor: publishedModule.displayColor,
   })
 
   return true


### PR DESCRIPTION
This PR adds the colors to the module search results.

This change required:
1. Adding the `displayColor` to the Algolia index
2. Updating the `SearchResultModule` component

Fixes #304.
