### PR TITLE
Match any DOI in a string and use it as a query

### DIFF
--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -269,15 +269,21 @@ const ModuleEdit = ({
                         return <SearchResultModule item={item} />
                       },
                       noResults() {
+                        const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                        const matchedDoi = matchedQuery.slice(-1)
                         return (
                           <>
                             {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                            {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
+                            {matchedDoi ? (
                               <>
                                 <button
                                   className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                   onClick={async () => {
-                                    toast.promise(createReferenceMutation({ doi: query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) }), {
+                                    toast.promise(
+                                      createReferenceMutation({
+                                        doi: matchedDoi,
+                                      }),
+                                      {
                                       loading: "Searching...",
                                       success: (data) => {
                                         toast.promise(
@@ -299,10 +305,11 @@ const ModuleEdit = ({
                                         return "Record added to database"
                                       },
                                       error: "Could not add record.",
-                                    })
+                                      }
+                                    )
                                   }}
                                 >
-                                  Click here to add {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)} to ResearchEquals database
+                                  Click here to add {matchedDoi} to ResearchEquals database
                                 </button>
                               </>
                             ) : (
@@ -479,15 +486,17 @@ const ModuleEdit = ({
                       )
                     },
                     noResults() {
+                      const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                      const matchedDoi = matchedQuery.slice(-1)
                       return (
                         <>
                           {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                          {query.match(/^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
+                          {matchedDoi ? (
                             <>
                               <button
                                 className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                 onClick={async () => {
-                                  toast.promise(createReferenceMutation({ doi: query }), {
+                                  toast.promise(createReferenceMutation({ doi: matchedDoi }), {
                                     loading: "Searching...",
                                     success: (data) => {
                                       toast.promise(
@@ -512,7 +521,7 @@ const ModuleEdit = ({
                                   })
                                 }}
                               >
-                                Click here to add {query} to ResearchEquals database
+                                Click here to add {matchedDoi} to ResearchEquals database
                               </button>
                             </>
                           ) : (

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -272,12 +272,12 @@ const ModuleEdit = ({
                         return (
                           <>
                             {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                            {query.match(/^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
+                            {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
                               <>
                                 <button
                                   className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                   onClick={async () => {
-                                    toast.promise(createReferenceMutation({ doi: query }), {
+                                    toast.promise(createReferenceMutation({ doi: query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) }), {
                                       loading: "Searching...",
                                       success: (data) => {
                                         toast.promise(
@@ -302,7 +302,7 @@ const ModuleEdit = ({
                                     })
                                   }}
                                 >
-                                  Click here to add {query} to ResearchEquals database
+                                  Click here to add {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)} to ResearchEquals database
                                 </button>
                               </>
                             ) : (

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -269,7 +269,9 @@ const ModuleEdit = ({
                         return <SearchResultModule item={item} />
                       },
                       noResults() {
-                        const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                        const matchedQuery = query.match(
+                          /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
+                        )
                         const matchedDoi = matchedQuery.slice(-1)
                         return (
                           <>
@@ -486,7 +488,9 @@ const ModuleEdit = ({
                       )
                     },
                     noResults() {
-                      const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                      const matchedQuery = query.match(
+                        /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
+                      )
                       const matchedDoi = matchedQuery.slice(-1)
                       return (
                         <>


### PR DESCRIPTION
This PR expands the matching of a DOI string so that any string containing a DOI will be matched and be added as a reference. (fix #325)

I was not able to run this on local so the changes are not verified. (sorry!) But hope it captures the idea.