### PR TITLE
Upgrade `*tailwindcss*`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "@prisma/client": "3.8.1",
         "@react-pdf-viewer/core": "3.3.0",
         "@stripe/stripe-js": "1.22.0",
-        "@tailwindcss/forms": "0.4.0",
-        "@tailwindcss/line-clamp": "0.3.1",
+        "@tailwindcss/forms": "0.5.1",
+        "@tailwindcss/line-clamp": "0.4.0",
         "@uploadcare/react-widget": "1.3.9",
         "algoliasearch": "4.12.0",
         "autoprefixer": "10.4.2",
@@ -53,7 +53,7 @@
         "remark-gfm": "3.0.1",
         "remark-math": "5.1.1",
         "stripe": "8.200.0",
-        "tailwindcss": "3.0.23",
+        "tailwindcss": "3.0.24",
         "typescript": "~4.5",
         "xml-js": "1.6.11",
         "zod": "3.11.6"
@@ -63,7 +63,7 @@
         "lint-staged": "12.3.2",
         "prettier": "2.5.1",
         "prettier-plugin-prisma": "3.8.0",
-        "prettier-plugin-tailwindcss": "0.1.7",
+        "prettier-plugin-tailwindcss": "0.1.10",
         "pretty-quick": "3.1.3"
       },
       "engines": {
@@ -3448,9 +3448,9 @@
       }
     },
     "node_modules/@tailwindcss/forms": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.4.0.tgz",
-      "integrity": "sha512-DeaQBx6EgEeuZPQACvC+mKneJsD8am1uiJugjgQK1+/Vt+Ai0GpFBC2T2fqnUad71WgOxyrZPE6BG1VaI6YqfQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.1.tgz",
+      "integrity": "sha512-QSwsFORnC2BAP0lRzQkz1pw+EzIiiPdk4e27vGQjyXkwJPeC7iLIRVndJzf9CJVbcrrIcirb/TfxF3gRTyFEVA==",
       "dependencies": {
         "mini-svg-data-uri": "^1.2.3"
       },
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz",
-      "integrity": "sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.0.tgz",
+      "integrity": "sha512-HQZo6gfx1D0+DU3nWlNLD5iA6Ef4JAXh0LeD8lOGrJwEDBwwJNKQza6WoXhhY1uQrxOuU8ROxV7CqiQV4CoiLw==",
       "peerDependencies": {
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
@@ -3772,11 +3772,6 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "license": "MIT"
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
@@ -6491,21 +6486,6 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/crc-32": {
       "version": "1.2.1",
@@ -12332,6 +12312,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
       "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -14130,9 +14111,9 @@
       "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14793,8 +14774,9 @@
       }
     },
     "node_modules/object-hash": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
       }
@@ -15628,11 +15610,11 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.1.tgz",
-      "integrity": "sha512-c/9XYboIbSEUZpiD1UQD0IKiUe8n9WHYV7YFe7X7J+ZwCsEKkUJSFWjS9hBU1RR9THR7jMXst8sxiqP0jjo2mg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
       "dependencies": {
-        "lilconfig": "^2.0.4",
+        "lilconfig": "^2.0.5",
         "yaml": "^1.10.2"
       },
       "engines": {
@@ -15643,12 +15625,24 @@
         "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
+        "postcss": ">=8.0.9",
         "ts-node": ">=9.0.0"
       },
       "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/postcss-nested": {
@@ -15670,9 +15664,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-      "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15745,9 +15739,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.7.tgz",
-      "integrity": "sha512-tmBr45hCLuit2Cz9Pwow0/Jl1bGivYGsfcF29O+3sKcE++ybjz9dfie565S3ZsvAeV8uYer9SRMBWDsHPly2Lg==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.10.tgz",
+      "integrity": "sha512-ooDGNuXUjgCXfShliVYQ6+0iXqUFXn+zdNInPe0WZN9qINt9srbLGFGY5jeVL4MXtY20/4S8JaBcd8l6N6NfCQ==",
       "dev": true,
       "engines": {
         "node": ">=12.17.0"
@@ -18649,28 +18643,28 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.23.tgz",
-      "integrity": "sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+      "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
       "dependencies": {
         "arg": "^5.0.1",
-        "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "cosmiconfig": "^7.0.1",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.11",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
+        "lilconfig": "^2.0.5",
         "normalize-path": "^3.0.0",
-        "object-hash": "^2.2.0",
-        "postcss": "^8.4.6",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.12",
         "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.0",
+        "postcss-load-config": "^3.1.4",
         "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.9",
+        "postcss-selector-parser": "^6.0.10",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.0"
@@ -18683,7 +18677,6 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "autoprefixer": "^10.0.2",
         "postcss": "^8.0.9"
       }
     },
@@ -18733,6 +18726,37 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/lilconfig": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss": {
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.3",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/tailwindcss/node_modules/readdirp": {
@@ -23020,17 +23044,17 @@
       }
     },
     "@tailwindcss/forms": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.4.0.tgz",
-      "integrity": "sha512-DeaQBx6EgEeuZPQACvC+mKneJsD8am1uiJugjgQK1+/Vt+Ai0GpFBC2T2fqnUad71WgOxyrZPE6BG1VaI6YqfQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.1.tgz",
+      "integrity": "sha512-QSwsFORnC2BAP0lRzQkz1pw+EzIiiPdk4e27vGQjyXkwJPeC7iLIRVndJzf9CJVbcrrIcirb/TfxF3gRTyFEVA==",
       "requires": {
         "mini-svg-data-uri": "^1.2.3"
       }
     },
     "@tailwindcss/line-clamp": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz",
-      "integrity": "sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.0.tgz",
+      "integrity": "sha512-HQZo6gfx1D0+DU3nWlNLD5iA6Ef4JAXh0LeD8lOGrJwEDBwwJNKQza6WoXhhY1uQrxOuU8ROxV7CqiQV4CoiLw=="
     },
     "@testing-library/dom": {
       "version": "7.31.2",
@@ -23283,11 +23307,6 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.1"
-    },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/parse5": {
       "version": "6.0.3",
@@ -25245,18 +25264,6 @@
     },
     "core-util-is": {
       "version": "1.0.2"
-    },
-    "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "requires": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      }
     },
     "crc-32": {
       "version": "1.2.1",
@@ -29325,7 +29332,8 @@
     "lilconfig": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
-      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA=="
+      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
+      "dev": true
     },
     "limiter": {
       "version": "1.1.5"
@@ -30518,9 +30526,9 @@
       "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -31028,7 +31036,9 @@
       }
     },
     "object-hash": {
-      "version": "2.2.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -31571,12 +31581,19 @@
       }
     },
     "postcss-load-config": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.1.tgz",
-      "integrity": "sha512-c/9XYboIbSEUZpiD1UQD0IKiUe8n9WHYV7YFe7X7J+ZwCsEKkUJSFWjS9hBU1RR9THR7jMXst8sxiqP0jjo2mg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
       "requires": {
-        "lilconfig": "^2.0.4",
+        "lilconfig": "^2.0.5",
         "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "lilconfig": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+          "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg=="
+        }
       }
     },
     "postcss-nested": {
@@ -31588,9 +31605,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-      "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -31641,9 +31658,9 @@
       }
     },
     "prettier-plugin-tailwindcss": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.7.tgz",
-      "integrity": "sha512-tmBr45hCLuit2Cz9Pwow0/Jl1bGivYGsfcF29O+3sKcE++ybjz9dfie565S3ZsvAeV8uYer9SRMBWDsHPly2Lg==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.10.tgz",
+      "integrity": "sha512-ooDGNuXUjgCXfShliVYQ6+0iXqUFXn+zdNInPe0WZN9qINt9srbLGFGY5jeVL4MXtY20/4S8JaBcd8l6N6NfCQ==",
       "dev": true
     },
     "pretty-format": {
@@ -33687,28 +33704,28 @@
       }
     },
     "tailwindcss": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.23.tgz",
-      "integrity": "sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+      "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
       "requires": {
         "arg": "^5.0.1",
-        "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "cosmiconfig": "^7.0.1",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.11",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
+        "lilconfig": "^2.0.5",
         "normalize-path": "^3.0.0",
-        "object-hash": "^2.2.0",
-        "postcss": "^8.4.6",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.12",
         "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.0",
+        "postcss-load-config": "^3.1.4",
         "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.9",
+        "postcss-selector-parser": "^6.0.10",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.0"
@@ -33745,6 +33762,21 @@
           "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "requires": {
             "is-glob": "^4.0.3"
+          }
+        },
+        "lilconfig": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+          "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg=="
+        },
+        "postcss": {
+          "version": "8.4.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+          "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+          "requires": {
+            "nanoid": "^3.3.3",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
           }
         },
         "readdirp": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@prisma/client": "3.8.1",
     "@react-pdf-viewer/core": "3.3.0",
     "@stripe/stripe-js": "1.22.0",
-    "@tailwindcss/forms": "0.4.0",
-    "@tailwindcss/line-clamp": "0.3.1",
+    "@tailwindcss/forms": "0.5.1",
+    "@tailwindcss/line-clamp": "0.4.0",
     "@uploadcare/react-widget": "1.3.9",
     "algoliasearch": "4.12.0",
     "autoprefixer": "10.4.2",
@@ -73,7 +73,7 @@
     "remark-gfm": "3.0.1",
     "remark-math": "5.1.1",
     "stripe": "8.200.0",
-    "tailwindcss": "3.0.23",
+    "tailwindcss": "3.0.24",
     "typescript": "~4.5",
     "xml-js": "1.6.11",
     "zod": "3.11.6"
@@ -83,7 +83,7 @@
     "lint-staged": "12.3.2",
     "prettier": "2.5.1",
     "prettier-plugin-prisma": "3.8.0",
-    "prettier-plugin-tailwindcss": "0.1.7",
+    "prettier-plugin-tailwindcss": "0.1.10",
     "pretty-quick": "3.1.3"
   },
   "private": true


### PR DESCRIPTION
This PR upgrades the `*tailwindcss*` dependencies.

These did not break anything upon initial test and seem to be either [SemVer](https://semver.org/) minor or patch upgrades.
