### PR TITLE
Upgrade `@carbon/icons-react`

### DIFF
--- a/app/auth/pages/signup.tsx
+++ b/app/auth/pages/signup.tsx
@@ -4,7 +4,7 @@ import { useFormik } from "formik"
 import { z } from "zod"
 import { useState } from "react"
 import { Switch } from "@headlessui/react"
-import { Close32, Checkmark32 } from "@carbon/icons-react"
+import { Close, Checkmark } from "@carbon/icons-react"
 import toast from "react-hot-toast"
 
 import signup from "../mutations/signup"
@@ -172,7 +172,7 @@ const SignupPage: BlitzPage = () => {
                     )}
                     aria-hidden="true"
                   >
-                    <Close32 className="h-3 w-3 stroke-current stroke-2 text-gray-400" />
+                    <Close size={32} className="h-3 w-3 stroke-current stroke-2 text-gray-400" />
                   </span>
                   <span
                     className={classNames(
@@ -183,7 +183,10 @@ const SignupPage: BlitzPage = () => {
                     )}
                     aria-hidden="true"
                   >
-                    <Checkmark32 className="h-3 w-3 stroke-current stroke-2 text-indigo-600" />
+                    <Checkmark
+                      size={32}
+                      className="h-3 w-3 stroke-current stroke-2 text-indigo-600"
+                    />
                   </span>
                 </span>
               </Switch>
@@ -233,7 +236,7 @@ const SignupPage: BlitzPage = () => {
                     )}
                     aria-hidden="true"
                   >
-                    <Close32 className="h-3 w-3 stroke-current stroke-2 text-gray-400" />
+                    <Close size={32} className="h-3 w-3 stroke-current stroke-2 text-gray-400" />
                   </span>
                   <span
                     className={classNames(
@@ -244,7 +247,10 @@ const SignupPage: BlitzPage = () => {
                     )}
                     aria-hidden="true"
                   >
-                    <Checkmark32 className="h-3 w-3 stroke-current stroke-2 text-indigo-600" />
+                    <Checkmark
+                      size={32}
+                      className="h-3 w-3 stroke-current stroke-2 text-indigo-600"
+                    />
                   </span>
                 </span>
               </Switch>

--- a/app/core/components/AccountSettings.tsx
+++ b/app/core/components/AccountSettings.tsx
@@ -4,7 +4,7 @@ import { useMutation, validateZodSchema } from "blitz"
 import { useFormik } from "formik"
 import toast from "react-hot-toast"
 import { z } from "zod"
-import { Checkmark32, Close32 } from "@carbon/icons-react"
+import { Checkmark, Close } from "@carbon/icons-react"
 
 import DeleteModal from "../modals/delete"
 
@@ -159,7 +159,11 @@ const WorkspaceSettings = ({ user, setIsOpen }) => {
                 setIsOpen(false)
               }}
             >
-              <Close32 className="h-4 w-4 fill-current pt-1 text-red-500" aria-hidden="true" />
+              <Close
+                size={32}
+                className="h-4 w-4 fill-current pt-1 text-red-500"
+                aria-hidden="true"
+              />
               Cancel
             </button>
           </div>
@@ -167,7 +171,8 @@ const WorkspaceSettings = ({ user, setIsOpen }) => {
             type="submit"
             className="mr-4 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
           >
-            <Checkmark32
+            <Checkmark
+              size={32}
               className="h-4 w-4 fill-current pt-1 text-emerald-500"
               aria-hidden="true"
             />

--- a/app/core/components/AuthorList.tsx
+++ b/app/core/components/AuthorList.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link, Routes, useSession } from "blitz"
-import { ChevronUp32, ChevronDown32, Checkmark32, Subtract32 } from "@carbon/icons-react"
+import { ChevronUp, ChevronDown, Checkmark, Subtract } from "@carbon/icons-react"
 
 // https://www.npmjs.com/package/array-move
 function arrayMoveMutable(array, fromIndex, toIndex) {
@@ -43,7 +43,7 @@ function AuthorList({
                 disabled={index === 0}
                 className="disabled:opacity-0"
               >
-                <ChevronUp32 className="h-5 w-5 text-gray-400" />
+                <ChevronUp size={32} className="h-5 w-5 text-gray-400" />
               </button>
               <button
                 onClick={() => {
@@ -52,7 +52,7 @@ function AuthorList({
                 disabled={index === authors.length - 1}
                 className="disabled:opacity-0"
               >
-                <ChevronDown32 className="h-5 w-5 text-gray-400" />
+                <ChevronDown size={32} className="h-5 w-5 text-gray-400" />
               </button>
             </div>
             <Link href={Routes.HandlePage({ handle: author.workspace.handle })}>
@@ -81,7 +81,7 @@ function AuthorList({
                   author.readyToPublish ? "text-emerald-500" : "text-gray-500 dark:text-gray-400"
                 }`}
               >
-                <Checkmark32 className="h-4 w-4 fill-current" aria-hidden="true" />
+                <Checkmark size={32} className="h-4 w-4 fill-current" aria-hidden="true" />
                 Approved
               </span>
             ) : (
@@ -90,7 +90,8 @@ function AuthorList({
                   author.readyToPublish ? "text-emerald-500" : "text-gray-500 dark:text-gray-400"
                 }`}
               >
-                <Subtract32
+                <Subtract
+                  size={32}
                   className="h-4 w-4 fill-current text-gray-500 dark:text-gray-400"
                   aria-hidden="true"
                 />

--- a/app/core/components/DefaultNode.tsx
+++ b/app/core/components/DefaultNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react"
 import { Handle, NodeProps, Position } from "react-flow-renderer"
-import { Launch16 } from "@carbon/icons-react"
+import { Launch } from "@carbon/icons-react"
 import { Link, Routes } from "blitz"
 
 // https://github.com/wbkd/react-flow/blob/main/src/components/Nodes/DefaultNode.tsx
@@ -32,7 +32,7 @@ const DefaultNode = ({
           }
         >
           <a target="_blank" rel="noreferrer" className="ml-2 inline-block align-middle">
-            <Launch16 />
+            <Launch size={16} />
           </a>
         </Link>
       </div>

--- a/app/core/components/EditMainFileDisplay.tsx
+++ b/app/core/components/EditMainFileDisplay.tsx
@@ -1,4 +1,4 @@
-import { Download24, TrashCan24 } from "@carbon/icons-react"
+import { Download, TrashCan } from "@carbon/icons-react"
 import { useMutation } from "blitz"
 import toast from "react-hot-toast"
 import filesize from "filesize"
@@ -22,7 +22,8 @@ const EditFileDisplay = ({ name, size, url, uuid, moduleId, setQueryData }) => {
       </a>
       <p className="flex">
         <button className="mx-2">
-          <TrashCan24
+          <TrashCan
+            size={24}
             className="inline-block h-6 w-6 fill-current align-middle text-red-500"
             onClick={async () => {
               toast.promise(deleteMainMutation({ id: moduleId, uuid }), {
@@ -38,7 +39,8 @@ const EditFileDisplay = ({ name, size, url, uuid, moduleId, setQueryData }) => {
           />
         </button>
         <a href={url} target="_blank" download rel="noreferrer">
-          <Download24
+          <Download
+            size={24}
             className="inline-block h-6 w-6 fill-current align-middle text-gray-900 dark:text-gray-200"
             aria-label="Download file"
           />

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -1,4 +1,4 @@
-import { Download24, TrashCan24 } from "@carbon/icons-react"
+import { Download, TrashCan } from "@carbon/icons-react"
 import { useMutation } from "blitz"
 import toast from "react-hot-toast"
 import filesize from "filesize"
@@ -22,7 +22,8 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
       </a>
       <p className="flex">
         <button className="mx-2">
-          <TrashCan24
+          <TrashCan
+            size={24}
             className="inline-block h-6 w-6 fill-current align-middle text-red-500"
             onClick={async () => {
               toast.promise(deleteMutation({ id: moduleId, uuid }), {
@@ -38,7 +39,8 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
           />
         </button>
         <a href={url} target="_blank" download rel="noreferrer">
-          <Download24
+          <Download
+            size={24}
             className="inline-block h-6 w-6 fill-current align-middle text-gray-900 dark:text-gray-200"
             aria-label="Download file"
           />

--- a/app/core/components/FeedPagination.tsx
+++ b/app/core/components/FeedPagination.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft32, ChevronRight32 } from "@carbon/icons-react"
+import { ChevronLeft, ChevronRight } from "@carbon/icons-react"
 
 const FeedPagination = ({
   ITEMS_PER_PAGE,
@@ -23,7 +23,7 @@ const FeedPagination = ({
             onClick={goToPreviousPage}
           >
             <span className="sr-only">Previous</span>
-            <ChevronLeft32 className="h-5 w-5" aria-hidden="true" />
+            <ChevronLeft size={32} className="h-5 w-5" aria-hidden="true" />
           </button>
           {/* TODO: Drop middle buttons that don't fit screen */}
           {Array.from({ length: Math.ceil(count / ITEMS_PER_PAGE) }, (x, i) => i).map((pageNr) => (
@@ -51,7 +51,7 @@ const FeedPagination = ({
             onClick={goToNextPage}
           >
             <span className="sr-only">Previous</span>
-            <ChevronRight32 className="h-5 w-5" aria-hidden="true" />
+            <ChevronRight size={32} className="h-5 w-5" aria-hidden="true" />
           </button>
         </nav>
       </div>

--- a/app/core/components/Footer.tsx
+++ b/app/core/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { Link, Routes } from "blitz"
-import { LogoDiscord32, LogoGithub32, LogoTwitter32 } from "@carbon/icons-react"
+import { LogoDiscord, LogoGithub, LogoTwitter } from "@carbon/icons-react"
 import LibscieLogo from "./LibscieLogo"
 
 const Footer = () => {
@@ -105,7 +105,7 @@ const Footer = () => {
           <p>
             <Link href="https://discord.gg/SefsGJWWSw">
               <a className="flex align-middle" target="_blank">
-                <LogoDiscord32 className="m-1 max-h-4 w-auto" aria-hidden="true" />
+                <LogoDiscord size={32} className="m-1 max-h-4 w-auto" aria-hidden="true" />
                 <span className="text-black hover:bg-indigo-600 hover:text-white dark:text-white">
                   Discord
                 </span>
@@ -115,7 +115,7 @@ const Footer = () => {
           <p>
             <Link href="https://github.com/libscie/ResearchEquals.com">
               <a className="flex align-middle" target="_blank">
-                <LogoGithub32 className="m-1 max-h-4 w-auto" aria-hidden="true" />
+                <LogoGithub size={32} className="m-1 max-h-4 w-auto" aria-hidden="true" />
                 <span className="text-black hover:bg-indigo-600 hover:text-white dark:text-white">
                   GitHub
                 </span>
@@ -125,7 +125,7 @@ const Footer = () => {
           <p>
             <Link href="https://twitter.com/ResearchEquals">
               <a className="flex align-middle" target="_blank">
-                <LogoTwitter32 className="m-1 max-h-4 w-auto" />
+                <LogoTwitter size={32} className="m-1 max-h-4 w-auto" />
                 <span
                   className="text-black hover:bg-indigo-600 hover:text-white dark:text-white"
                   aria-hidden="true"

--- a/app/core/components/InputNode.tsx
+++ b/app/core/components/InputNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react"
 import { Handle, NodeProps, Position } from "react-flow-renderer"
-import { Launch16 } from "@carbon/icons-react"
+import { Launch } from "@carbon/icons-react"
 import { Link, Routes } from "blitz"
 
 // https://github.com/wbkd/react-flow/blob/main/src/components/Nodes/InputNode.tsx
@@ -21,7 +21,7 @@ const InputNode = ({ data, isConnectable, sourcePosition = Position.Bottom }: No
           }
         >
           <a target="_blank" rel="noreferrer" className="ml-2 inline-block align-middle">
-            <Launch16 />
+            <Launch size={16} />
           </a>
         </Link>
       </div>

--- a/app/core/components/NavbarDropdown.tsx
+++ b/app/core/components/NavbarDropdown.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from "react"
 import { Transition, Dialog } from "@headlessui/react"
 import { Link, Routes, useMutation } from "blitz"
-import { Add32, Close32, Menu32 } from "@carbon/icons-react"
+import { Add, Close, Menu } from "@carbon/icons-react"
 import logout from "../../auth/mutations/logout"
 import SettingsModal from "../modals/settings"
 import ResearchEqualsLogo from "./ResearchEqualsLogo"
@@ -25,7 +25,8 @@ const DropdownContents = ({
           <QuickDraft
             buttonText={
               <>
-                <Add32
+                <Add
+                  size={32}
                   className="inline h-4 w-4 fill-current text-indigo-500 dark:text-gray-400"
                   aria-hidden="true"
                 />
@@ -148,7 +149,8 @@ const NavbarDropdown = ({
       {isOpen ? (
         <>
           <span className="sr-only">Close menu</span>
-          <Close32
+          <Close
+            size={32}
             className="block h-6 w-6 text-gray-400"
             onClick={() => {
               setIsOpen(false)
@@ -164,7 +166,10 @@ const NavbarDropdown = ({
             }}
           >
             <span className="sr-only">Open menu</span>
-            <Menu32 className="block h-6 w-6 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:ring-2 focus:ring-gray-200 focus:ring-offset-0 dark:text-gray-200 dark:hover:bg-gray-800" />
+            <Menu
+              size={32}
+              className="block h-6 w-6 rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:ring-2 focus:ring-gray-200 focus:ring-offset-0 dark:text-gray-200 dark:hover:bg-gray-800"
+            />
           </button>
         </>
       )}
@@ -214,7 +219,7 @@ const NavbarDropdown = ({
                           }}
                         >
                           <span className="sr-only">Close menu</span>
-                          <Close32 className="h-6 w-6" aria-hidden="true" />
+                          <Close size={32} className="h-6 w-6" aria-hidden="true" />
                         </button>
                       </div>
                     </div>

--- a/app/core/components/NavbarFullwidthMenu.tsx
+++ b/app/core/components/NavbarFullwidthMenu.tsx
@@ -1,7 +1,7 @@
 import { Link, Routes, useMutation } from "blitz"
 import { Menu, Popover, Transition } from "@headlessui/react"
 import { Fragment } from "react"
-import { Add32, Settings32, Notification32, NotificationNew32 } from "@carbon/icons-react"
+import { Add, Settings, Notification, NotificationNew } from "@carbon/icons-react"
 
 import logout from "../../auth/mutations/logout"
 import SettingsModal from "../modals/settings"
@@ -33,9 +33,13 @@ const FullWidthMenu = ({
               >
                 <span className="sr-only">View notifications</span>
                 {invitedModules.length > 0 ? (
-                  <NotificationNew32 className="h-6 w-6" aria-hidden="true" />
+                  <NotificationNew size={32} className="h-6 w-6" aria-hidden="true" />
                 ) : (
-                  <Notification32 className="h-6 w-6 cursor-not-allowed" aria-hidden="true" />
+                  <Notification
+                    size={32}
+                    className="h-6 w-6 cursor-not-allowed"
+                    aria-hidden="true"
+                  />
                 )}
               </Popover.Button>
               <Transition
@@ -64,7 +68,8 @@ const FullWidthMenu = ({
         <SettingsModal
           styling="ml-1 shrink-0 p-1 text-gray-400 hover:text-gray-500 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 "
           button={
-            <Settings32
+            <Settings
+              size={32}
               className="flex h-6 w-6 rounded-full text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
               aria-hidden="true"
             />
@@ -129,7 +134,8 @@ const FullWidthMenu = ({
         <QuickDraft
           buttonText={
             <>
-              <Add32
+              <Add
+                size={32}
                 className="h-4 w-4 fill-current text-indigo-500 dark:text-gray-400"
                 aria-hidden="true"
               />

--- a/app/core/components/NavbarTabs.tsx
+++ b/app/core/components/NavbarTabs.tsx
@@ -1,5 +1,5 @@
 import { Link, Routes } from "blitz"
-import { Undo32 } from "@carbon/icons-react"
+import { Undo } from "@carbon/icons-react"
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
@@ -56,7 +56,7 @@ const NavTabs = ({ currentUser, currentWorkspace, session, router, drafts, invit
                 }}
                 className="m-2 "
               >
-                <Undo32 />{" "}
+                <Undo size={32} />{" "}
               </button>
               {tabs.map((tab) => (
                 <Link key={tab.name} href={tab.href}>

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 import { Formik, Form } from "formik"
-import { Email32, UserAvatar32, User32, Parameter32 } from "@carbon/icons-react"
+import { Email, UserAvatar, User, Parameter } from "@carbon/icons-react"
 
 import SettingsModal from "../modals/settings"
 import changeAvatar from "../../workspaces/mutations/changeAvatar"
@@ -40,7 +40,11 @@ const OnboardingEmail = ({ data }) => {
         >
           <div className="flex flex-grow">
             <div className="">
-              <Email32 className="h-5 w-5 text-amber-400 dark:text-amber-200" aria-hidden="true" />
+              <Email
+                size={32}
+                className="h-5 w-5 text-amber-400 dark:text-amber-200"
+                aria-hidden="true"
+              />
             </div>
             <div className="ml-3 flex-1 text-amber-800 dark:text-amber-200 md:flex">
               <p className="mr-2 text-sm">
@@ -99,7 +103,7 @@ const OnboardingOrcid = ({ data }) => {
                 className="h-5 w-5 fill-current text-emerald-400 dark:text-emerald-200 "
                 aria-hidden="true"
               >
-                <path d="M12.6007 8.01734C12.3707 7.91001 12.1533 7.838 11.9473 7.804C11.742 7.76868 11.4127 7.752 10.9567 7.752H9.77266V12.6793H10.9867C11.46 12.6793 11.828 12.6467 12.0907 12.582C12.3533 12.5173 12.572 12.436 12.7473 12.336C12.9227 12.2367 13.0833 12.1147 13.2293 11.9687C13.6967 11.494 13.9307 10.8953 13.9307 10.1713C13.9307 9.45998 13.6907 8.87932 13.21 8.42998C13.0327 8.26331 12.8287 8.12531 12.6007 8.0173V8.01734ZM10 2C5.58134 2 2 5.582 2 10C2 14.418 5.58134 18 10 18C14.4187 18 18 14.418 18 10C18 5.582 14.4187 2 10 2ZM7.34399 13.5327H6.39598V6.908H7.34399V13.5327ZM6.86934 6.21601C6.51001 6.21601 6.21734 5.92534 6.21734 5.564C6.21734 5.20534 6.50933 4.91268 6.86934 4.91268C7.23 4.91268 7.522 5.20467 7.522 5.564C7.52129 5.926 7.23 6.21601 6.86934 6.21601ZM14.656 11.4933C14.4853 11.898 14.242 12.254 13.9253 12.5607C13.6033 12.878 13.2287 13.1153 12.8013 13.2767C12.5514 13.374 12.3227 13.44 12.114 13.474C11.9047 13.5067 11.5067 13.5227 10.918 13.5227H8.82269V6.908H11.056C11.958 6.908 12.67 7.04201 13.1954 7.31267C13.72 7.58266 14.1367 7.98134 14.4467 8.50534C14.7567 9.03001 14.912 9.60268 14.912 10.2213C14.9128 10.6653 14.826 11.0893 14.656 11.4933H14.656Z" />
+                <path d="M12.6007 8.01734C12.3707 7.91001 12.1533 7.838 11.9473 7.804C11.742 7.76868 11.4127 7.752 10.9567 7.752H9.77266V12.6793H10.9867C11.46 12.6793 11.828 12.6467 12.0907 12.582C12.3533 12.5173 12.572 12.436 12.7473 12.336C12.9227 12.2367 13.0833 12.1147 13.2293 11.9687C13.6967 11.494 13.9307 10.8953 13.9307 10.1713C13.9307 9.45998 13.6907 8.879 size={32} .21 8.42998C13.0 size={32} .26331 12.8287 8.12531 12.6007 8.0173V8.01734ZM10 2C5.58134 2 2 5.582 2 10C2 14.418 5.58134 18 10 18C14.4187 18 18 14.418 18 10C18 5.582 14.4187 2 10 2ZM7.34399 13.5327H6.39598V6.908H7.34399V13.5327ZM6.86934 6.21601C6.51001 6.21601 6.21734 5.92534 6.21734 5.564C6.21734 5.20534 6.50933 4.91268 6.86934 4.91268C7.23 4.91268 7.522 5.20467 7.522 5.564C7.52129 5.926 7.23 6.21601 6.86934 6.21601ZM14.656 11.4933C14.4853 11.898 14.242 12.254 13.9253 12.5607C13.6033 12.878 13.2287 13.1153 12.8013 13.2767C12.5514 13.374 12.3227 13.44 12.114 13.474C11.9047 13.5067 11.5067 13.5227 10.918 13.5227H8.82269V6.908H11.056C11.958 6.908 12.67 7.04201 13.1954 7.31267C13.72 7.58266 14.1367 7.98134 14.4467 8.50534C14.7567 9.03001 14.912 9.60268 14.912 10.2213C14.9128 10.6653 14.826 11.0893 14.656 11.4933H14.656Z" />
               </svg>
             </div>
             <div className="ml-3 flex-1 text-emerald-800 dark:text-emerald-200 md:flex">
@@ -137,7 +141,11 @@ const OnboardingProfile = ({ data }) => {
         >
           <div className="flex flex-grow">
             <div className="">
-              <User32 className="h-5 w-5 text-pink-400 dark:text-pink-200" aria-hidden="true" />
+              <User
+                size={32}
+                className="h-5 w-5 text-pink-400 dark:text-pink-200"
+                aria-hidden="true"
+              />
             </div>
             <div className="ml-3 flex-1 text-pink-800 dark:text-pink-200 md:flex">
               <p className="mr-2 text-sm">
@@ -185,7 +193,8 @@ const OnboardingAvatar = ({ data, expire, signature, refetch }) => {
         >
           <div className="flex flex-grow">
             <div className="">
-              <UserAvatar32
+              <UserAvatar
+                size={32}
                 className="h-5 w-5 text-indigo-400 dark:text-indigo-200"
                 aria-hidden="true"
               />
@@ -248,7 +257,8 @@ const OnboardingDraft = ({ data, refetch }) => {
         >
           <div className="flex flex-grow">
             <div className="">
-              <Parameter32
+              <Parameter
+                size={32}
                 className="h-5 w-5 text-violet-400 dark:text-violet-200"
                 aria-hidden="true"
               />

--- a/app/core/components/WorkspaceSettings.tsx
+++ b/app/core/components/WorkspaceSettings.tsx
@@ -4,7 +4,7 @@ import changeUrl from "app/workspaces/mutations/changeUrl"
 import { Link, useMutation, validateZodSchema } from "blitz"
 import { useFormik } from "formik"
 import { z } from "zod"
-import { Checkmark32, Close32, Renew32 } from "@carbon/icons-react"
+import { Checkmark, Close, Renew } from "@carbon/icons-react"
 import toast from "react-hot-toast"
 import ReactTooltip from "react-tooltip"
 import changeLastName from "../../workspaces/mutations/changeLastName"
@@ -262,7 +262,11 @@ const WorkspaceSettings = ({ workspace, setIsOpen }) => {
                 setIsOpen(false)
               }}
             >
-              <Close32 className="h-4 w-4 fill-current pt-1 text-red-500" aria-hidden="true" />
+              <Close
+                size={32}
+                className="h-4 w-4 fill-current pt-1 text-red-500"
+                aria-hidden="true"
+              />
               Cancel
             </button>
           </div>
@@ -270,7 +274,8 @@ const WorkspaceSettings = ({ workspace, setIsOpen }) => {
             type="submit"
             className="mr-4 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
           >
-            <Checkmark32
+            <Checkmark
+              size={32}
               className="h-4 w-4 fill-current pt-1 text-emerald-500"
               aria-hidden="true"
             />

--- a/app/core/modals/DropdownNotificationModal.tsx
+++ b/app/core/modals/DropdownNotificationModal.tsx
@@ -1,5 +1,5 @@
 import { Listbox, Transition, Dialog } from "@headlessui/react"
-import { Close32, Menu32, NotificationNew32, Notification32 } from "@carbon/icons-react"
+import { Close, Menu, NotificationNew, Notification } from "@carbon/icons-react"
 
 import { Fragment, useState } from "react"
 import ResearchEqualsLogo from "../components/ResearchEqualsLogo"
@@ -22,12 +22,14 @@ const DropdownNotificationModal = ({ invitedModules }) => {
         <span className="inline-block h-full align-middle"></span>
 
         {invitedModules.length > 0 ? (
-          <NotificationNew32
+          <NotificationNew
+            size={32}
             className="inline-block h-6 w-6 stroke-current align-middle text-gray-400"
             aria-hidden="true"
           />
         ) : (
-          <Notification32
+          <Notification
+            size={32}
             className="inline-block h-6 w-6 stroke-current align-middle text-gray-400"
             aria-hidden="true"
           />
@@ -78,7 +80,7 @@ const DropdownNotificationModal = ({ invitedModules }) => {
                           }}
                         >
                           <span className="sr-only">Close menu</span>
-                          <Close32 className="h-6 w-6" aria-hidden="true" />
+                          <Close size={32} className="h-6 w-6" aria-hidden="true" />
                         </button>
                       </div>
                     </div>

--- a/app/core/modals/PublishModuleModal.tsx
+++ b/app/core/modals/PublishModuleModal.tsx
@@ -1,8 +1,8 @@
 import { Link, useMutation, useRouter } from "blitz"
 import { Fragment, useState } from "react"
 import { Dialog, Switch, Transition } from "@headlessui/react"
-import { CheckmarkOutline32 } from "@carbon/icons-react"
-import { Close32, Checkmark32 } from "@carbon/icons-react"
+import { CheckmarkOutline } from "@carbon/icons-react"
+import { Close, Checkmark } from "@carbon/icons-react"
 
 import publishModule from "../../modules/mutations/publishModule"
 import toast from "react-hot-toast"
@@ -32,7 +32,8 @@ export default function PublishModule({ module, user, workspace }) {
     <>
       <div className="my-4 flex w-full rounded-md bg-emerald-50 p-2 dark:bg-emerald-800">
         <div className="inline-block shrink-0 align-middle">
-          <CheckmarkOutline32
+          <CheckmarkOutline
+            size={32}
             className="inline-block h-5 w-5 stroke-current align-middle text-emerald-500 dark:text-emerald-200"
             aria-hidden="true"
           />
@@ -160,7 +161,10 @@ export default function PublishModule({ module, user, workspace }) {
                               )}
                               aria-hidden="true"
                             >
-                              <Close32 className="h-3 w-3 stroke-current stroke-2 text-gray-400" />
+                              <Close
+                                size={32}
+                                className="h-3 w-3 stroke-current stroke-2 text-gray-400"
+                              />
                             </span>
                             <span
                               className={classNames(
@@ -171,7 +175,10 @@ export default function PublishModule({ module, user, workspace }) {
                               )}
                               aria-hidden="true"
                             >
-                              <Checkmark32 className="h-3 w-3 stroke-current stroke-2 text-emerald-600" />
+                              <Checkmark
+                                size={32}
+                                className="h-3 w-3 stroke-current stroke-2 text-emerald-600"
+                              />
                             </span>
                           </span>
                         </Switch>

--- a/app/core/modals/delete.tsx
+++ b/app/core/modals/delete.tsx
@@ -3,7 +3,7 @@ import { Fragment, useState } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 
 import deleteUser from "app/users/mutations/deleteUser"
-import { TrashCan32 } from "@carbon/icons-react"
+import { TrashCan } from "@carbon/icons-react"
 
 export default function DeleteModal() {
   let [isOpen, setIsOpen] = useState(false)
@@ -35,7 +35,7 @@ export default function DeleteModal() {
             className="flex rounded-md bg-red-50 py-2 px-4 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
             onClick={openModal}
           >
-            <TrashCan32 className="h-5 w-5 fill-current text-red-500" aria-hidden="true" />
+            <TrashCan size={32} className="h-5 w-5 fill-current text-red-500" aria-hidden="true" />
             Delete
           </button>
         </div>

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -1,6 +1,6 @@
 import { Dialog, Transition, Tab } from "@headlessui/react"
 import { Fragment, useState } from "react"
-import { Close32 } from "@carbon/icons-react"
+import { Close } from "@carbon/icons-react"
 
 import WorkspaceSettings from "../components/WorkspaceSettings"
 import AccountSettings from "../components/AccountSettings"
@@ -91,7 +91,8 @@ export default function SettingsModal({ button, styling, user, workspace }) {
                         ))}
                         <button className="inline-flex items-center justify-center  rounded-md p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:text-gray-500 dark:hover:text-gray-300">
                           <span className="sr-only">Close menu</span>
-                          <Close32
+                          <Close
+                            size={32}
                             className="h-6 w-6"
                             aria-hidden="true"
                             onClick={() => {

--- a/app/modules/components/ChildPanel.tsx
+++ b/app/modules/components/ChildPanel.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { Link, Routes } from "blitz"
 import moment from "moment"
-import { Close32 } from "@carbon/icons-react"
+import { Close } from "@carbon/icons-react"
 import ModuleCard from "../../core/components/ModuleCard"
 
 const ChildPanel = ({ openObject, openFunction, module }) => {
@@ -37,7 +37,7 @@ const ChildPanel = ({ openObject, openFunction, module }) => {
                             onClick={() => openFunction(false)}
                           >
                             <span className="sr-only">Close panel</span>
-                            <Close32 className="h-6 w-6" aria-hidden="true" />
+                            <Close size={32} className="h-6 w-6" aria-hidden="true" />
                           </button>
                         </div>
                       </div>

--- a/app/modules/components/EditMainFile.jsx
+++ b/app/modules/components/EditMainFile.jsx
@@ -2,7 +2,7 @@ import { useMutation } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 import toast from "react-hot-toast"
-import { Add32 } from "@carbon/icons-react"
+import { Add } from "@carbon/icons-react"
 
 import addMain from "../mutations/addMain"
 import EditMainFileDisplay from "../../core/components/EditMainFileDisplay"
@@ -42,7 +42,7 @@ const EditMainFile = ({
               widgetApi.current.openDialog()
             }}
           >
-            <Add32 className="h-4 w-4" aria-hidden="true" /> Upload Main File
+            <Add size={32} className="h-4 w-4" aria-hidden="true" /> Upload Main File
             <Widget
               publicKey={process.env.UPLOADCARE_PUBLIC_KEY ?? ""}
               secureSignature={signature}

--- a/app/modules/components/EditSupportingFiles.jsx
+++ b/app/modules/components/EditSupportingFiles.jsx
@@ -2,7 +2,7 @@ import { useMutation } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 import toast from "react-hot-toast"
-import { Add32 } from "@carbon/icons-react"
+import { Add } from "@carbon/icons-react"
 
 import addSupporting from "../mutations/addSupporting"
 import getSupportingFiles from "../mutations/getSupportingFiles"
@@ -48,7 +48,7 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace, expire
               widgetApi.current.openDialog()
             }}
           >
-            <Add32 className="h-4 w-4" aria-hidden="true" /> Add Supporting File(s)
+            <Add size={32} className="h-4 w-4" aria-hidden="true" /> Add Supporting File(s)
             <Widget
               publicKey={process.env.UPLOADCARE_PUBLIC_KEY ?? ""}
               secureSignature={signature}

--- a/app/modules/components/HandlePanel.tsx
+++ b/app/modules/components/HandlePanel.tsx
@@ -4,7 +4,7 @@ import UnfollowButton from "app/workspaces/components/UnfollowButton"
 import getCurrentWorkspace from "app/workspaces/queries/getCurrentWorkspace"
 import { Link, Routes, useQuery } from "blitz"
 import { Fragment, useState } from "react"
-import { Close32 } from "@carbon/icons-react"
+import { Close } from "@carbon/icons-react"
 
 const AuthorPanel = ({ buttonText, title, authors, name }) => {
   const [openPanel, setPanelOpen] = useState(false)
@@ -48,7 +48,7 @@ const AuthorPanel = ({ buttonText, title, authors, name }) => {
                             onClick={() => setPanelOpen(false)}
                           >
                             <span className="sr-only">Close panel</span>
-                            <Close32 className="h-6 w-6" aria-hidden="true" />
+                            <Close size={32} className="h-6 w-6" aria-hidden="true" />
                           </button>
                         </div>
                       </div>

--- a/app/modules/components/ManageAuthors.tsx
+++ b/app/modules/components/ManageAuthors.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { useMutation } from "blitz"
-import { Checkmark32, Close32 } from "@carbon/icons-react"
+import { Checkmark, Close } from "@carbon/icons-react"
 
 import updateAuthorRank from "../../authorship/mutations/updateAuthorRank"
 import AuthorList from "../../core/components/AuthorList"
@@ -41,7 +41,7 @@ const ManageAuthors = ({ open, setOpen, moduleEdit, setQueryData }) => {
                           onClick={() => setOpen(false)}
                         >
                           <span className="sr-only">Close panel</span>
-                          <Close32 className="h-6 w-6" aria-hidden="true" />
+                          <Close size={32} className="h-6 w-6" aria-hidden="true" />
                         </button>
                       </div>
                     </div>
@@ -68,7 +68,8 @@ const ManageAuthors = ({ open, setOpen, moduleEdit, setQueryData }) => {
                         setOpen(false)
                       }}
                     >
-                      <Close32
+                      <Close
+                        size={32}
                         className="h-4 w-4 fill-current pt-1 text-red-500"
                         aria-hidden="true"
                       />
@@ -91,7 +92,8 @@ const ManageAuthors = ({ open, setOpen, moduleEdit, setQueryData }) => {
                         setOpen(false)
                       }}
                     >
-                      <Checkmark32
+                      <Checkmark
+                        size={32}
                         className="h-4 w-4 stroke-current pt-1 text-emerald-500"
                         aria-hidden="true"
                       />

--- a/app/modules/components/ManageParents.tsx
+++ b/app/modules/components/ManageParents.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { Link, Routes, useMutation } from "blitz"
-import { Checkmark32, Close32, TrashCan24 } from "@carbon/icons-react"
+import { Checkmark, Close, TrashCan } from "@carbon/icons-react"
 
 import ModuleCard from "app/core/components/ModuleCard"
 import moment from "moment"
@@ -41,7 +41,7 @@ const ManageParents = ({ open, setOpen, moduleEdit, setQueryData }) => {
                           onClick={() => setOpen(false)}
                         >
                           <span className="sr-only">Close panel</span>
-                          <Close32 className="h-6 w-6" aria-hidden="true" />
+                          <Close size={32} className="h-6 w-6" aria-hidden="true" />
                         </button>
                       </div>
                     </div>
@@ -99,7 +99,8 @@ const ManageParents = ({ open, setOpen, moduleEdit, setQueryData }) => {
                               )
                             }}
                           >
-                            <TrashCan24
+                            <TrashCan
+                              size={24}
                               className="inline-block h-4 w-4 fill-current align-middle text-red-500"
                               aria-hidden="true"
                             />
@@ -117,7 +118,8 @@ const ManageParents = ({ open, setOpen, moduleEdit, setQueryData }) => {
                         setOpen(false)
                       }}
                     >
-                      <Close32
+                      <Close
+                        size={32}
                         className="h-4 w-4 fill-current pt-1 text-red-500"
                         aria-hidden="true"
                       />
@@ -130,7 +132,8 @@ const ManageParents = ({ open, setOpen, moduleEdit, setQueryData }) => {
                         setOpen(false)
                       }}
                     >
-                      <Checkmark32
+                      <Checkmark
+                        size={32}
                         className="h-4 w-4 stroke-current pt-1 text-emerald-500"
                         aria-hidden="true"
                       />

--- a/app/modules/components/MetadataView.tsx
+++ b/app/modules/components/MetadataView.tsx
@@ -4,7 +4,7 @@ import moment from "moment"
 import toast from "react-hot-toast"
 import algoliasearch from "algoliasearch"
 import { getAlgoliaResults } from "@algolia/autocomplete-js"
-import { Add32 } from "@carbon/icons-react"
+import { Add } from "@carbon/icons-react"
 
 import addAuthor from "../mutations/addAuthor"
 import AuthorAvatarsNew from "./AuthorAvatarsNew"
@@ -155,7 +155,8 @@ const MetadataView = ({ module, addAuthors, setQueryData, setAddAuthors }) => {
                   setAddAuthors(true)
                 }}
               >
-                <Add32
+                <Add
+                  size={32}
                   className="h-4 w-4 fill-current text-gray-500 dark:text-gray-200 dark:hover:text-gray-400"
                   aria-hidden="true"
                 />

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -3,10 +3,10 @@ import { useState, useEffect } from "react"
 import algoliasearch from "algoliasearch"
 import { z } from "zod"
 import { getAlgoliaResults } from "@algolia/autocomplete-js"
-import { ArrowLeft32, Edit24, EditOff24 } from "@carbon/icons-react"
+import { ArrowLeft, Edit, EditOff } from "@carbon/icons-react"
 import { Prisma } from "prisma"
 import { useFormik } from "formik"
-import { WarningSquareFilled32, Maximize24, TrashCan24 } from "@carbon/icons-react"
+import { WarningSquareFilled, Maximize, TrashCan } from "@carbon/icons-react"
 import toast from "react-hot-toast"
 import Xarrows from "react-xarrows"
 
@@ -119,7 +119,8 @@ const ModuleEdit = ({
         <>
           <div className="my-4 flex w-full rounded-md bg-orange-50 p-2 dark:bg-orange-800">
             <div className="inline-block shrink-0 align-middle">
-              <WarningSquareFilled32
+              <WarningSquareFilled
+                size={32}
                 className="inline-block h-5 w-5 fill-current align-middle text-orange-500 dark:text-orange-200"
                 aria-hidden="true"
               />
@@ -199,7 +200,7 @@ const ModuleEdit = ({
             }}
           >
             <label className="sr-only">Go full screen</label>
-            <Maximize24 className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200" />
+            <Maximize size={24} className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200" />
           </button>
         ) : (
           <button
@@ -208,7 +209,8 @@ const ModuleEdit = ({
             }}
           >
             <label className="sr-only">Go full screen</label>
-            <ArrowLeft32
+            <ArrowLeft
+              size={32}
               className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
               aria-hidden="true"
             />
@@ -332,7 +334,8 @@ const ModuleEdit = ({
         </div>
         <div className="items-middle pt-8">
           {isEditing ? (
-            <EditOff24
+            <EditOff
+              size={24}
               className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
               onClick={() => {
                 setIsEditing(false)
@@ -340,7 +343,8 @@ const ModuleEdit = ({
               aria-label="End editing mode without saving"
             />
           ) : (
-            <Edit24
+            <Edit
+              size={24}
               className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
               onClick={() => {
                 setIsEditing(true)
@@ -553,7 +557,8 @@ const ModuleEdit = ({
               <>
                 <li>
                   <button className="mx-2">
-                    <TrashCan24
+                    <TrashCan
+                      size={24}
                       className="inline-block h-6 w-6 fill-current align-middle text-red-500"
                       onClick={async () => {
                         toast.promise(

--- a/app/modules/components/ModuleInvitation.tsx
+++ b/app/modules/components/ModuleInvitation.tsx
@@ -6,7 +6,7 @@ import Xarrows from "react-xarrows"
 
 import useCurrentModule from "../queries/useCurrentModule"
 import ViewFiles from "./ViewFiles"
-import { ArrowLeft32, Maximize24, UserFollow32 } from "@carbon/icons-react"
+import { ArrowLeft, Maximize, UserFollow } from "@carbon/icons-react"
 import acceptInvitation from "app/authorship/mutations/acceptInvitation"
 import removeInvitation from "app/authorship/mutations/removeInvitation"
 import MetadataInvite from "./MetadataInvite"
@@ -42,7 +42,8 @@ const ModuleInvitation = ({
       <div className="my-4 w-full rounded-md bg-blue-50 p-2 dark:bg-blue-800 lg:flex">
         <div className="my-2 flex flex-grow lg:my-0">
           <div className="inline-block shrink-0 align-middle">
-            <UserFollow32
+            <UserFollow
+              size={32}
               className="inline-block h-5 w-5 stroke-current align-middle text-blue-500 dark:text-blue-200"
               aria-hidden="true"
             />
@@ -107,7 +108,7 @@ const ModuleInvitation = ({
             }}
           >
             <label className="sr-only">Go full screen</label>
-            <Maximize24 className="h-6 w-6 fill-current text-gray-300 dark:text-gray-600" />
+            <Maximize size={24} className="h-6 w-6 fill-current text-gray-300 dark:text-gray-600" />
           </button>
         ) : (
           <button
@@ -116,7 +117,8 @@ const ModuleInvitation = ({
             }}
           >
             <label className="sr-only">Go full screen</label>
-            <ArrowLeft32
+            <ArrowLeft
+              size={32}
               className="h-6 w-6 fill-current text-gray-300 dark:text-gray-600"
               aria-hidden="true"
             />

--- a/app/modules/components/ParentPanel.tsx
+++ b/app/modules/components/ParentPanel.tsx
@@ -2,7 +2,7 @@ import { Fragment, useState } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { Link, Routes } from "blitz"
 import moment from "moment"
-import { Close32 } from "@carbon/icons-react"
+import { Close } from "@carbon/icons-react"
 import ModuleCard from "../../core/components/ModuleCard"
 
 const ParentPanel = ({ openObject, openFunction, module }) => {
@@ -37,7 +37,7 @@ const ParentPanel = ({ openObject, openFunction, module }) => {
                             onClick={() => openFunction(false)}
                           >
                             <span className="sr-only">Close panel</span>
-                            <Close32 className="h-6 w-6" aria-hidden="true" />
+                            <Close size={32} className="h-6 w-6" aria-hidden="true" />
                           </button>
                         </div>
                       </div>

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -5,7 +5,7 @@ import { Link, useMutation, useQuery, validateZodSchema, useRouter } from "blitz
 import { useFormik } from "formik"
 import { Fragment, useState } from "react"
 import { z } from "zod"
-import { Checkmark32, Close32, InformationSquareFilled32 } from "@carbon/icons-react"
+import { Checkmark, Close, InformationSquareFilled } from "@carbon/icons-react"
 
 import createModule from "../mutations/createModule"
 import toast from "react-hot-toast"
@@ -129,7 +129,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                               onClick={() => setCreateOpen(false)}
                             >
                               <span className="sr-only">Close panel</span>
-                              <Close32 className="h-6 w-6" aria-hidden="true" />
+                              <Close size={32} className="h-6 w-6" aria-hidden="true" />
                             </button>
                           </div>
                         </div>
@@ -223,7 +223,10 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                             License{" "}
                             <Link href="https://creativecommons.org/about/cclicenses">
                               <a target="_blank">
-                                <InformationSquareFilled32 className="h-5 w-5 fill-current text-gray-700 dark:text-gray-200" />
+                                <InformationSquareFilled
+                                  size={32}
+                                  className="h-5 w-5 fill-current text-gray-700 dark:text-gray-200"
+                                />
                               </a>
                             </Link>
                             {formik.touched.license && formik.errors.license ? (
@@ -321,7 +324,8 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                           formikReset()
                         }}
                       >
-                        <Close32
+                        <Close
+                          size={32}
                           className="h-4 w-4 fill-current pt-1 text-red-500"
                           aria-hidden="true"
                         />
@@ -331,7 +335,8 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                         type="submit"
                         className="flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                       >
-                        <Checkmark32
+                        <Checkmark
+                          size={32}
                           className="h-4 w-4 fill-current pt-1 text-emerald-500"
                           aria-hidden="true"
                         />

--- a/app/modules/components/ViewAuthors.tsx
+++ b/app/modules/components/ViewAuthors.tsx
@@ -3,7 +3,7 @@ import { Dialog, Transition } from "@headlessui/react"
 import { Link, Routes, useQuery } from "blitz"
 import FollowButton from "app/workspaces/components/FollowButton"
 import UnfollowButton from "app/workspaces/components/UnfollowButton"
-import { Close32 } from "@carbon/icons-react"
+import { Close } from "@carbon/icons-react"
 
 import getCurrentWorkspace from "../../workspaces/queries/getCurrentWorkspace"
 
@@ -51,7 +51,7 @@ const ViewAuthors = ({ button, module }) => {
                             onClick={() => setViewAuthorsOpen(false)}
                           >
                             <span className="sr-only">Close panel</span>
-                            <Close32 className="h-6 w-6" aria-hidden="true" />
+                            <Close size={32} className="h-6 w-6" aria-hidden="true" />
                           </button>
                         </div>
                       </div>

--- a/app/modules/components/ViewFiles.tsx
+++ b/app/modules/components/ViewFiles.tsx
@@ -1,4 +1,4 @@
-import { Download24 } from "@carbon/icons-react"
+import { Download } from "@carbon/icons-react"
 import filesize from "filesize"
 
 const ViewFiles = ({ name, size, url }) => {
@@ -17,7 +17,10 @@ const ViewFiles = ({ name, size, url }) => {
       </a>
       <p className="flex">
         <a href={url} target="_blank" download rel="noreferrer">
-          <Download24 className="inline-block h-6 w-6 fill-current align-middle text-gray-900 dark:text-gray-200" />
+          <Download
+            size={24}
+            className="inline-block h-6 w-6 fill-current align-middle text-gray-900 dark:text-gray-200"
+          />
         </a>
       </p>
     </div>

--- a/app/modules/components/ViewFollowers.tsx
+++ b/app/modules/components/ViewFollowers.tsx
@@ -3,7 +3,7 @@ import { Dialog, Transition } from "@headlessui/react"
 import { Link, Routes, useQuery } from "blitz"
 import FollowButton from "app/workspaces/components/FollowButton"
 import UnfollowButton from "app/workspaces/components/UnfollowButton"
-import { Close32 } from "@carbon/icons-react"
+import { Close } from "@carbon/icons-react"
 
 const ViewFollowers = ({
   viewAuthorsOpen,
@@ -43,7 +43,7 @@ const ViewFollowers = ({
                             onClick={() => setViewAuthorsOpen(false)}
                           >
                             <span className="sr-only">Close panel</span>
-                            <Close32 className="h-6 w-6" aria-hidden="true" />
+                            <Close size={32} className="h-6 w-6" aria-hidden="true" />
                           </button>
                         </div>
                       </div>

--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -3,7 +3,7 @@ import db from "db"
 import { Link, useRouter, usePaginatedQuery, useParams, useQuery, useSession } from "blitz"
 import { Suspense } from "react"
 import moment from "moment"
-import { Calendar32, UserFollow32, Link32 } from "@carbon/icons-react"
+import { Calendar, UserFollow, Link as Link32 } from "@carbon/icons-react"
 
 import Navbar from "../core/components/Navbar"
 import getHandleFeed from "../workspaces/queries/getHandleFeed"
@@ -119,7 +119,8 @@ const Handle = ({ workspace, expire, signature }) => {
               <p className="flex text-sm font-normal leading-4 text-gray-500 dark:text-gray-200">
                 <p>
                   <span className="inline-block h-full align-middle"> </span>
-                  <Calendar32
+                  <Calendar
+                    size={32}
                     className="mr-1 inline-block h-4 w-4 align-middle text-gray-700 dark:text-gray-400"
                     aria-hidden="true"
                   />
@@ -157,6 +158,7 @@ const Handle = ({ workspace, expire, signature }) => {
                   <p>
                     <span className="inline-block h-full align-middle"> </span>
                     <Link32
+                      size={32}
                       className="mr-1 inline-block h-4 w-4 align-middle text-gray-700 dark:text-gray-400"
                       aria-hidden="true"
                     />
@@ -179,7 +181,8 @@ const Handle = ({ workspace, expire, signature }) => {
                     <p className="flex text-sm font-normal leading-4 text-gray-500 underline dark:text-gray-200">
                       <p>
                         <span className="inline-block h-full align-middle"> </span>
-                        <UserFollow32
+                        <UserFollow
+                          size={32}
                           className="mr-1 inline-block h-4 w-4 align-middle text-gray-700 dark:text-gray-400"
                           aria-hidden="true"
                         />

--- a/app/pages/coc.tsx
+++ b/app/pages/coc.tsx
@@ -1,6 +1,6 @@
 import { BlitzPage, Link, useQuery, useRouter, useSession } from "blitz"
 import Layout from "app/core/layouts/Layout"
-import { SendAltFilled32 } from "@carbon/icons-react"
+import { SendAltFilled } from "@carbon/icons-react"
 import Markdown from "markdown-it"
 
 import Navbar from "../core/components/Navbar"
@@ -197,7 +197,8 @@ const CodeOfConduct: BlitzPage = () => {
           <div className="onboarding my-2 flex w-full flex-col rounded-r border-l-4 border-amber-400 bg-amber-50 p-4 dark:border-amber-200 dark:bg-amber-900 lg:my-0">
             <div className="flex flex-grow">
               <div className="">
-                <SendAltFilled32
+                <SendAltFilled
+                  size={32}
                   className="h-5 w-5 text-amber-400 dark:text-amber-200"
                   aria-hidden="true"
                 />

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -10,7 +10,7 @@ import {
 import Layout from "app/core/layouts/Layout"
 import React, { useEffect, useState } from "react"
 import toast from "react-hot-toast"
-import { ArrowUp32, ArrowDown32 } from "@carbon/icons-react"
+import { ArrowUp, ArrowDown } from "@carbon/icons-react"
 
 import getDashboardData from "../core/queries/getDashboardData"
 import Navbar from "../core/components/Navbar"
@@ -145,12 +145,14 @@ const DashboardContent = ({
                                 )}
                               >
                                 {item.change > 0 ? (
-                                  <ArrowUp32
+                                  <ArrowUp
+                                    size={32}
                                     className="h-5 w-5 shrink-0 self-center text-emerald-500"
                                     aria-hidden="true"
                                   />
                                 ) : (
-                                  <ArrowDown32
+                                  <ArrowDown
+                                    size={32}
                                     className="h-5 w-5 shrink-0 self-center text-red-500"
                                     aria-hidden="true"
                                   />
@@ -192,12 +194,14 @@ const DashboardContent = ({
                                   )}
                                 >
                                   {item.change > 0 ? (
-                                    <ArrowUp32
+                                    <ArrowUp
+                                      size={32}
                                       className="h-5 w-5 shrink-0 self-center text-emerald-500"
                                       aria-hidden="true"
                                     />
                                   ) : (
-                                    <ArrowDown32
+                                    <ArrowDown
+                                      size={32}
                                       className="h-5 w-5 shrink-0 self-center text-red-500"
                                       aria-hidden="true"
                                     />

--- a/app/pages/drafts.tsx
+++ b/app/pages/drafts.tsx
@@ -1,7 +1,6 @@
 import { useSession, useQuery, useRouterQuery, Router, useRouter } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { Suspense, useEffect, useState } from "react"
-import { ProgressBarRound32 } from "@carbon/icons-react"
 import moment from "moment"
 
 import Navbar from "../core/components/Navbar"

--- a/app/pages/graph.jsx
+++ b/app/pages/graph.jsx
@@ -11,7 +11,7 @@ import ReactFlow, {
 } from "react-flow-renderer"
 import dagre from "dagre"
 import { useMediaPredicate } from "react-media-hook"
-import { Connect16 } from "@carbon/icons-react"
+import { Connect } from "@carbon/icons-react"
 
 import LayoutLoader from "../core/components/LayoutLoader"
 import { useCurrentUser } from "app/core/hooks/useCurrentUser"
@@ -132,7 +132,7 @@ const Graph = () => {
               title="toggle connected view"
               aria-label="toggle view to show only connected modules or all modules"
             >
-              <Connect16 className={`${onlyConnected ? "rotate-180" : ""}`} />
+              <Connect size={16} className={`${onlyConnected ? "rotate-180" : ""}`} />
             </button>
           </Controls>
           <Background />

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -10,19 +10,19 @@ import {
 } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import {
-  CurrencyEuro32,
-  Save32,
-  Checkmark24,
-  Favorite32,
-  CircleStrokeGlyph,
-  TableSplit32,
-  Terminal32,
-  Language32,
-  Alarm32,
-  Events32,
-  TextAlignLeft32,
-  Video32,
-  CircleFillGlyph,
+  CurrencyEuro,
+  Save,
+  Checkmark,
+  Favorite,
+  CircleStroke,
+  TableSplit,
+  Terminal,
+  Language,
+  Alarm,
+  Events,
+  TextAlignLeft,
+  Video,
+  CircleFill,
 } from "@carbon/icons-react"
 import Xarrows from "react-xarrows"
 import { useMediaPredicate } from "react-media-hook"
@@ -35,7 +35,6 @@ import { useCurrentUser } from "app/core/hooks/useCurrentUser"
 import { useCurrentWorkspace } from "app/core/hooks/useCurrentWorkspace"
 import getDrafts from "app/core/queries/getDrafts"
 import getInvitedModules from "app/workspaces/queries/getInvitedModules"
-import { useRef } from "react"
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const licenses = await db.license.findMany({
@@ -125,7 +124,7 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                       className="module h-28 w-28 bg-pink-600 text-center text-white md:h-28  md:w-28"
                     >
                       <span className="inline-block h-full align-middle"></span>
-                      <CircleStrokeGlyph
+                      <CircleStroke
                         id="step-1-button"
                         className="justify-middle inline-block h-6 w-6 fill-current stroke-current stroke-2 align-middle text-white"
                       />
@@ -139,7 +138,7 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                       className="module h-28 w-28 bg-indigo-600 text-center text-white md:h-28  md:w-28"
                     >
                       <span className="inline-block h-full align-middle"></span>
-                      <CircleFillGlyph
+                      <CircleFill
                         id="step-2-button"
                         className="justify-middle inline-block h-6 w-6 fill-current stroke-current stroke-2 align-middle text-white"
                       />
@@ -150,7 +149,7 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                       className="module h-28 w-28 bg-emerald-600 text-center text-white md:h-28  md:w-28"
                     >
                       <span className="inline-block h-full align-middle"></span>
-                      <CircleFillGlyph
+                      <CircleFill
                         id="step-3-button"
                         className="justify-middle inline-block h-6 w-6 fill-current stroke-current stroke-2 align-middle text-white"
                       />
@@ -277,7 +276,8 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
           <div className="flex">
             <div className="relative hidden text-center sm:inline">
               <div className="grid h-full w-full grid-cols-3 gap-8 fill-current  text-center text-gray-900 dark:text-white">
-                <Terminal32
+                <Terminal
+                  size={32}
                   data-tip
                   data-for="codeTip"
                   id="code-module"
@@ -289,7 +289,8 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                 <div></div>
                 <div></div>
                 <div></div>
-                <TextAlignLeft32
+                <TextAlignLeft
+                  size={32}
                   data-tip
                   data-for="textTip"
                   id="text-module"
@@ -299,14 +300,21 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                   Text
                 </ReactTooltip>
                 <div></div>
-                <Video32 data-tip data-for="videoTip" id="video-module" className="opacity-40" />
+                <Video
+                  size={32}
+                  data-tip
+                  data-for="videoTip"
+                  id="video-module"
+                  className="opacity-40"
+                />
                 <ReactTooltip id="videoTip" place="top" effect="solid">
                   Video
                 </ReactTooltip>
                 <div></div>
                 <div></div>
                 <div></div>
-                <TableSplit32
+                <TableSplit
+                  size={32}
                   data-tip
                   data-for="tableTip"
                   id="data-module"
@@ -359,13 +367,17 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                   </h2>
                   <p className="my-2 flex text-lg">
                     We{" "}
-                    <Favorite32 className="mx-2 h-6 w-6 fill-current stroke-current stroke-2 text-white" />{" "}
+                    <Favorite
+                      size={32}
+                      className="mx-2 h-6 w-6 fill-current stroke-current stroke-2 text-white"
+                    />{" "}
                     open access, so we made it free.
                   </p>
                   <ul role="list" className="my-4 space-y-4">
                     {freeLicenses.map((license) => (
                       <li key={license.id} className="flex space-x-3 text-lg">
-                        <Checkmark24
+                        <Checkmark
+                          size={24}
                           className="h-6 w-6 shrink-0 fill-current stroke-current stroke-2 text-white"
                           aria-hidden="true"
                         />
@@ -393,7 +405,8 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                   <ul role="list" className="my-4 space-y-4">
                     {payToClose.map((license) => (
                       <li className="flex space-x-3 text-lg" key={license.id}>
-                        <CurrencyEuro32
+                        <CurrencyEuro
+                          size={32}
                           className="h-6 w-6 shrink-0 fill-current stroke-current stroke-2 text-white"
                           aria-hidden="true"
                         />
@@ -420,28 +433,32 @@ const Home: BlitzPage = ({ licenses }: InferGetStaticPropsType<typeof getStaticP
                 <div className="flex-grow"></div>
                 <div className="">
                   <div className="mr-4 flex space-x-3 text-lg">
-                    <Language32
+                    <Language
+                      size={32}
                       className=" mr-2 h-6 w-6 shrink-0 fill-current text-white"
                       aria-hidden="true"
                     />
                     Your language
                   </div>
                   <div className="mr-4 flex space-x-3 text-lg">
-                    <Alarm32
+                    <Alarm
+                      size={32}
                       className=" mr-2 h-6 w-6 shrink-0 fill-current text-white"
                       aria-hidden="true"
                     />
                     Your timeline
                   </div>
                   <div className="mr-4 flex space-x-3 text-lg">
-                    <Events32
+                    <Events
+                      size={32}
                       className=" mr-2 h-6 w-6 shrink-0 fill-current text-white"
                       aria-hidden="true"
                     />
                     Your co-authors
                   </div>
                   <div className="mr-4 flex space-x-3 text-lg">
-                    <Save32
+                    <Save
+                      size={32}
                       className=" mr-2 h-6 w-6 shrink-0 fill-current text-white"
                       aria-hidden="true"
                     />

--- a/app/pages/invitations.tsx
+++ b/app/pages/invitations.tsx
@@ -1,7 +1,7 @@
 import { BlitzPage, useSession, useQuery, useRouterQuery, Router, useRouter } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { Suspense, useEffect, useState } from "react"
-import { ProgressBarRound32 } from "@carbon/icons-react"
+import { ProgressBarRound } from "@carbon/icons-react"
 import moment from "moment"
 
 import Navbar from "../core/components/Navbar"
@@ -79,7 +79,10 @@ const Invitations = ({ currentWorkspace }) => {
               <Suspense
                 fallback={
                   <div className="mx-auto my-auto">
-                    <ProgressBarRound32 className="animate-spin text-white dark:text-white" />
+                    <ProgressBarRound
+                      size={32}
+                      className="animate-spin text-white dark:text-white"
+                    />
                   </div>
                 }
               >

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -1,6 +1,6 @@
 import { Prisma } from "prisma"
 import { Link, NotFoundError, Routes, useMutation, useQuery, useRouter, useSession } from "blitz"
-import { AddAlt32, NextFilled32, PreviousFilled32 } from "@carbon/icons-react"
+import { AddAlt, NextFilled, PreviousFilled } from "@carbon/icons-react"
 import Xarrows from "react-xarrows"
 import { useEffect, useState } from "react"
 import Helmet from "react-helmet"
@@ -151,7 +151,8 @@ const Module = ({ module, mainFile, supportingRaw }) => {
               setPreviousOpen(true)
             }}
           >
-            <PreviousFilled32
+            <PreviousFilled
+              size={32}
               className="h-10 w-10 rounded-full bg-white dark:bg-gray-900 "
               id="modulePrevious"
             />
@@ -177,7 +178,10 @@ const Module = ({ module, mainFile, supportingRaw }) => {
               setPreviousOpen(true)
             }}
           >
-            <PreviousFilled32 className="h-10 w-10 rounded-full bg-white dark:bg-gray-900 " />
+            <PreviousFilled
+              size={32}
+              className="h-10 w-10 rounded-full bg-white dark:bg-gray-900 "
+            />
           </button>
         ) : (
           ""
@@ -193,7 +197,8 @@ const Module = ({ module, mainFile, supportingRaw }) => {
                 setLeadsToOpen(true)
               }}
             >
-              <NextFilled32
+              <NextFilled
+                size={32}
                 className="h-10 w-10 rounded-full bg-white dark:bg-gray-900"
                 id="moduleNext"
               />
@@ -244,7 +249,11 @@ const Module = ({ module, mainFile, supportingRaw }) => {
           }}
           className={`${(previousOpen || leadsToOpen) && !biggerWindow ? "hidden" : "inline"}`}
         >
-          <AddAlt32 className="h-10 w-10 rounded-full bg-white dark:bg-gray-900 " id="moduleAdd" />
+          <AddAlt
+            size={32}
+            className="h-10 w-10 rounded-full bg-white dark:bg-gray-900 "
+            id="moduleAdd"
+          />
         </button>
 
         <Xarrows

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@algolia/autocomplete-js": "1.5.2",
-        "@carbon/icons-react": "10.45.0",
+        "@carbon/icons-react": "11.3.0",
         "@faker-js/faker": "6.0.0-alpha.6",
         "@floating-ui/dom": "0.2.0",
         "@headlessui/react": "1.4.3",
@@ -1273,18 +1273,18 @@
       }
     },
     "node_modules/@carbon/icon-helpers": {
-      "version": "10.26.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.26.0.tgz",
-      "integrity": "sha512-zrWRGn40whcKddYlj9MFsPMWwM5sLK2yfYpUbqKv2QFxlMyT60d/4Jd+yS81JVSQ39JO3vvlfb+Vl93O5Zl+dw=="
+      "version": "10.30.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.30.0.tgz",
+      "integrity": "sha512-K+wvv1H9ey/5L30QTZAd2r2UnoAfDABDT9Xv2e5GWstw+uK7HEnoog6etFt0/ADU7KKRGmxq9mkJFGykASzPRA=="
     },
     "node_modules/@carbon/icons-react": {
-      "version": "10.45.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-10.45.0.tgz",
-      "integrity": "sha512-bQfAxq19VnNkvaqYvBtF1H1WrINQK0JCA0wR0t8YLDPuC+WmlOPAyJIkAGlYukFJuHVP4p+CpSWIO6+/8PXsqw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-11.3.0.tgz",
+      "integrity": "sha512-7mh/uUvKFTbWXD9QzrWApXuPe27WvWCEqwIp6wtfZRfceQrdCAgMBryVIxkTUG75JhWIzp6pepFead3URRGefw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@carbon/icon-helpers": "^10.26.0",
-        "@carbon/telemetry": "0.0.0-alpha.6",
+        "@carbon/icon-helpers": "^10.30.0-rc.0",
+        "@carbon/telemetry": "0.1.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -1292,65 +1292,11 @@
       }
     },
     "node_modules/@carbon/telemetry": {
-      "version": "0.0.0-alpha.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/parser": "^7.12.5",
-        "@babel/traverse": "^7.12.5",
-        "ci-info": "^2.0.0",
-        "configstore": "^5.0.1",
-        "fast-glob": "^3.2.4",
-        "fs-extra": "^9.0.1",
-        "got": "^11.8.0",
-        "semver": "^7.3.2",
-        "winston": "^3.3.3",
-        "yargs": "^16.1.1"
-      },
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.1.0.tgz",
+      "integrity": "sha512-kNWt0bkgPwGW0i5h7HFuljbKRXPvIhsKbB+1tEURAYLXoJg9iJLF1eGvWN5iVoFCS2zje4GR3OGOsvvKVe7Hlg==",
       "bin": {
         "carbon-telemetry": "bin/carbon-telemetry.js"
-      }
-    },
-    "node_modules/@carbon/telemetry/node_modules/ci-info": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
-    "node_modules/@carbon/telemetry/node_modules/cliui": {
-      "version": "7.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/@carbon/telemetry/node_modules/y18n": {
-      "version": "5.0.8",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@carbon/telemetry/node_modules/yargs": {
-      "version": "16.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@carbon/telemetry/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@chevrotain/types": {
@@ -1375,15 +1321,6 @@
       },
       "engines": {
         "node": ">=0.1.95"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
       }
     },
     "node_modules/@datadog/native-metrics": {
@@ -6109,14 +6046,6 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/color-string": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -6128,33 +6057,6 @@
       "engines": {
         "node": ">=0.1.90"
       }
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "color": "3.0.x",
-        "text-hex": "1.0.x"
-      }
-    },
-    "node_modules/colorspace/node_modules/color": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
-      }
-    },
-    "node_modules/colorspace/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/colorspace/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6320,31 +6222,6 @@
     "node_modules/conditional-type-checks": {
       "version": "1.0.5",
       "license": "MIT"
-    },
-    "node_modules/configstore": {
-      "version": "5.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/configstore/node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -7472,23 +7349,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dot-prop/node_modules/is-obj": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dotenv": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-15.0.0.tgz",
@@ -7599,10 +7459,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -8904,10 +8760,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.1",
-      "license": "MIT"
-    },
     "node_modules/fengari": {
       "version": "0.1.4",
       "license": "MIT",
@@ -9176,10 +9028,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.14.7",
@@ -12313,10 +12161,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -12840,17 +12684,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/logform": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "colors": "^1.2.1",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^1.1.0",
-        "triple-beam": "^1.3.0"
       }
     },
     "node_modules/long": {
@@ -15056,13 +14889,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -17550,10 +17376,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -18034,17 +17856,6 @@
       "version": "3.0.3",
       "license": "ISC"
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "license": "MIT"
-    },
     "node_modules/simple-wcswidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
@@ -18326,13 +18137,6 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.3",
@@ -19073,10 +18877,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "license": "MIT"
@@ -19247,10 +19047,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.3.0",
-      "license": "MIT"
     },
     "node_modules/trough": {
       "version": "2.1.0",
@@ -20290,59 +20086,6 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/winston": {
-      "version": "3.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.1.0",
-        "is-stream": "^2.0.0",
-        "logform": "^2.2.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.0"
-      },
-      "engines": {
-        "node": ">= 6.4.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.7",
-        "triple-beam": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.4.0"
-      }
-    },
-    "node_modules/winston-transport/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/winston-transport/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/winston-transport/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "license": "MIT",
@@ -20397,13 +20140,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/xml-js": {
@@ -21499,65 +21235,24 @@
       }
     },
     "@carbon/icon-helpers": {
-      "version": "10.26.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.26.0.tgz",
-      "integrity": "sha512-zrWRGn40whcKddYlj9MFsPMWwM5sLK2yfYpUbqKv2QFxlMyT60d/4Jd+yS81JVSQ39JO3vvlfb+Vl93O5Zl+dw=="
+      "version": "10.30.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.30.0.tgz",
+      "integrity": "sha512-K+wvv1H9ey/5L30QTZAd2r2UnoAfDABDT9Xv2e5GWstw+uK7HEnoog6etFt0/ADU7KKRGmxq9mkJFGykASzPRA=="
     },
     "@carbon/icons-react": {
-      "version": "10.45.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-10.45.0.tgz",
-      "integrity": "sha512-bQfAxq19VnNkvaqYvBtF1H1WrINQK0JCA0wR0t8YLDPuC+WmlOPAyJIkAGlYukFJuHVP4p+CpSWIO6+/8PXsqw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-11.3.0.tgz",
+      "integrity": "sha512-7mh/uUvKFTbWXD9QzrWApXuPe27WvWCEqwIp6wtfZRfceQrdCAgMBryVIxkTUG75JhWIzp6pepFead3URRGefw==",
       "requires": {
-        "@carbon/icon-helpers": "^10.26.0",
-        "@carbon/telemetry": "0.0.0-alpha.6",
+        "@carbon/icon-helpers": "^10.30.0-rc.0",
+        "@carbon/telemetry": "0.1.0",
         "prop-types": "^15.7.2"
       }
     },
     "@carbon/telemetry": {
-      "version": "0.0.0-alpha.6",
-      "requires": {
-        "@babel/parser": "^7.12.5",
-        "@babel/traverse": "^7.12.5",
-        "ci-info": "^2.0.0",
-        "configstore": "^5.0.1",
-        "fast-glob": "^3.2.4",
-        "fs-extra": "^9.0.1",
-        "got": "^11.8.0",
-        "semver": "^7.3.2",
-        "winston": "^3.3.3",
-        "yargs": "^16.1.1"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "2.0.0"
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8"
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9"
-        }
-      }
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.1.0.tgz",
+      "integrity": "sha512-kNWt0bkgPwGW0i5h7HFuljbKRXPvIhsKbB+1tEURAYLXoJg9iJLF1eGvWN5iVoFCS2zje4GR3OGOsvvKVe7Hlg=="
     },
     "@chevrotain/types": {
       "version": "9.1.0",
@@ -21574,14 +21269,6 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
-      }
-    },
-    "@dabh/diagnostics": {
-      "version": "2.0.2",
-      "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
       }
     },
     "@datadog/native-metrics": {
@@ -25139,13 +24826,6 @@
     "color-name": {
       "version": "1.1.4"
     },
-    "color-string": {
-      "version": "1.6.0",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -25153,31 +24833,6 @@
     },
     "colors": {
       "version": "1.4.0"
-    },
-    "colorspace": {
-      "version": "1.1.2",
-      "requires": {
-        "color": "3.0.x",
-        "text-hex": "1.0.x"
-      },
-      "dependencies": {
-        "color": {
-          "version": "3.0.0",
-          "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3"
-        }
-      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -25300,28 +24955,6 @@
     },
     "conditional-type-checks": {
       "version": "1.0.5"
-    },
-    "configstore": {
-      "version": "5.0.1",
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "dependencies": {
-        "write-file-atomic": {
-          "version": "3.0.3",
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
-        }
-      }
     },
     "connect": {
       "version": "3.7.0",
@@ -26125,17 +25758,6 @@
         }
       }
     },
-    "dot-prop": {
-      "version": "5.3.0",
-      "requires": {
-        "is-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-obj": {
-          "version": "2.0.0"
-        }
-      }
-    },
     "dotenv": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-15.0.0.tgz",
@@ -26223,9 +25845,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
-    },
-    "enabled": {
-      "version": "2.0.0"
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -27176,9 +26795,6 @@
         "bser": "2.1.1"
       }
     },
-    "fecha": {
-      "version": "4.2.1"
-    },
     "fengari": {
       "version": "0.1.4",
       "requires": {
@@ -27379,9 +26995,6 @@
       "version": "0.171.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.171.0.tgz",
       "integrity": "sha512-cqEsgic6HH81Pz0IQLeyuoh0O8Y7ECAIdZ0idPQ9P1jZ/kHB9KK0hwqnjVtqTGog15JURkIxvyXm+9pAb6uuSQ=="
-    },
-    "fn.name": {
-      "version": "1.1.0"
     },
     "follow-redirects": {
       "version": "1.14.7",
@@ -29488,9 +29101,6 @@
     "koalas": {
       "version": "1.0.2"
     },
-    "kuler": {
-      "version": "2.0.0"
-    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -29883,16 +29493,6 @@
             "strip-ansi": "^6.0.0"
           }
         }
-      }
-    },
-    "logform": {
-      "version": "2.3.0",
-      "requires": {
-        "colors": "^1.2.1",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^1.1.0",
-        "triple-beam": "^1.3.0"
       }
     },
     "long": {
@@ -31402,12 +31002,6 @@
       "version": "1.4.0",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "one-time": {
-      "version": "1.0.0",
-      "requires": {
-        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -33082,9 +32676,6 @@
         }
       }
     },
-    "safe-stable-stringify": {
-      "version": "1.1.1"
-    },
     "safer-buffer": {
       "version": "2.1.2"
     },
@@ -33435,17 +33026,6 @@
     "signal-exit": {
       "version": "3.0.3"
     },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2"
-        }
-      }
-    },
     "simple-wcswidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
@@ -33647,9 +33227,6 @@
     },
     "sprintf-js": {
       "version": "1.0.3"
-    },
-    "stack-trace": {
-      "version": "0.0.10"
     },
     "stack-utils": {
       "version": "2.0.3",
@@ -34183,9 +33760,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "text-hex": {
-      "version": "1.0.0"
-    },
     "text-table": {
       "version": "0.2.0"
     },
@@ -34307,9 +33881,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
       "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
-    },
-    "triple-beam": {
-      "version": "1.3.0"
     },
     "trough": {
       "version": "2.1.0",
@@ -35030,50 +34601,6 @@
         }
       }
     },
-    "winston": {
-      "version": "3.3.3",
-      "requires": {
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.1.0",
-        "is-stream": "^2.0.0",
-        "logform": "^2.2.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.0"
-      }
-    },
-    "winston-transport": {
-      "version": "4.4.0",
-      "requires": {
-        "readable-stream": "^2.3.7",
-        "triple-beam": "^1.2.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2"
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "word-wrap": {
       "version": "1.2.3"
     },
@@ -35102,9 +34629,6 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
-    },
-    "xdg-basedir": {
-      "version": "4.0.0"
     },
     "xml-js": {
       "version": "1.6.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.5.2",
-    "@carbon/icons-react": "10.45.0",
+    "@carbon/icons-react": "11.3.0",
     "@faker-js/faker": "6.0.0-alpha.6",
     "@floating-ui/dom": "0.2.0",
     "@headlessui/react": "1.4.3",


### PR DESCRIPTION
This PR upgrades `@carbon/icons-react` to `v11`. 

This was a bit of a pain to upgrade, because it introduced minor but breaking changes that were not documented on the [repository itself](https://github.com/carbon-design-system/carbon). Had to dig a bit to find the details [here](https://carbondesignsystem.com/migrating/guide/develop/#@carbonicons-react).

It should work fine now and be good to go for a while again.

PS: Specifically annoying was that they renamed one component to `Link` that conflicts with other declarations...