### PR TITLE
Prevent author approve publishing when no author names

### DIFF
--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -29,6 +29,7 @@ import { useMediaPredicate } from "react-media-hook"
 import addParent from "../mutations/addParent"
 import ManageParents from "./ManageParents"
 import approveAuthorship from "app/authorship/mutations/approveAuthorship"
+import SettingsModal from "../../core/modals/settings"
 
 const searchClient = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_SEARCH_KEY!)
 
@@ -127,10 +128,16 @@ const ModuleEdit = ({
               </h3>
               <ol className="list-inside list-decimal text-sm">
                 {moduleEdit!.main!["name"] ? "" : <li>Upload a main file</li>}
-                {moduleEdit?.authors.filter(
-                  (author) => !author.workspace!.firstName || !author.workspace!.lastName
-                ).length! > 0 ? (
-                  <li>All authors must add their author name</li>
+                {!ownAuthorship?.workspace?.firstName || !ownAuthorship?.workspace?.lastName ? (
+                  <li>
+                    You must add your author names in{" "}
+                    <SettingsModal
+                      styling="whitespace-nowrap font-medium hover:text-blue-600 underline"
+                      button={<>settings</>}
+                      user={user}
+                      workspace={workspace}
+                    />
+                  </li>
                 ) : (
                   ""
                 )}
@@ -162,7 +169,7 @@ const ModuleEdit = ({
                     </button>
                   </li>
                 ) : (
-                  <li>You must add your author name</li>
+                  ""
                 )}
                 {moduleEdit!.authors.length > 1 ? (
                   <li>Your co-authors must approve to publish</li>


### PR DESCRIPTION
This PR adds some further improvements to the publish instructions, as the ones resulting from #317 introduced some confusing language (i.e., prompting for author names after approving to publish).

Also removes the prompt for other authors to fill out their author names and focuses more on the user in that regard.