### PR TITLE
Upgrade prisma client dependency (minor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@faker-js/faker": "7.2.0",
         "@floating-ui/dom": "0.5.2",
         "@headlessui/react": "1.6.4",
-        "@prisma/client": "3.8.1",
+        "@prisma/client": "3.15.0",
         "@react-pdf-viewer/core": "3.3.3",
         "@stripe/stripe-js": "1.22.0",
         "@tailwindcss/forms": "0.5.1",
@@ -2715,12 +2715,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.8.1.tgz",
-      "integrity": "sha512-NxD1Xbkx1eT1mxSwo1RwZe665mqBETs0VxohuwNfFIxMqcp0g6d4TgugPxwZ4Jb4e5wCu8mQ9quMedhNWIWcZQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.15.0.tgz",
+      "integrity": "sha512-0bwpIXtE3qkkm8JV6kSHLPyEbEUQD+hFAO7NM5INr23vFBOoyKwKI1Q4V08A7jq3NdI7g2NlBuugCHE9//1ANw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+        "@prisma/engines-version": "3.15.0-29.b9297dc3a59307060c1c39d7e4f5765066f38372"
       },
       "engines": {
         "node": ">=12.6"
@@ -2798,9 +2798,9 @@
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g=="
+      "version": "3.15.0-29.b9297dc3a59307060c1c39d7e4f5765066f38372",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.15.0-29.b9297dc3a59307060c1c39d7e4f5765066f38372.tgz",
+      "integrity": "sha512-VRj1Svti6h4UnUxEbIpio+40zppFztGKogVbkgblndbEQfmNdLh2M5bzDD6kaO+r8LBxHUBzUG/zEmlpxTvwoA=="
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009",
@@ -22361,11 +22361,11 @@
       "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
     },
     "@prisma/client": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.8.1.tgz",
-      "integrity": "sha512-NxD1Xbkx1eT1mxSwo1RwZe665mqBETs0VxohuwNfFIxMqcp0g6d4TgugPxwZ4Jb4e5wCu8mQ9quMedhNWIWcZQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.15.0.tgz",
+      "integrity": "sha512-0bwpIXtE3qkkm8JV6kSHLPyEbEUQD+hFAO7NM5INr23vFBOoyKwKI1Q4V08A7jq3NdI7g2NlBuugCHE9//1ANw==",
       "requires": {
-        "@prisma/engines-version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+        "@prisma/engines-version": "3.15.0-29.b9297dc3a59307060c1c39d7e4f5765066f38372"
       }
     },
     "@prisma/debug": {
@@ -22429,9 +22429,9 @@
       "integrity": "sha512-qM+uJbkelB21bnK44gYE049YTHIjHysOuj0mj5U2gDGyNLfmiazlggzFPCgEjgme4U5YB2tYs6Z5Hq08Kl8pjA=="
     },
     "@prisma/engines-version": {
-      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
-      "integrity": "sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g=="
+      "version": "3.15.0-29.b9297dc3a59307060c1c39d7e4f5765066f38372",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.15.0-29.b9297dc3a59307060c1c39d7e4f5765066f38372.tgz",
+      "integrity": "sha512-VRj1Svti6h4UnUxEbIpio+40zppFztGKogVbkgblndbEQfmNdLh2M5bzDD6kaO+r8LBxHUBzUG/zEmlpxTvwoA=="
     },
     "@prisma/fetch-engine": {
       "version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@carbon/icons-react": "11.3.0",
     "@floating-ui/dom": "0.5.2",
     "@headlessui/react": "1.6.4",
-    "@prisma/client": "3.8.1",
+    "@prisma/client": "3.15.0",
     "@react-pdf-viewer/core": "3.3.3",
     "@stripe/stripe-js": "1.22.0",
     "@tailwindcss/forms": "0.5.1",


### PR DESCRIPTION
This PR upgrades the prisma client dependency (minor version).

This merges into https://github.com/libscie/ResearchEquals.com/pull/403 so this has to be finalized before merging over there as part of cascading upgrades.