### PR TITLE
Replace dynamic with static `og:image` links

### DIFF
--- a/app/pages/[handle].tsx
+++ b/app/pages/[handle].tsx
@@ -217,22 +217,8 @@ const HandlePage = ({ workspace, expire, signature }) => {
         <>
           <meta property="og:title" content={workspace.firstName || workspace.handle} />
           {workspace.bio ? <meta property="og:description" content={workspace.bio} /> : ""}
-          <meta
-            property="og:image"
-            content={`http://og-images.herokuapp.com/api/workspace?title=${
-              encodeURIComponent(workspace.firstName) || ""
-            } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
-              workspace.avatar
-            )}&handle=${encodeURIComponent(workspace.handle)}&orcid=${workspace.orcid || ""}`}
-          />
-          <meta
-            property="og:image:secure_url"
-            content={`http://og-images.herokuapp.com/api/workspace?title=${
-              encodeURIComponent(workspace.firstName) || ""
-            } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
-              workspace.avatar
-            )}&handle=${encodeURIComponent(workspace.handle)}&orcid=${workspace.orcid || ""}`}
-          />
+          <meta property="og:image" content={`${workspace.avatar}`} />
+          <meta property="og:image:secure_url" content={`${workspace.avatar}`} />
           <meta
             property="og:image:alt"
             content={`Social media sharing image of the profile for ${workspace.handle}, including the avatar, name, handle, and ORCID.`}
@@ -249,14 +235,7 @@ const HandlePage = ({ workspace, expire, signature }) => {
             }
           />
           {workspace.bio ? <meta name="twitter:description" content={workspace.bio} /> : ""}
-          <meta
-            name="twitter:image"
-            content={`http://og-images.herokuapp.com/api/workspace?title=${
-              encodeURIComponent(workspace.firstName) || ""
-            } ${encodeURIComponent(workspace.lastName) || ""}&avatar=${encodeURIComponent(
-              workspace.avatar
-            )}&handle=${encodeURIComponent(workspace.handle)}&orcid=${workspace.orcid || ""}`}
-          />
+          <meta name="twitter:image" content={`${workspace.avatar}`} />
         </>
       }
     >

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -483,27 +483,11 @@ const ModulePage = ({ module }) => {
           )}
           <meta
             property="og:image"
-            content={`http://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
-              module.title
-            )}&type=${module.type.name}&doi=${module.prefix}/${
-              module.suffix
-            }&publishedAt=${module.publishedAt
-              .toISOString()
-              .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
-              module.license.name
-            }`}
+            content={`https://ucarecdn.com/f65e7eca-bd38-48ab-ad79-ddcafa184431/`}
           />
           <meta
             property="og:image:secure_url"
-            content={`http://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
-              module.title
-            )}&type=${module.type.name}&doi=${module.prefix}/${
-              module.suffix
-            }&publishedAt=${module.publishedAt
-              .toISOString()
-              .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
-              module.license.name
-            }`}
+            content={`https://ucarecdn.com/f65e7eca-bd38-48ab-ad79-ddcafa184431/`}
           />
           <meta
             property="og:image:alt"
@@ -519,15 +503,7 @@ const ModulePage = ({ module }) => {
           <meta name="twitter:description" content={module.description} />
           <meta
             name="twitter:image"
-            content={`http://og-images.herokuapp.com/api/module?title=${encodeURIComponent(
-              module.title
-            )}&type=${module.type.name}&doi=${module.prefix}/${
-              module.suffix
-            }&publishedAt=${module.publishedAt
-              .toISOString()
-              .substr(0, 10)}&avatars=${encodeURIComponent(authorsOG.join(";"))}&license=${
-              module.license.name
-            }`}
+            content={`https://ucarecdn.com/f65e7eca-bd38-48ab-ad79-ddcafa184431/`}
           />
         </>
       }


### PR DESCRIPTION
This PR replaces the `og:image` links from the dynamic ones to static, to tackle the issues presented in #280 an #281.

This is not an optimal implementation in the long run, but better an imperfect implementation that works in a stable manner. 