### PR TITLE
Remove crossref banner

### DIFF
--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -26,14 +26,14 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
         {headChildren}
       </Head>
       <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-white">
-        <div className="z-50 w-screen bg-red-700 py-4 text-center text-white">
+        {/* <div className="z-50 w-screen bg-red-700 py-4 text-center text-white">
           <Link href="https://status.crossref.org/">
             <a target="_blank" className="underline">
               CrossRef services are interrupted.
             </a>
           </Link>{" "}
           Publishing not possible until resolved.
-        </div>
+        </div> */}
         <div className="flex-grow">{children}</div>
       </div>
       <Footer />


### PR DESCRIPTION
This PR removes the banner - everything seems to be fixed again from CrossRef - will keep an eye on their blog for a post-mortem.﻿
