### PR TITLE
Remove analytics from verification link

### DIFF
--- a/app/auth/pages/verifyEmail/[code].tsx
+++ b/app/auth/pages/verifyEmail/[code].tsx
@@ -55,6 +55,4 @@ const VerifyMail: BlitzPage = () => {
   )
 }
 
-VerifyMail.getLayout = (page) => <Layout title="Verifying Email ...">{page}</Layout>
-
 export default VerifyMail


### PR DESCRIPTION
This PR removes the analytics tracking from the verification of the email. It is superfluous and preferably not tracked in a portal more people have access to.﻿
