### PR TITLE
Improve state management of onboarding information

### DIFF
--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -1,14 +1,23 @@
 import { useMutation, useQuery } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
-import { useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Formik, Form } from "formik"
 import { Email, UserAvatar, User, Parameter } from "@carbon/icons-react"
+import { useRecoilValue, useRecoilState } from "recoil"
 
 import SettingsModal from "../modals/settings"
 import changeAvatar from "../../workspaces/mutations/changeAvatar"
 import getSignature from "../../auth/queries/getSignature"
 import QuickDraft from "../../modules/components/QuickDraft"
 import resendVerification from "../../auth/mutations/resendVerification"
+import {
+  workspaceFirstNameAtom,
+  workspaceLastNameAtom,
+  workspaceBioAtom,
+  workspacePronounsAtom,
+  workspaceUrlAtom,
+  settingsModalAtom,
+} from "../utils/Atoms"
 
 const OnboardingQuests = ({ data, expire, signature, refetch }) => {
   return (
@@ -132,9 +141,21 @@ const OnboardingOrcid = ({ data }) => {
 }
 
 const OnboardingProfile = ({ data }) => {
+  // State management
+  const workspaceFirstName = useRecoilValue(workspaceFirstNameAtom)
+  const workspaceLastName = useRecoilValue(workspaceLastNameAtom)
+  const workspaceBio = useRecoilValue(workspaceBioAtom)
+  const workspacePronouns = useRecoilValue(workspacePronounsAtom)
+  const workspaceUrl = useRecoilValue(workspaceUrlAtom)
+  const [settingsModal, setSettingsModal] = useRecoilState(settingsModalAtom)
+
   return (
     <>
-      {!data.workspace.bio ? (
+      {!workspaceFirstName ||
+      !workspaceLastName ||
+      !workspaceBio ||
+      !workspacePronouns ||
+      !workspaceUrl ? (
         <div
           key="onboarding profile-onboarding-quest"
           className="onboarding my-2 flex w-full flex-col rounded-r border-l-4 border-pink-400 bg-pink-50 p-4 dark:border-pink-200 dark:bg-pink-900 lg:my-0"
@@ -158,18 +179,16 @@ const OnboardingProfile = ({ data }) => {
             </div>
           </div>
           <div className="block text-right text-pink-700 dark:text-pink-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
-              <SettingsModal
-                styling="whitespace-nowrap font-medium hover:text-blue-600 underline"
-                button={
-                  <>
-                    Add information <span aria-hidden="true">&rarr;</span>
-                  </>
-                }
-                user={data.user}
-                workspace={data.workspace}
-              />
-            </p>
+            <button
+              className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:mt-0 md:ml-6"
+              onClick={() => {
+                setSettingsModal(!settingsModal)
+              }}
+            >
+              <>
+                Add information <span aria-hidden="true">&rarr;</span>
+              </>
+            </button>
           </div>
         </div>
       ) : (

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -5,7 +5,6 @@ import { Formik, Form } from "formik"
 import { Email, UserAvatar, User, Parameter } from "@carbon/icons-react"
 import { useRecoilValue, useRecoilState } from "recoil"
 
-import SettingsModal from "../modals/settings"
 import changeAvatar from "../../workspaces/mutations/changeAvatar"
 import getSignature from "../../auth/queries/getSignature"
 import QuickDraft from "../../modules/components/QuickDraft"

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
-import { useEffect, useRef, useState } from "react"
+import { useRef } from "react"
 import { Formik, Form } from "formik"
 import { Email, UserAvatar, User, Parameter } from "@carbon/icons-react"
 import { useRecoilValue, useRecoilState } from "recoil"

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -1,7 +1,7 @@
 import { Dialog, Transition, Tab } from "@headlessui/react"
 import { Fragment, useState } from "react"
 import { Close } from "@carbon/icons-react"
-import { useRecoilState, useResetRecoilState } from "recoil"
+import { useRecoilState } from "recoil"
 import { settingsModalAtom } from "../utils/Atoms"
 
 import WorkspaceSettings from "../components/WorkspaceSettings"

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -1,6 +1,8 @@
 import { Dialog, Transition, Tab } from "@headlessui/react"
 import { Fragment, useState } from "react"
 import { Close } from "@carbon/icons-react"
+import { useRecoilState, useResetRecoilState } from "recoil"
+import { settingsModalAtom } from "../utils/Atoms"
 
 import WorkspaceSettings from "../components/WorkspaceSettings"
 import AccountSettings from "../components/AccountSettings"
@@ -10,7 +12,7 @@ function classNames(...classes) {
 }
 
 export default function SettingsModal({ button, styling, user, workspace }) {
-  let [isOpen, setIsOpen] = useState(false)
+  let [isOpen, setIsOpen] = useRecoilState(settingsModalAtom)
   let [categories] = useState(["Workspace", "Account"])
 
   return (

--- a/app/core/utils/Atoms.tsx
+++ b/app/core/utils/Atoms.tsx
@@ -33,10 +33,17 @@ const workspaceUrlAtom = atom({
   effects_UNSTABLE: [persistAtom],
 })
 
+const settingsModalAtom = atom({
+  key: "settingsModal",
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+})
+
 export {
   workspaceFirstNameAtom,
   workspaceLastNameAtom,
   workspaceBioAtom,
   workspacePronounsAtom,
   workspaceUrlAtom,
+  settingsModalAtom,
 }


### PR DESCRIPTION
This PR improves the state management of the onboarding information. Fixes #264.

https://user-images.githubusercontent.com/2946344/178457312-ca30ba21-ce4a-4f19-af55-626cd8c3670a.mov

This took a few more steps than I'd thought, because I needed to also manage the state of the settings modal now (otherwise the modal would close automatically once all the information was entered but not yet saved).

I am learning about the `recoil` library and this is really a fantastic way to increase the responsive feel of the platform while at the same time reducing the database actions needed. This is possible because everything is written into the `localStorage` for persistence.


