### PR TITLE
Add admin dashboard

### DIFF
--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -17,6 +17,7 @@ export default resolver.pipe(
     // This prevents people registering handles that are also page routes
     const forbiddenHandles = [
       "404",
+      "admin",
       "browse",
       "coc",
       "dashboard",

--- a/app/core/queries/getAdminInfo.ts
+++ b/app/core/queries/getAdminInfo.ts
@@ -1,0 +1,10 @@
+import { resolver, Ctx } from "blitz"
+import db from "db"
+import * as z from "zod"
+
+export default resolver.pipe(resolver.authorize(), async (input, ctx: Ctx) => {
+  // Only authorize the SUPERADMIN role for this
+  ctx.session.$authorize("SUPERADMIN")
+
+  return true
+})

--- a/app/core/queries/getAdminInfo.ts
+++ b/app/core/queries/getAdminInfo.ts
@@ -6,5 +6,18 @@ export default resolver.pipe(resolver.authorize(), async (input, ctx: Ctx) => {
   // Only authorize the SUPERADMIN role for this
   ctx.session.$authorize("SUPERADMIN")
 
-  return true
+  const modules = await db.module.findMany({
+    where: {
+      published: true,
+    },
+    include: {
+      type: true,
+      license: true,
+    },
+    orderBy: {
+      publishedAt: "desc",
+    },
+  })
+
+  return modules
 })

--- a/app/modules/mutations/updateCrossRef.ts
+++ b/app/modules/mutations/updateCrossRef.ts
@@ -1,0 +1,115 @@
+import { NotFoundError, resolver } from "blitz"
+import db from "db"
+import moment from "moment"
+import axios from "axios"
+import convert from "xml-js"
+import FormData from "form-data"
+import { Readable } from "stream"
+import generateCrossRefObject from "../../core/crossref/generateCrossRefObject"
+
+export default resolver.pipe(resolver.authorize(), async ({ id }) => {
+  const datetime = Date.now()
+
+  // TODO: Can be simplified along with stripe_webhook.ts and publishModule.ts
+  const module = await db.module.findFirst({
+    where: {
+      id,
+    },
+    include: {
+      license: true,
+      type: true,
+      authors: {
+        include: {
+          workspace: true,
+        },
+      },
+      references: {
+        include: {
+          authors: {
+            include: {
+              workspace: true,
+            },
+            orderBy: {
+              authorshipRank: "asc",
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!module!.main) throw Error("Main file is empty")
+
+  const x = generateCrossRefObject({
+    schema: "5.3.1",
+    type: module!.type!.name,
+    title: module!.title,
+    authors: module!.authors!.map((author) => {
+      const js = {
+        firstName: author.workspace?.firstName,
+        lastName: author.workspace?.lastName,
+        orcid: author.workspace?.orcid,
+      }
+
+      return js
+    }),
+    citations:
+      module!.references.length === 0
+        ? []
+        : module?.references.map((reference) => {
+            const refJs = {
+              publishedWhere: reference.publishedWhere,
+              authors:
+                reference.publishedWhere === "ResearchEquals"
+                  ? reference.authors.map((author) => {
+                      const authJs = {
+                        name: `${author.workspace?.firstName} ${author.workspace?.lastName}`,
+                        orcid: `https://orcid.org/${author!.workspace!.orcid}`,
+                      }
+
+                      return authJs
+                    })
+                  : reference!.authorsRaw!["object"].map((author) => {
+                      const authJs = {
+                        name:
+                          author.given && author.family
+                            ? `${author.given} ${author.family}`
+                            : `${author.name}`,
+                      }
+
+                      return authJs
+                    }),
+              publishedAt: reference.publishedAt,
+              prefix: reference.prefix,
+              suffix: reference.suffix,
+              isbn: reference.isbn,
+              title: reference.title,
+            }
+            return refJs
+          }),
+    abstractText: module!.description,
+    license_url: module!.license!.url,
+    doi: `${module!.prefix}/${module!.suffix}`,
+    resolve_url: `${process.env.APP_ORIGIN}/modules/${module!.suffix}`,
+  })
+
+  const xmlData = convert.js2xml(x)
+  const xmlStream = new Readable()
+  xmlStream._read = () => {}
+  xmlStream.push(xmlData)
+  xmlStream.push(null)
+
+  const form = new FormData()
+  form.append("operation", "doMDUpload")
+  form.append("login_id", process.env.CROSSREF_LOGIN_ID)
+  form.append("login_passwd", process.env.CROSSREF_LOGIN_PASSWD)
+  form.append("fname", xmlStream, {
+    filename: `${module!.suffix}.xml`,
+    contentType: "text/xml",
+    knownLength: (xmlStream as any)._readableState!.length,
+  })
+
+  await axios.post(process.env.CROSSREF_URL!, form, { headers: form.getHeaders() })
+
+  return true
+})

--- a/app/pages/admin.tsx
+++ b/app/pages/admin.tsx
@@ -1,0 +1,45 @@
+import { BlitzPage, useQuery, useRouter, useSession } from "blitz"
+import Layout from "app/core/layouts/Layout"
+
+import Navbar from "../core/components/Navbar"
+import LayoutLoader from "../core/components/LayoutLoader"
+import { useCurrentUser } from "app/core/hooks/useCurrentUser"
+import { useCurrentWorkspace } from "app/core/hooks/useCurrentWorkspace"
+import getDrafts from "app/core/queries/getDrafts"
+import getInvitedModules from "app/workspaces/queries/getInvitedModules"
+import getAdminInfo from "../core/queries/getAdminInfo"
+
+const Admin: BlitzPage = () => {
+  const currentUser = useCurrentUser()
+  const session = useSession()
+  const currentWorkspace = useCurrentWorkspace()
+  const router = useRouter()
+  const [drafts, { refetch }] = useQuery(getDrafts, { session })
+  const [invitations] = useQuery(getInvitedModules, { session })
+  const [adminInfo] = useQuery(getAdminInfo, null)
+
+  return (
+    <>
+      <Navbar
+        currentUser={currentUser}
+        session={session}
+        currentWorkspace={currentWorkspace}
+        router={router}
+        drafts={drafts}
+        invitations={invitations}
+        refetchFn={refetch}
+      />
+      <main className="bg-white dark:bg-gray-900 lg:relative"></main>
+    </>
+  )
+}
+
+Admin.authenticate = true
+Admin.suppressFirstRenderFlicker = true
+Admin.getLayout = (page) => (
+  <Layout title="R= Admin">
+    <LayoutLoader>{page}</LayoutLoader>
+  </Layout>
+)
+
+export default Admin

--- a/app/pages/admin.tsx
+++ b/app/pages/admin.tsx
@@ -1,4 +1,4 @@
-import { BlitzPage, useQuery, useRouter, useSession } from "blitz"
+import { BlitzPage, useQuery, useRouter, useSession, Link, useMutation } from "blitz"
 import Layout from "app/core/layouts/Layout"
 
 import Navbar from "../core/components/Navbar"
@@ -8,6 +8,8 @@ import { useCurrentWorkspace } from "app/core/hooks/useCurrentWorkspace"
 import getDrafts from "app/core/queries/getDrafts"
 import getInvitedModules from "app/workspaces/queries/getInvitedModules"
 import getAdminInfo from "../core/queries/getAdminInfo"
+import toast from "react-hot-toast"
+import updateCrossRef from "../modules/mutations/updateCrossRef"
 
 const Admin: BlitzPage = () => {
   const currentUser = useCurrentUser()
@@ -17,6 +19,7 @@ const Admin: BlitzPage = () => {
   const [drafts, { refetch }] = useQuery(getDrafts, { session })
   const [invitations] = useQuery(getInvitedModules, { session })
   const [adminInfo] = useQuery(getAdminInfo, null)
+  const [updateCrossRefMutation] = useMutation(updateCrossRef)
 
   return (
     <>
@@ -29,7 +32,95 @@ const Admin: BlitzPage = () => {
         invitations={invitations}
         refetchFn={refetch}
       />
-      <main className="bg-white dark:bg-gray-900 lg:relative"></main>
+      <main className="my-8 bg-white dark:bg-gray-900 lg:relative">
+        <div className="flex flex-col">
+          <div className="">
+            <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+              <div className="overflow-hidden border-b border-gray-200 shadow sm:rounded-lg">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50 dark:bg-gray-800">
+                    <tr>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white"
+                      >
+                        DOI
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white"
+                      >
+                        Name
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white"
+                      >
+                        Type
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white"
+                      >
+                        License
+                      </th>
+                      <th scope="col" className="relative px-6 py-3">
+                        <span className="sr-only">Update DOI registration</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {adminInfo.map((module, moduleIdx) => (
+                      <tr
+                        key={module.title}
+                        className={
+                          moduleIdx % 2 === 0
+                            ? "bg-white dark:bg-gray-900"
+                            : "bg-gray-50 dark:bg-gray-800"
+                        }
+                      >
+                        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900 dark:text-white ">
+                          <Link
+                            href={`https://api.crossref.org/works/${module.prefix}/${module.suffix}`}
+                          >
+                            <a
+                              target="_blank"
+                              className="underline"
+                            >{`${module.prefix}/${module.suffix}`}</a>
+                          </Link>
+                        </td>
+                        <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900 dark:text-white">
+                          {module.title}
+                        </td>
+                        <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                          {module.type.name}
+                        </td>
+                        <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                          {module.license?.name}
+                        </td>
+                        <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                          <button
+                            onClick={async () => {
+                              toast.promise(updateCrossRefMutation({ id: module.id }), {
+                                loading: "Updating...",
+                                success: "Updated metadata with CrossRef",
+                                error: "That did not work",
+                              })
+                            }}
+                            className="whitespace-nowrap rounded border-0 bg-indigo-100 px-4 py-2 text-sm font-normal leading-5 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                          >
+                            Update CrossRef
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
     </>
   )
 }


### PR DESCRIPTION
This PR adds an admin dashboard. The main goal for this was to permit manually triggering an update of CrossRef metadata for specific modules.

This dashboard is not accessible to the regular user - only to superadmins. These have to be manually assigned in the database. So anyone can try to access the route but you'll get this (and **no this is not a challenge**):

![Screenshot 2022-02-16 at 16 17 49](https://user-images.githubusercontent.com/2946344/154295634-8fb3194c-97cb-4064-9ceb-f95fbc147b34.png)

For the few who have superadmin privileges they will see something like this:

![Screenshot 2022-02-16 at 16 18 41](https://user-images.githubusercontent.com/2946344/154295799-68a76c58-0022-4822-abc1-9d8a7cb4b8d8.png)

In the future, this might also permit other operations, depending on the needs that arise. 

Fixes #323.