### PR TITLE
Add file extensions to `/stats`

### DIFF
--- a/app/core/queries/getBrowseGraphData.ts
+++ b/app/core/queries/getBrowseGraphData.ts
@@ -19,8 +19,41 @@ export default async function getSignature() {
       },
     ],
     select: {
+      main: true,
+      supporting: true,
       publishedAt: true,
     },
+  })
+
+  // Get file extensions
+  const re = /(?:\.([^.]+))?$/
+  let mainFilenames = [] as any
+  let supportingFilenames = [] as any
+  modules.map((module) => {
+    mainFilenames.push(re.exec(module.main!["name"])![1])
+    if (module.supporting!["files"].length > 0) {
+      module.supporting!["files"].map((file) => {
+        supportingFilenames.push(re.exec(file.original_filename)![1])
+      })
+    }
+  })
+
+  const uniqMainExtensions = mainFilenames.filter(onlyUnique)
+  let mainExtensions = [] as any
+  uniqMainExtensions.forEach((date, index) => {
+    mainExtensions.push({
+      extension: date ? date : "None",
+      count: itemCounter(mainFilenames, date),
+    })
+  })
+
+  const uniqSupportingExtensions = supportingFilenames.filter(onlyUnique)
+  let supportingExtensions = [] as any
+  uniqSupportingExtensions.forEach((date, index) => {
+    supportingExtensions.push({
+      extension: date,
+      count: itemCounter(supportingFilenames, date),
+    })
   })
 
   const dates = modules.map((module) => {
@@ -31,7 +64,6 @@ export default async function getSignature() {
   const uniqDates = dates.filter(onlyUnique)
   uniqDates.forEach((date, index) => {
     const epochTime = new Date(date!)
-    console.log(epochTime.getTime())
     data.push({
       time: epochTime.getTime(),
       modules:
@@ -39,5 +71,5 @@ export default async function getSignature() {
     })
   })
 
-  return data
+  return { data, mainExtensions, supportingExtensions }
 }

--- a/app/pages/browse.jsx
+++ b/app/pages/browse.jsx
@@ -1,8 +1,6 @@
 import Navbar from "app/core/components/Navbar"
 import Layout from "app/core/layouts/Layout"
-import getBrowseGraphData from "app/core/queries/getBrowseGraphData"
 import { useInfiniteQuery, useQuery, useRouter, useSession, Link, Routes } from "blitz"
-import moment from "moment"
 import React from "react"
 
 import getBrowseData from "../core/queries/getBrowseData"
@@ -15,38 +13,11 @@ import ModuleBoxFeed from "app/core/components/ModuleBoxFeed"
 import getBrowseWorkspaceData from "../core/queries/getBrowseWorkspaceData"
 import getBrowseWorkspaceGraphData from "../core/queries/getBrowseWorkspaceGraphData"
 
-const CustomTooltip = ({ active, payload, label }) => {
-  if (active && payload && payload.length) {
-    return (
-      <div className="custom-tooltip bgborder-gray-400 rounded border border-b bg-white p-2 shadow-xl dark:border-gray-600 dark:bg-gray-900">
-        <p className="label">{`${moment(label).format("YYYY-MM-DD")}`}</p>
-        <p>Total modules: {`${payload[0].value}`}</p>
-      </div>
-    )
-  }
-
-  return null
-}
-
-const CustomTooltipWorkspace = ({ active, payload, label }) => {
-  if (active && payload && payload.length) {
-    return (
-      <div className="custom-tooltip bgborder-gray-400 rounded border border-b bg-white p-2 shadow-xl dark:border-gray-600 dark:bg-gray-900">
-        <p className="label">{`${moment(label).format("YYYY-MM-DD")}`}</p>
-        <p>Total signups: {`${payload[0].value}`}</p>
-      </div>
-    )
-  }
-
-  return null
-}
-
 const BrowseContent = () => {
   const [modulePages, { isFetching, isFetchingNextPage, fetchNextPage, hasNextPage }] =
     useInfiniteQuery(getBrowseData, (page = { take: 20, skip: 0 }) => page, {
       getNextPageParam: (lastPage) => lastPage.nextPage,
     })
-  const [graphData] = useQuery(getBrowseGraphData, undefined)
 
   return (
     <div className="mx-4 max-w-7xl py-16 text-gray-900 dark:text-gray-200 xl:mx-auto">

--- a/app/pages/stats.jsx
+++ b/app/pages/stats.jsx
@@ -3,8 +3,22 @@ import Layout from "app/core/layouts/Layout"
 import getBrowseGraphData from "app/core/queries/getBrowseGraphData"
 import { useInfiniteQuery, useQuery, useRouter, useSession, Link, Routes } from "blitz"
 import moment from "moment"
+import { useMediaPredicate } from "react-media-hook"
+
 import React from "react"
-import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+} from "recharts"
 
 import getBrowseData from "../core/queries/getBrowseData"
 import LayoutLoader from "../core/components/LayoutLoader"
@@ -42,18 +56,16 @@ const CustomTooltipWorkspace = ({ active, payload, label }) => {
   return null
 }
 
-const BrowseContent = () => {
-  const [graphData] = useQuery(getBrowseGraphData, undefined)
-
+const BrowseContent = ({ graphData }) => {
   return (
-    <div className="mx-4 max-w-xl py-16 text-gray-900 dark:text-gray-200">
+    <div className="mx-4 py-16 text-gray-900 dark:text-gray-200">
       <h2 className="text-center text-3xl font-extrabold ">Published modules</h2>
       <div className="mx-auto text-center">
         <ResponsiveContainer width="100%" height={250}>
           <AreaChart
             width={1280}
             height={250}
-            data={graphData}
+            data={graphData.data}
             margin={{ top: 10, right: 0, left: 0, bottom: 0 }}
           >
             <defs>
@@ -162,6 +174,59 @@ const BrowseWorkspaces = () => {
   )
 }
 
+const StatsExtensions = ({ graphData }) => {
+  const biggerWindow = useMediaPredicate("(min-width: 640px)")
+
+  return (
+    <>
+      <div className="mx-4 py-16 text-gray-900 dark:text-gray-200">
+        <h2 className="text-center text-3xl font-extrabold ">Main file extensions</h2>
+        <div className="mx-auto text-center ">
+          <RadarChart
+            cx={biggerWindow ? 300 : 150}
+            cy={biggerWindow ? 250 : 150}
+            outerRadius={biggerWindow ? 150 : 100}
+            width={biggerWindow ? 500 : 300}
+            height={biggerWindow ? 500 : 300}
+            data={graphData.mainExtensions}
+            className="mx-auto h-full w-full"
+          >
+            <PolarGrid />
+            <PolarAngleAxis dataKey="extension" />
+            <PolarRadiusAxis />
+            <Radar name="Main" dataKey="count" stroke="#090909" fill="#db2777" fillOpacity={0.6} />
+          </RadarChart>
+        </div>
+      </div>
+      <div className="mx-4 py-16 text-gray-900 dark:text-gray-200">
+        <h2 className="text-center text-3xl font-extrabold ">Supporting file extensions</h2>
+        <div className="mx-auto w-full text-center">
+          <RadarChart
+            cx={biggerWindow ? 300 : 150}
+            cy={biggerWindow ? 250 : 150}
+            outerRadius={biggerWindow ? 150 : 100}
+            width={biggerWindow ? 500 : 300}
+            height={biggerWindow ? 500 : 300}
+            data={graphData.supportingExtensions}
+            className="mx-auto h-full w-full"
+          >
+            <PolarGrid />
+            <PolarAngleAxis dataKey="extension" />
+            <PolarRadiusAxis />
+            <Radar
+              name="Supporting"
+              dataKey="count"
+              stroke="#090909"
+              fill="#d946ef"
+              fillOpacity={0.6}
+            />
+          </RadarChart>
+        </div>
+      </div>
+    </>
+  )
+}
+
 const Stats = () => {
   const currentUser = useCurrentUser()
   const session = useSession()
@@ -169,6 +234,7 @@ const Stats = () => {
   const router = useRouter()
   const [drafts, { refetch }] = useQuery(getDrafts, { session })
   const [invitations] = useQuery(getInvitedModules, { session })
+  const [graphData] = useQuery(getBrowseGraphData, undefined)
 
   return (
     <>
@@ -185,8 +251,9 @@ const Stats = () => {
         Real-time statistics
       </h1>
       <div className="mx-auto max-w-7xl grid-cols-2 xl:grid">
-        <BrowseContent />
+        <BrowseContent graphData={graphData} />
         <BrowseWorkspaces />
+        <StatsExtensions graphData={graphData} />
       </div>
     </>
   )


### PR DESCRIPTION
This PR adds a radar chart for file extensions used in main and supporting files. This can help inform the discussion in #346.

Fixes #347.

## Example (test environment)

![Screenshot 2022-03-02 at 15 17 07](https://user-images.githubusercontent.com/2946344/156379961-7cf7679f-c525-4d4c-8883-64bad5c6e5a2.png)

