### PR TITLE
Cascade-delete the token when deleting a user

### DIFF
--- a/db/migrations/20220516210705_cascade_delete_token/migration.sql
+++ b/db/migrations/20220516210705_cascade_delete_token/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Token" DROP CONSTRAINT "Token_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Token" ADD CONSTRAINT "Token_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -179,7 +179,7 @@ model Token {
   expiresAt   DateTime
   sentTo      String
 
-  user   User @relation(fields: [userId], references: [id])
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId Int
 
   @@unique([hashedToken, type])


### PR DESCRIPTION
This PR deletes any existing token with a user when they delete their account (via adding cascading deletes to the Prisma DB schema). On my local, I checked that the 500 error does not occur with the procedure reported in #372. Fixes #372.