### PR TITLE
Add an instruction to seed the database in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ DATABASE_URL=postgres://<username>:<password>@localhost:5432/researchequals-dev
 
 To get a fully functional development environment you need to add the environment variables as listed in `.env.example`. Please note most of these services are freemium and you can sign up for a free account.
 
+You can seed your database with
+```
+blitz db seed
+```
+
 You can start your development environment with
 
 ```


### PR DESCRIPTION
This PR adds a step in the README to seed the database.

(I was trying to run the app and wondering why I'm not seeing licenses etc. Just to realize that I'm forgetting to seed the DB. 😆  Just a suggestion!)