### PR TITLE
Add api for supporting files

### DIFF
--- a/app/api/modules/supporting/[suffix]/[filename].ts
+++ b/app/api/modules/supporting/[suffix]/[filename].ts
@@ -1,0 +1,46 @@
+import { BlitzApiHandler } from "blitz"
+import { PrismaClient, Prisma } from "@prisma/client"
+import db from "db"
+import https from "https"
+
+const handler: BlitzApiHandler = async (req, res) => {
+  const {
+    query: { suffix, filename },
+  } = req
+
+  const module = await db.module.findFirst({
+    where: { suffix: suffix?.toString(), published: true },
+  })
+
+  const files = module?.supporting as Prisma.JsonArray
+
+  return new Promise((resolve, reject) => {
+    files["files"].filter((file) => {
+      if (file.original_filename === filename) {
+        https
+          .get(file.original_file_url, (response) => {
+            var data = [] as any
+
+            response
+              .on("data", function (chunk) {
+                data.push(chunk)
+              })
+              .on("end", function () {
+                res.statusCode = 200
+                res.setHeader("Content-Type", file.mime_type)
+                res.setHeader("Content-Disposition", `filename=${file.original_filename}`)
+                var buffer = Buffer.concat(data)
+                res.end(buffer)
+                resolve()
+              })
+          })
+          .on("error", (e) => {
+            res.status(404).end()
+            resolve()
+          })
+      }
+    })
+  })
+}
+
+export default handler

--- a/app/modules/components/EditSupportingFiles.jsx
+++ b/app/modules/components/EditSupportingFiles.jsx
@@ -29,7 +29,9 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace, expire
             setQueryData(data)
             return "Uploaded!"
           },
-          error: "Uh-oh something went wrong.",
+          error: (error) => {
+            return error.toString()
+          },
         }
       )
     } catch (err) {

--- a/app/modules/mutations/addSupporting.ts
+++ b/app/modules/mutations/addSupporting.ts
@@ -10,6 +10,11 @@ export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
   let supportingFiles = oldModule?.supporting as Prisma.JsonObject
   // 2. Map the array to push each files object into supporting files
   newFiles.map((newFile) => {
+    supportingFiles.files.filter((file) => {
+      if (file.original_filename == newFile.original_filename) {
+        throw new Error("Please check for duplicates.")
+      }
+    })
     supportingFiles.files.push(newFile)
   })
 

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -359,7 +359,9 @@ const Module = ({ module, mainFile, supportingRaw }) => {
                   <ViewFiles
                     name={file.original_filename}
                     size={file.size}
-                    url={file.original_file_url}
+                    url={`/api/modules/supporting/${module.suffix}/${encodeURI(
+                      file.original_filename
+                    )}`}
                   />
                 </>
               ))}


### PR DESCRIPTION
This PR adds an api route for supporting files. This is similar to #467.

This is a way to clean up the uploadcare CDN urls - which are very opaque for usage. They're also brittle in case we ever want to change the storage provider.

So with this PR you can easily retrieve files across modules using the following route that is stable even if we switch storage providers:

```
/api/modules/supporting/[suffix]/[filename]
```

An example could be (after merging this)

```
https://researchequals.com/api/supporting/kpg3-tb37/plot.png
```

This will effectively help make ResearchEquals a storage provider too - which could be helpful in the future if we want to for example host podcasts or anything 😊 