### PR TITLE
Add basic rendering of office files

### DIFF
--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -318,6 +318,21 @@ const Module = ({ module, mainFile, supportingRaw }) => {
             ) : (
               ""
             )}
+            {/* Preview Office files */}
+            {mainFile.mimeType === "application/vnd.ms-excel" ||
+            mainFile.mimeType ===
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+            mainFile.mimeType ===
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ? (
+              <iframe
+                src={`https://view.officeapps.live.com/op/embed.aspx?src=${mainFile.cdnUrl}`}
+                width="100%"
+                height="800px"
+                frameBorder="0"
+              ></iframe>
+            ) : (
+              ""
+            )}
           </div>
         ) : (
           ""


### PR DESCRIPTION
This PR adds basic rendering of office files using the Microsoft Office Viewer.

At the moment this adds the rendering of spreadsheets and word files - which is helpful in terms of content consumption.

![Screenshot 2022-05-17 at 17 20 00](https://user-images.githubusercontent.com/2946344/168847503-0a1422bb-1f73-4fce-b3ab-2c8d56e8b91e.png)
![Screenshot 2022-05-17 at 17 20 36](https://user-images.githubusercontent.com/2946344/168847614-d40d119d-e43b-43c7-bd8d-5728287c2ced.png)

We could also still add Powerpoint previewer, but nobody has published that yet 😊 


