### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
+        stale-pr-message: 'This pull request is stale because it has been open for 2 days with no activity.'
+        stale-issue-label: 'Stale'
+        stale-pr-label: 'Stale'
+        exempt-all-milestones: true
+        exempt-draft-pr: true
+        exempt-issue-labels: 'blocked,wontfix'
+        exempt-pr-labels: 'blocked,wontfix'
+        days-before-issue-stale: 60
+        days-before-pr-stale: 2
+        days-before-issue-close: -1
+        days-before-pr-close: -1
+
+        
+


### PR DESCRIPTION
This PR adds a GitHub action to tag any and all stale issues (60 days) and pull requests (2 days). Based on the recommendation by @nsunami 💚

It does not close anything - only tags them. This helps in triaging especially the PRs, as we have dependency upgrades coming on an ongoing basis.