### PR TITLE
Remove `*MIGRATE_OLD*` env vars

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -57,12 +57,8 @@
             "QUIRREL_ENCRYPTION_SECRET": {
               "fromParameterStore": "QUIRREL_ENCRYPTION_SECRET"
             },
-            "QUIRREL_MIGRATE_OLD_API_URL": "api.quirrel.dev",
             "QUIRREL_API_URL": {
               "fromParameterStore": "QUIRREL_API_URL"
-            },
-            "QUIRREL_MIGRATE_OLD_TOKEN": {
-              "fromParameterStore": "QUIRREL_MIGRATE_OLD_TOKEN"
             },
             "QUIRREL_TOKEN": {
               "fromParameterStore": "QUIRREL_TOKEN"


### PR DESCRIPTION
This PR removes the environment variables that #392 introduced. 

We're now completely migrated to our self-hosted instance, so we no longer need these.

## To-do after merging

- [ ] Remove `*MIGRATE_OLD*` env  vars from the AWS parameter store