### PR TITLE
Add CrossRef banner

### DIFF
--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -26,6 +26,14 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
         {headChildren}
       </Head>
       <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-white">
+        <div className="z-50 w-screen bg-red-700 py-4 text-center text-white">
+          <Link href="https://status.crossref.org/">
+            <a target="_blank" className="underline">
+              CrossRef services are interrupted.
+            </a>
+          </Link>{" "}
+          Publishing not possible until resolved.
+        </div>
         <div className="flex-grow">{children}</div>
       </div>
       <Footer />


### PR DESCRIPTION
This PR adds a banner to indicate CrossRef services are interrupted.﻿

<img width="1791" alt="Screenshot 2022-03-24 at 11 41 34" src="https://user-images.githubusercontent.com/2946344/159899262-3875b7d2-501c-412a-b143-324041577587.png">

This banner will be removed as soon as this is resolved.
