### PR TITLE
Remove search bar duplication

### DIFF
--- a/app/core/styles/algolia.css
+++ b/app/core/styles/algolia.css
@@ -85,6 +85,9 @@
 .aa-Autocomplete {
   height: 100%;
 }
+.aa-Autocomplete:not(:first-child) {
+  display: none;
+}
 .aa-DetachedFormContainer *,
 .aa-Panel * {
   box-sizing: border-box;


### PR DESCRIPTION
This PR forces the CSS to only display the first of the algolia search bars to remove the issue reported in #295.

Fixes #295.

https://user-images.githubusercontent.com/2946344/165318757-ef8b2e84-240f-49d3-8320-9cde653790dc.mov

