### PR TITLE
Migrate Quirrel to self-hosted

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -57,6 +57,13 @@
             "QUIRREL_ENCRYPTION_SECRET": {
               "fromParameterStore": "QUIRREL_ENCRYPTION_SECRET"
             },
+            "QUIRREL_MIGRATE_OLD_API_URL": "api.quirrel.dev",
+            "QUIRREL_API_URL": {
+              "fromParameterStore": "QUIRREL_API_URL"
+            },
+            "QUIRREL_MIGRATE_OLD_TOKEN": {
+              "fromParameterStore": "QUIRREL_MIGRATE_OLD_TOKEN"
+            },
             "QUIRREL_TOKEN": {
               "fromParameterStore": "QUIRREL_TOKEN"
             },


### PR DESCRIPTION
This PR handles the environment variable changes for the Quirrel migration.

Quirrel is stopping their services soon, so migrating to our own deployed version is necessary. See also [the docs for doing so](https://docs.quirrel.dev/migrating-servers/) and [the original announcement](https://dev.to/quirrel/quirrel-is-acquired-and-i-am-joining-netlify-dha). Thanks to @skn0tt for providing such a clear migration guide!

## To-do before merging

- [x] Update AWS Parameter Store
  - [x] `QUIRREL_API_URL`
  - [x] `QUIRREL_MIGRATE_OLD_TOKEN` (the old `QUIRREL_TOKEN`)
  - [x] `QUIRREL_TOKEN` (the new one from the self-hosted instance)

After the migration is complete we can remove the tokens with `*MIGRATE_OLD*` in them.