### PR TITLE
Make file extensions case insensitive

### DIFF
--- a/app/core/utils/fileTypeLimit.ts
+++ b/app/core/utils/fileTypeLimit.ts
@@ -158,7 +158,7 @@ export const fileTypeLimit = (fileInfo: FileInfo) => {
   }
   const extension = fileInfo.name.split(".").pop()
 
-  if (extension && !types.includes(extension)) {
+  if (extension && !types.includes(extension.toLowerCase())) {
     throw new Error("fileType")
   }
 }


### PR DESCRIPTION
This PR makes file extension limitations case insensitive.

This was a bug I noticed while trying to upload an R file 😅 