### PR TITLE
Add main file image preview

### DIFF
--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -247,6 +247,12 @@ const Module = ({ module, mainFile, supportingRaw }) => {
           <div className="my-8">
             <h2 className="text-lg">Main file</h2>
             <ViewFiles name={mainFile.name} size={mainFile.size} url={mainFile.cdnUrl} />
+            {/* Preview image */}
+            {mainFile.isImage ? (
+              <img src={mainFile.cdnUrl} className="mx-auto my-2 h-auto w-full" />
+            ) : (
+              ""
+            )}
             {/* Preview PDF */}
             {mainFile.mimeType === "application/pdf" ? (
               <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.13.216/build/pdf.worker.min.js">


### PR DESCRIPTION
This PR adds an image preview for the main file.

This was so easy I should've done it from the get go. But hey, it's here now

![](https://media.giphy.com/media/d3MJZ8GJSFoftD8I/giphy.gif)

## Screenshot
<img width="1778" alt="Screenshot 2022-04-05 at 17 26 15" src="https://user-images.githubusercontent.com/2946344/161790073-498d0e45-47d6-4220-9248-f55d42f27f4c.png">

