### PR TITLE
Add api route for main files

### DIFF
--- a/app/api/modules/main/[suffix].ts
+++ b/app/api/modules/main/[suffix].ts
@@ -1,10 +1,36 @@
 import { BlitzApiHandler } from "blitz"
+import db from "db"
+import https from "https"
 
-const handler: BlitzApiHandler = (req, res) => {
+const handler: BlitzApiHandler = async (req, res) => {
   const {
     query: { suffix },
   } = req
 
-  res.end(`Post: ${suffix}`)
+  const module = await db.module.findFirst({ where: { suffix: suffix?.toString() } })
+  return new Promise((resolve, reject) => {
+    https
+      .get(module?.main!["cdnUrl"], (response) => {
+        var data = [] as any
+
+        response
+          .on("data", function (chunk) {
+            data.push(chunk)
+          })
+          .on("end", function () {
+            res.statusCode = 200
+            res.setHeader("Content-Type", module?.main!["mimeType"])
+            res.setHeader("Content-Disposition", `filename=${module?.main!["name"]}`)
+            var buffer = Buffer.concat(data)
+            res.end(buffer)
+            resolve()
+          })
+      })
+      .on("error", (e) => {
+        res.status(404).end()
+        resolve()
+      })
+  })
 }
+
 export default handler

--- a/app/api/modules/main/[suffix].ts
+++ b/app/api/modules/main/[suffix].ts
@@ -1,0 +1,10 @@
+import { BlitzApiHandler } from "blitz"
+
+const handler: BlitzApiHandler = (req, res) => {
+  const {
+    query: { suffix },
+  } = req
+
+  res.end(`Post: ${suffix}`)
+}
+export default handler

--- a/app/modules/components/ModuleInvitation.tsx
+++ b/app/modules/components/ModuleInvitation.tsx
@@ -151,7 +151,11 @@ const ModuleInvitation = ({
       {mainFile.name ? (
         <div className="my-8">
           <h2 className="text-lg">Main file</h2>
-          <ViewFiles name={mainFile.name} size={mainFile.size} url={mainFile.cdnUrl} />
+          <ViewFiles
+            name={mainFile.name}
+            size={mainFile.size}
+            url={`/api/modules/main/${module.suffix}`}
+          />
         </div>
       ) : (
         ""

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -123,7 +123,7 @@ const Module = ({ module, mainFile, supportingRaw }) => {
   } else {
     arrowColor = "transparent"
   }
-
+  console.log(process.env.APP_ORIGIN)
   useEffect(() => {
     if (mainFile.mimeType === "text/markdown") {
       fetch(mainFile.cdnUrl)
@@ -271,7 +271,11 @@ const Module = ({ module, mainFile, supportingRaw }) => {
         {mainFile.name ? (
           <div className="my-8">
             <h2 className="text-lg">Main file</h2>
-            <ViewFiles name={mainFile.name} size={mainFile.size} url={mainFile.cdnUrl} />
+            <ViewFiles
+              name={mainFile.name}
+              size={mainFile.size}
+              url={`/api/modules/main/${module.suffix}`}
+            />
             {/* Preview image */}
             {mainFile.isImage ? (
               <img src={mainFile.cdnUrl} className="mx-auto my-2 h-auto w-full" />


### PR DESCRIPTION
This PR adds an api route for the main files of modules, making it more predictable. 

The need for this came up while trying to make a reproducible piece of output, and noticing the uploadcare URL was incomprehensible.

Specifically, the route is now as easy as:

```
/api/modules/main/[suffix]
```

✌️ 