### PR TITLE
Add uploadcareError for proprietary file formats

### DIFF
--- a/app/core/utils/uploadcareError.ts
+++ b/app/core/utils/uploadcareError.ts
@@ -1,0 +1,17 @@
+const settings = {
+  dialog: {
+    tabs: {
+      preview: {
+        error: {
+          fileType: {
+            title: "Error",
+            text: "Proprietary file formats are not supported.",
+            back: "Try again",
+          },
+        },
+      },
+    },
+  },
+}
+
+export default settings

--- a/app/modules/components/EditMainFile.jsx
+++ b/app/modules/components/EditMainFile.jsx
@@ -7,6 +7,7 @@ import { Add } from "@carbon/icons-react"
 import addMain from "../mutations/addMain"
 import EditMainFileDisplay from "../../core/components/EditMainFileDisplay"
 import { fileSizeLimit, fileTypeLimit } from "../../core/utils/fileTypeLimit"
+import uploadcareError from "../../core/utils/uploadcareError"
 
 const validators = [fileTypeLimit, fileSizeLimit]
 
@@ -51,6 +52,7 @@ const EditMainFile = ({
               previewStep
               validators={validators}
               clearable
+              localeTranslations={uploadcareError}
               onChange={async (info) => {
                 // TODO: Only store upon save
                 try {

--- a/app/modules/components/EditSupportingFiles.jsx
+++ b/app/modules/components/EditSupportingFiles.jsx
@@ -7,6 +7,7 @@ import { Add } from "@carbon/icons-react"
 import addSupporting from "../mutations/addSupporting"
 import getSupportingFiles from "../mutations/getSupportingFiles"
 import { fileSizeLimit, fileTypeLimit } from "../../core/utils/fileTypeLimit"
+import uploadcareError from "../../core/utils/uploadcareError"
 
 const validators = [fileTypeLimit, fileSizeLimit]
 
@@ -61,6 +62,7 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace, expire
               multiple
               multipleMax={10}
               clearable
+              localeTranslations={uploadcareError}
               onChange={updateSupporting}
             />
           </button>


### PR DESCRIPTION
This PR adds a custom error for proprietary file formats (i.e., non open file formats). Fixes #476.

Attached a screencap of the error:
<img width="1032" alt="Screenshot 2022-07-12 at 13 25 37" src="https://user-images.githubusercontent.com/2946344/178480083-48064cd2-dd7d-4613-8109-d4d5d294826b.png">

I am more than happy to hear alternatives for the copy if the current version is not 100% clear - I gave it a shot and happy to iterate in here 😊 

Note: I factored out the error message into a separate file so that we can update it more easily across the board.
