### PR TITLE
Add stale tagger action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: "Stale handler"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@main
+        id: stale
+        with:
+          stale-issue-message: "This issue is stale because it has been open 60 days with no activity."
+          days-before-stale: 60
+          days-before-close: -1
+          stale-issue-label: "Stale"
+          exempt-issue-milestones: true
+          exempt-issue-labels: "blocked,wontfix"
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}
+      - uses: actions/stale@main
+        id: stale
+        with:
+          stale-pr-message: "This pull request is stale because it has been open for 2 days with no activity. "
+          days-before-stale: 2
+          days-before-close: -1
+          stale-pr-label: "Stale"
+          exempt-pr-labels: "blocked,wontfix"
+          exempt-draft-pr: true
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
This PR adds a GitHub action to tag any and all stale issues (60 days) and pull requests (2 days). Based on the recommendation by @nsunami 💚 

It does not close anything - only tags them. This helps in triaging especially the PRs, as we have dependency upgrades coming on an ongoing basis.

Note: GitHub actions noob over here so I might've done something wrong - will run the Action in a sec to check.