### PR TITLE
Add `authorshipRank` sorting

### DIFF
--- a/app/api/stripe_webhook.ts
+++ b/app/api/stripe_webhook.ts
@@ -62,6 +62,9 @@ const webhook = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
           references: {
             include: {

--- a/app/authorship/mutations/acceptInvitation.ts
+++ b/app/authorship/mutations/acceptInvitation.ts
@@ -11,18 +11,6 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     },
   })
 
-  // Force all authors to reapprove for publishing
-  await db.authorship.updateMany({
-    where: {
-      module: {
-        suffix,
-      },
-    },
-    data: {
-      readyToPublish: false,
-    },
-  })
-
   const module = await db.module.findFirst({
     where: {
       suffix,

--- a/app/authorship/mutations/acceptInvitation.ts
+++ b/app/authorship/mutations/acceptInvitation.ts
@@ -42,6 +42,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -51,6 +54,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/authorship/mutations/approveAuthorship.ts
+++ b/app/authorship/mutations/approveAuthorship.ts
@@ -42,6 +42,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -51,6 +54,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/authorship/mutations/removeInvitation.ts
+++ b/app/authorship/mutations/removeInvitation.ts
@@ -49,6 +49,9 @@ export default resolver.pipe(resolver.authorize(), async ({ workspaceId, moduleI
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -58,6 +61,9 @@ export default resolver.pipe(resolver.authorize(), async ({ workspaceId, moduleI
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/authorship/mutations/updateAuthorRank.ts
+++ b/app/authorship/mutations/updateAuthorRank.ts
@@ -42,6 +42,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, rank, suffix }) 
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -51,6 +54,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, rank, suffix }) 
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -146,8 +146,8 @@ const OnboardingProfile = ({ data }) => {
               <p className="text-sm mr-2">
                 <span className=" font-bold">Add your info</span>{" "}
                 <span>
-                  Make sure people know who you are. Add your bio, pronouns, and a link to your
-                  website.
+                  Make sure people know who you are. Add your author name, bio, pronouns, and a link
+                  to your website.
                 </span>
               </p>
             </div>

--- a/app/core/components/WorkspaceSettings.tsx
+++ b/app/core/components/WorkspaceSettings.tsx
@@ -169,7 +169,7 @@ const WorkspaceSettings = ({ workspace, setIsOpen }) => {
       <form onSubmit={formik.handleSubmit}>
         <div className="my-4 text-gray-900 dark:text-gray-200 px-2">
           <label htmlFor="firstName" className="my-1 block text-sm font-medium">
-            First Name{" "}
+            Author First Name{" "}
             {formik.touched.firstName && formik.errors.firstName
               ? " - " + formik.errors.firstName
               : null}
@@ -186,7 +186,7 @@ const WorkspaceSettings = ({ workspace, setIsOpen }) => {
         </div>
         <div className="my-4 text-gray-900 dark:text-gray-200 px-2">
           <label htmlFor="lastName" className="my-1 block text-sm font-medium">
-            Last Name{" "}
+            Author Last Name{" "}
             {formik.touched.lastName && formik.errors.lastName
               ? " - " + formik.errors.lastName
               : null}

--- a/app/core/queries/getBrowseData.ts
+++ b/app/core/queries/getBrowseData.ts
@@ -33,6 +33,9 @@ export default async function getBrowseData({ skip = 0, take = 100 }) {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       }),

--- a/app/core/queries/getDrafts.ts
+++ b/app/core/queries/getDrafts.ts
@@ -22,6 +22,9 @@ export default async function getSignature({ session }) {
         include: {
           workspace: true,
         },
+        orderBy: {
+          authorshipRank: "asc",
+        },
       },
     },
   })

--- a/app/modules/components/AuthorAvatarsNew.tsx
+++ b/app/modules/components/AuthorAvatarsNew.tsx
@@ -27,7 +27,7 @@ const AuthorAvatarsNew = ({ authors, size, toDisplay }) => {
             <div>
               <span className="inline-block h-full align-middle"> </span>
               <span className="inline-flex align-middle items-center px-3 py-0.5 rounded-full text-xs leading-4 font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 ring-1 ring-gray-300 dark:ring-gray-600 max-h-8 shadow-sm dark:shadow-none">
-                + {authors.length}
+                + {authors.length - toDisplay}
               </span>
             </div>
           </>

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -105,11 +105,6 @@ const ModuleEdit = ({
     (author) => author.workspace?.handle === workspace.handle
   )
 
-  console.log(
-    moduleEdit?.authors.find((author) => author.workspace?.handle === workspace.handle)
-      ?.readyToPublish
-  )
-
   return (
     <div className="p-5 max-w-4xl mx-auto overflow-y-auto text-base">
       {/* Publish module */}
@@ -135,11 +130,14 @@ const ModuleEdit = ({
                 {moduleEdit?.authors.filter(
                   (author) => !author.workspace!.firstName || !author.workspace!.lastName
                 ).length! > 0 ? (
-                  <li>All authors must add their first and last name</li>
+                  <li>All authors must add their author name</li>
                 ) : (
                   ""
                 )}
-                {!ownAuthorship?.readyToPublish && moduleEdit!.authors!.length > 1 ? (
+                {!ownAuthorship?.readyToPublish &&
+                ownAuthorship?.workspace?.firstName &&
+                ownAuthorship?.workspace?.lastName &&
+                moduleEdit!.authors!.length > 1 ? (
                   <li>
                     <button
                       className="text-xs my-1 leading-4 font-medium text-orange-500 dark:text-orange-200 rounded border border-orange-300 dark:border-orange-200 bg-orange shadow-sm dark:bg-orange-800 px-4 py-2 hover:bg-orange-100 dark:hover:border-orange-200 dark:hover:bg-orange-700"
@@ -164,7 +162,7 @@ const ModuleEdit = ({
                     </button>
                   </li>
                 ) : (
-                  ""
+                  <li>You must add your author name</li>
                 )}
                 {moduleEdit!.authors.length > 1 ? (
                   <li>Your co-authors must approve to publish</li>

--- a/app/modules/mutations/addMain.ts
+++ b/app/modules/mutations/addMain.ts
@@ -47,6 +47,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, json }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -56,6 +59,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, json }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/addParent.ts
+++ b/app/modules/mutations/addParent.ts
@@ -36,6 +36,9 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -45,6 +48,9 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/addReference.ts
+++ b/app/modules/mutations/addReference.ts
@@ -36,6 +36,9 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -45,6 +48,9 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, connectId
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/addSupporting.ts
+++ b/app/modules/mutations/addSupporting.ts
@@ -53,6 +53,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -62,6 +65,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/changeAbstract.ts
+++ b/app/modules/mutations/changeAbstract.ts
@@ -46,6 +46,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, description }) =
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -55,6 +58,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, description }) =
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/changeTitle.ts
+++ b/app/modules/mutations/changeTitle.ts
@@ -46,6 +46,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, title }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -55,6 +58,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, title }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/deleteMainFile.ts
+++ b/app/modules/mutations/deleteMainFile.ts
@@ -58,6 +58,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -67,6 +70,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/deleteParent.ts
+++ b/app/modules/mutations/deleteParent.ts
@@ -36,6 +36,9 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnec
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -45,6 +48,9 @@ export default resolver.pipe(resolver.authorize(), async ({ currentId, disconnec
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/deleteSupportingFile.ts
+++ b/app/modules/mutations/deleteSupportingFile.ts
@@ -52,6 +52,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -61,6 +64,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, uuid }) => {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/modules/mutations/publishModule.ts
+++ b/app/modules/mutations/publishModule.ts
@@ -33,6 +33,9 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },

--- a/app/modules/queries/useCurrentModule.ts
+++ b/app/modules/queries/useCurrentModule.ts
@@ -33,6 +33,9 @@ export default async function getCurrentWorkspace({ suffix }) {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -42,6 +45,9 @@ export default async function getCurrentWorkspace({ suffix }) {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -60,6 +60,9 @@ export async function getServerSideProps(context) {
             include: {
               workspace: true,
             },
+            orderBy: {
+              authorshipRank: "asc",
+            },
           },
         },
       },
@@ -72,6 +75,9 @@ export async function getServerSideProps(context) {
           authors: {
             include: {
               workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
             },
           },
         },

--- a/app/workspaces/queries/getInvitedModules.ts
+++ b/app/workspaces/queries/getInvitedModules.ts
@@ -22,6 +22,9 @@ export default async function getInvitedModules({ session }) {
         include: {
           workspace: true,
         },
+        orderBy: {
+          authorshipRank: "asc",
+        },
       },
     },
   })


### PR DESCRIPTION
This PR adds `authorshipRank` sorting to the many places where that's relevant. Fixes #299.

Also adds a few minor changes regarding copy for name, and a tweak to when somebody is allowed to approve a module for publication. This was the result of a DOI being minted for an author who hadn't filled out their name, resulting in a `null` in the XML for that.