### PR TITLE
Update QUIRREL domain

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -53,7 +53,7 @@
             },
             "PORT": "3000",
             "MAIL_FROM": "no-reply@libscie.org",
-            "QUIRREL_BASE_URL": "https://researchequals.com/",
+            "QUIRREL_BASE_URL": "https://www.researchequals.com/",
             "QUIRREL_ENCRYPTION_SECRET": {
               "fromParameterStore": "QUIRREL_ENCRYPTION_SECRET"
             },


### PR DESCRIPTION
I keep receiving 401 errors for quirrel, and I am not sure where it comes from. I know that we switched to the main domain being `www.` so maybe this fixes it?

![image](https://user-images.githubusercontent.com/2946344/167366372-f95f9ae3-1ff8-48b2-a399-902a540b9e46.png)

This is a non-breaking change given that it's already broken - simply making a PR for documentation. 