### PR TITLE
Add Crisp chat

### DIFF
--- a/app/core/components/Footer.tsx
+++ b/app/core/components/Footer.tsx
@@ -6,7 +6,7 @@ const Footer = () => {
   const date = new Date()
 
   return (
-    <footer className="w-full bg-white py-4 dark:bg-gray-900 sm:p-0">
+    <footer className="w-full bg-white pt-4 pb-24  dark:bg-gray-900 sm:p-0">
       <div className="mx-4 pt-8 text-black dark:text-white sm:flex sm:max-w-7xl xl:mx-auto ">
         <div className="mb-0 mt-0 w-10/12 text-sm sm:mb-28 sm:w-full">
           <h3 className="text-base font-bold">ResearchEquals</h3>

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -14,11 +14,14 @@ let crispCode = `window.$crisp=[];window.CRISP_WEBSITE_ID="cb17dd6e-f56c-4c2c-a8
 
 const Layout = ({ title, children, headChildren }: LayoutProps) => {
   const [cookie, setCookie] = useState(() => <></>)
+  const [cookieAccepted, setCookieAccepted] = useState(
+    getCookieConsentValue("researchequals-website-cookie") === "true"
+  )
   useEffect(() => {
-    if (getCookieConsentValue("researchequals-website-cookie") === "true") {
+    if (cookieAccepted) {
       setCookie(<script type="text/javascript">{crispCode}</script>)
     }
-  }, [])
+  }, [cookieAccepted])
 
   return (
     <>
@@ -75,7 +78,9 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
           fontSize: "1rem",
         }}
         expires={150}
-        onAccept={() => {}}
+        onAccept={() => {
+          setCookieAccepted(true)
+        }}
         enableDeclineButton
       >
         We use cookies for essential website security purposes. You can withdraw your consent for

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -79,7 +79,7 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
         enableDeclineButton
       >
         We use cookies for essential website security purposes. You can withdraw your consent for
-        optional cookies at any time. See also our{" "}
+        optional chat cookies at any time. See also our{" "}
         <Link href={Routes.PrivacyPage()}>
           <a className="underline hover:text-white hover:no-underline" target="_blank">
             Privacy policy

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from "react"
+import { ReactNode, useEffect, useState } from "react"
 import { Head, Link, Routes } from "blitz"
 import CookieConsent, { Cookies, getCookieConsentValue } from "react-cookie-consent"
 import { Toaster } from "react-hot-toast"
@@ -10,11 +10,15 @@ type LayoutProps = {
   headChildren?: ReactNode
 }
 
+let crispCode = `window.$crisp=[];window.CRISP_WEBSITE_ID="cb17dd6e-f56c-4c2c-a85f-463da113e860";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();`
+
 const Layout = ({ title, children, headChildren }: LayoutProps) => {
-  // useEffect(() => {
-  //   if (getCookieConsentValue("researchequals-website-cookie") === "true") {
-  //   }
-  // }, [])
+  const [cookie, setCookie] = useState(() => <></>)
+  useEffect(() => {
+    if (getCookieConsentValue("researchequals-website-cookie") === "true") {
+      setCookie(<script type="text/javascript">{crispCode}</script>)
+    }
+  }, [])
 
   return (
     <>
@@ -23,6 +27,17 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
         <title>{title || "ResearchEquals"}</title>
         <link rel="icon" href="/favicon-32.png" />
         <script data-respect-dnt data-no-cookie async src="https://cdn.splitbee.io/sb.js"></script>
+        {cookie}
+        {/* {cookie ? <script type="text/javascript">{crispCode}</script> : ""} */}
+        {/* <script type="text/javascript">{cookie ? crispCode : false}</script> */}
+        {/* <div
+          dangerouslySetInnerHTML={{
+            __html:
+              getCookieConsentValue("researchequals-website-cookie") !== "true"
+                ? '<script type="text/javascript"></script'
+                : '<script type="text/javascript">window.$crisp=[];window.CRISP_WEBSITE_ID="cb17dd6e-f56c-4c2c-a85f-463da113e860";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();</script>',
+          }}
+        /> */}
         {headChildren}
       </Head>
       <div className="flex min-h-screen flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-white">

--- a/app/pages/privacy.tsx
+++ b/app/pages/privacy.tsx
@@ -165,6 +165,9 @@ We use the service Splitbee provided by Tobias Lins e.U. Alserbachstraße 10 109
 
 You can opt-out by enabling the Do Not Track functionality in your browser.
 
+### 3. Crisp
+
+We use the service Crisp provided by Crisp IM SARL 2 Boulevard de Launay, 44100 Nantes, France. Crisp helps us provide chat support and live assistance in your use of our Site. It collects certain information such as messages exchanged, activity status and datetime, IP address, device type (operating system and browser), geolocation (as based on IP), timezone, preferred language, page activity, professional life data (position, employer, business address), and guesses data from public information on Google (Avatar, Twitter/Facebook handle). Additional consent can be actively provided to process email and phone number. Any processing of personal data for these purposes is based on Art. 6 par. 1 lit. f) GDPR whereas our legitimate interest is to provide actionable assistance in the use of our Site.
 `
 
 const md = new Markdown()


### PR DESCRIPTION
This PR adds the Crisp chat to the platform.

I was able to add the chat only upon page reload after consenting to the cookie. Re-rendering the `<head>` elements using hooks was something I struggled with a bit but didn't get to work in the way I wanted. 

Additional updates:
* Privacy policy (permitted to be changed like this, terms would require a legal notice to the users I think four weeks in advance as it changes the contract)
* Cookie consent banner

Fixes #289.