### PR TITLE
Remove PR limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    labels: 
+    labels:
       - "Maintenance"
+    open-pull-requests-limit: 999


### PR DESCRIPTION
This was supposed to be implemented before, but I think this is a good opportunity to discuss this. 

@nsunami what do you think about having no (real) limit on the dependabot upgrades?

This may flood our notifications (and anyone who follows the repo 😅 ) but then again, it will help us stay observe the amount of upgrades that need to happen. We could end up getting "infinite-feeling" upgrade cycles without it?