### PR TITLE
Upgrade react-pdf-viewer (minor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@floating-ui/dom": "0.5.2",
         "@headlessui/react": "1.6.4",
         "@prisma/client": "3.15.0",
-        "@react-pdf-viewer/core": "3.3.3",
+        "@react-pdf-viewer/core": "3.4.0",
         "@stripe/stripe-js": "1.22.0",
         "@tailwindcss/forms": "0.5.1",
         "@tailwindcss/line-clamp": "0.4.0",
@@ -3188,9 +3188,9 @@
       }
     },
     "node_modules/@react-pdf-viewer/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-weAmU1N8TzCnLhgPzF3GHtlTURh1v3PTors0weHfA33Mpk0wa8Aj8OGTp1jCuljp5ACRM4rZ0G2uvMKlyWXvDQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-MSlk47hPYV8DEmggc7PSRI1CVCwDeBp/hJOlbrf174J8LllmF5CqcWaNlz4EcF3roEG9citDhATbqk3DM10iRg==",
       "peerDependencies": {
         "pdfjs-dist": "^2.6.347",
         "react": ">=16.8.0",
@@ -22761,9 +22761,9 @@
       }
     },
     "@react-pdf-viewer/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-weAmU1N8TzCnLhgPzF3GHtlTURh1v3PTors0weHfA33Mpk0wa8Aj8OGTp1jCuljp5ACRM4rZ0G2uvMKlyWXvDQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-MSlk47hPYV8DEmggc7PSRI1CVCwDeBp/hJOlbrf174J8LllmF5CqcWaNlz4EcF3roEG9citDhATbqk3DM10iRg=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@floating-ui/dom": "0.5.2",
     "@headlessui/react": "1.6.4",
     "@prisma/client": "3.15.0",
-    "@react-pdf-viewer/core": "3.3.3",
+    "@react-pdf-viewer/core": "3.4.0",
     "@stripe/stripe-js": "1.22.0",
     "@tailwindcss/forms": "0.5.1",
     "@tailwindcss/line-clamp": "0.4.0",


### PR DESCRIPTION
This PR upgrades the react-pdf-viewer dependency (minor version). This updates a lot!

This merges into https://github.com/libscie/ResearchEquals.com/pull/404 so this has to be finalized before merging over there. I am doing these cascading upgrades now because batch upgrading for major, minor, and patch versions was too fickle-y and broke things.