### PR TITLE
[Cont.] Match any DOI in a string and use it as a query

### DIFF
--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -269,15 +269,21 @@ const ModuleEdit = ({
                         return <SearchResultModule item={item} />
                       },
                       noResults() {
+                        const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                        const matchedDoi = matchedQuery.slice(-1)
                         return (
                           <>
                             {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                            {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
+                            {matchedDoi ? (
                               <>
                                 <button
                                   className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                   onClick={async () => {
-                                    toast.promise(createReferenceMutation({ doi: query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) }), {
+                                    toast.promise(
+                                      createReferenceMutation({
+                                        doi: matchedDoi,
+                                      }),
+                                      {
                                       loading: "Searching...",
                                       success: (data) => {
                                         toast.promise(
@@ -299,10 +305,11 @@ const ModuleEdit = ({
                                         return "Record added to database"
                                       },
                                       error: "Could not add record.",
-                                    })
+                                      }
+                                    )
                                   }}
                                 >
-                                  Click here to add {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)} to ResearchEquals database
+                                  Click here to add {matchedDoi} to ResearchEquals database
                                 </button>
                               </>
                             ) : (
@@ -479,15 +486,17 @@ const ModuleEdit = ({
                       )
                     },
                     noResults() {
+                      const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                      const matchedDoi = matchedQuery.slice(-1)
                       return (
                         <>
                           {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                          {query.match(/^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
+                          {matchedDoi ? (
                             <>
                               <button
                                 className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                 onClick={async () => {
-                                  toast.promise(createReferenceMutation({ doi: query }), {
+                                  toast.promise(createReferenceMutation({ doi: matchedDoi }), {
                                     loading: "Searching...",
                                     success: (data) => {
                                       toast.promise(
@@ -512,7 +521,7 @@ const ModuleEdit = ({
                                   })
                                 }}
                               >
-                                Click here to add {query} to ResearchEquals database
+                                Click here to add {matchedDoi} to ResearchEquals database
                               </button>
                             </>
                           ) : (

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -269,9 +269,7 @@ const ModuleEdit = ({
                         return <SearchResultModule item={item} />
                       },
                       noResults() {
-                        const matchedQuery = query.match(
-                          /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
-                        )
+                        const matchedQuery = query.match(/10.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i)
 
                         return (
                           <>
@@ -283,7 +281,9 @@ const ModuleEdit = ({
                                   onClick={async () => {
                                     toast.promise(
                                       createReferenceMutation({
-                                        doi: matchedQuery.slice(-1),
+                                        doi: matchedQuery.slice(-1)[0].endsWith("/")
+                                          ? matchedQuery.slice(-1)[0].slice(0, -1)
+                                          : matchedQuery.slice(-1)[0],
                                       }),
                                       {
                                         loading: "Searching...",
@@ -489,9 +489,7 @@ const ModuleEdit = ({
                       )
                     },
                     noResults() {
-                      const matchedQuery = query.match(
-                        /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
-                      )
+                      const matchedQuery = query.match(/10.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i)
 
                       return (
                         <>
@@ -502,7 +500,11 @@ const ModuleEdit = ({
                                 className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                 onClick={async () => {
                                   toast.promise(
-                                    createReferenceMutation({ doi: matchedQuery.slice(-1) }),
+                                    createReferenceMutation({
+                                      doi: matchedQuery.slice(-1)[0].endsWith("/")
+                                        ? matchedQuery.slice(-1)[0].slice(0, -1)
+                                        : matchedQuery.slice(-1)[0],
+                                    }),
                                     {
                                       loading: "Searching...",
                                       success: (data) => {

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -272,46 +272,47 @@ const ModuleEdit = ({
                         const matchedQuery = query.match(
                           /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
                         )
-                        const matchedDoi = matchedQuery.slice(-1)
+
                         return (
                           <>
                             {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                            {matchedDoi ? (
+                            {matchedQuery ? (
                               <>
                                 <button
                                   className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                   onClick={async () => {
                                     toast.promise(
                                       createReferenceMutation({
-                                        doi: matchedDoi,
+                                        doi: matchedQuery.slice(-1),
                                       }),
                                       {
-                                      loading: "Searching...",
-                                      success: (data) => {
-                                        toast.promise(
-                                          addParentMutation({
-                                            currentId: module?.id,
-                                            connectId: data.id,
-                                          }),
-                                          {
-                                            loading: "Adding link...",
-                                            success: (info) => {
-                                              setQueryData(info)
+                                        loading: "Searching...",
+                                        success: (data) => {
+                                          toast.promise(
+                                            addParentMutation({
+                                              currentId: module?.id,
+                                              connectId: data.id,
+                                            }),
+                                            {
+                                              loading: "Adding link...",
+                                              success: (info) => {
+                                                setQueryData(info)
 
-                                              return `Linked to: "${data.title}"`
-                                            },
-                                            error: "Failed to add link...",
-                                          }
-                                        )
+                                                return `Linked to: "${data.title}"`
+                                              },
+                                              error: "Failed to add link...",
+                                            }
+                                          )
 
-                                        return "Record added to database"
-                                      },
-                                      error: "Could not add record.",
+                                          return "Record added to database"
+                                        },
+                                        error: "Could not add record.",
                                       }
                                     )
                                   }}
                                 >
-                                  Click here to add {matchedDoi} to ResearchEquals database
+                                  Click here to add {matchedQuery.slice(-1)} to ResearchEquals
+                                  database
                                 </button>
                               </>
                             ) : (
@@ -491,41 +492,45 @@ const ModuleEdit = ({
                       const matchedQuery = query.match(
                         /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
                       )
-                      const matchedDoi = matchedQuery.slice(-1)
+
                       return (
                         <>
                           {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                          {matchedDoi ? (
+                          {matchedQuery ? (
                             <>
                               <button
                                 className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                 onClick={async () => {
-                                  toast.promise(createReferenceMutation({ doi: matchedDoi }), {
-                                    loading: "Searching...",
-                                    success: (data) => {
-                                      toast.promise(
-                                        addReferenceMutation({
-                                          currentId: moduleEdit?.id,
-                                          connectId: data.id,
-                                        }),
-                                        {
-                                          loading: "Adding reference...",
-                                          success: (data) => {
-                                            setQueryData(data)
+                                  toast.promise(
+                                    createReferenceMutation({ doi: matchedQuery.slice(-1) }),
+                                    {
+                                      loading: "Searching...",
+                                      success: (data) => {
+                                        toast.promise(
+                                          addReferenceMutation({
+                                            currentId: moduleEdit?.id,
+                                            connectId: data.id,
+                                          }),
+                                          {
+                                            loading: "Adding reference...",
+                                            success: (data) => {
+                                              setQueryData(data)
 
-                                            return "Added reference!"
-                                          },
-                                          error: "Failed to add reference...",
-                                        }
-                                      )
+                                              return "Added reference!"
+                                            },
+                                            error: "Failed to add reference...",
+                                          }
+                                        )
 
-                                      return "Reference added to database"
-                                    },
-                                    error: "Could not add reference.",
-                                  })
+                                        return "Reference added to database"
+                                      },
+                                      error: "Could not add reference.",
+                                    }
+                                  )
                                 }}
                               >
-                                Click here to add {matchedDoi} to ResearchEquals database
+                                Click here to add {matchedQuery.slice(-1)} to ResearchEquals
+                                database
                               </button>
                             </>
                           ) : (

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -272,12 +272,12 @@ const ModuleEdit = ({
                         return (
                           <>
                             {/* https://www.crossref.org/blog/dois-and-matching-regular-expressions/ */}
-                            {query.match(/^10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
+                            {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) ? (
                               <>
                                 <button
                                   className="text-sm font-normal leading-4 text-gray-900 dark:text-gray-200"
                                   onClick={async () => {
-                                    toast.promise(createReferenceMutation({ doi: query }), {
+                                    toast.promise(createReferenceMutation({ doi: query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i) }), {
                                       loading: "Searching...",
                                       success: (data) => {
                                         toast.promise(
@@ -302,7 +302,7 @@ const ModuleEdit = ({
                                     })
                                   }}
                                 >
-                                  Click here to add {query} to ResearchEquals database
+                                  Click here to add {query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)} to ResearchEquals database
                                 </button>
                               </>
                             ) : (

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -269,7 +269,9 @@ const ModuleEdit = ({
                         return <SearchResultModule item={item} />
                       },
                       noResults() {
-                        const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                        const matchedQuery = query.match(
+                          /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
+                        )
                         const matchedDoi = matchedQuery.slice(-1)
                         return (
                           <>
@@ -486,7 +488,9 @@ const ModuleEdit = ({
                       )
                     },
                     noResults() {
-                      const matchedQuery = query.match(/10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i)
+                      const matchedQuery = query.match(
+                        /^((http)s?:\/\/)?((dx\.)?doi\.org\/)?(10.\d{4,9}\/[-._;()\/:A-Z0-9]+$)/i
+                      )
                       const matchedDoi = matchedQuery.slice(-1)
                       return (
                         <>


### PR DESCRIPTION
This PR is a continuation of #334.

- Match any DOI in a string and use it as a query
- Update the regex pattern and postprocessing
- Update the regex
- Fix nonmatch error

## Last comment in #334

@nsunami I tried testing it in the app but this doesn't work when there is **no** DOI.

When I for example use `https://oxfamilibrary.openrepository.com/handle/10546/621341` it returns the following error

![Screenshot 2022-03-02 at 11 23 42](https://user-images.githubusercontent.com/2946344/156344008-b248af26-51f3-4820-9241-6910a697a25f.png)

I updated the code as follows:

* Removed the `matchedDoi` variable
* Logic based on `matchedQuery` only
* If there is a match, use the slice command where it previously had `matchedDoi`

This only has the odd result that when the DOI is already in the database (e.g., `10.53962/0000`) that the URL cannot be added (e.g., `https://doi.org/10.53962/0000`) - the search does not filter out the already indexed items at the moment.

What do you think?
