### PR TITLE
Upgrade Autocomplete to use createRoot

### DIFF
--- a/app/core/components/Autocomplete.jsx
+++ b/app/core/components/Autocomplete.jsx
@@ -1,9 +1,11 @@
 import { autocomplete } from "@algolia/autocomplete-js"
 import React, { createElement, Fragment, useEffect, useRef } from "react"
-import { render } from "react-dom"
+import { createRoot } from "react-dom/client"
 
 function Autocomplete(props) {
   const containerRef = useRef(null)
+  const panelRootRef = useRef(null)
+  const rootRef = useRef(null)
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -12,9 +14,16 @@ function Autocomplete(props) {
 
     const search = autocomplete({
       container: containerRef.current,
-      renderer: { createElement, Fragment },
+      renderer: { createElement, Fragment, render: () => {} },
       render({ children }, root) {
-        render(children, root)
+        if (!panelRootRef.current || rootRef.current !== root) {
+          rootRef.current = root
+
+          panelRootRef.current?.unmount()
+          panelRootRef.current = createRoot(root)
+        }
+
+        panelRootRef.current.render(children)
       },
       ...props,
     })
@@ -24,7 +33,7 @@ function Autocomplete(props) {
     }
   }, [props])
 
-  return <div className="h-full w-full" ref={containerRef} />
+  return <div ref={containerRef} />
 }
 
 export default Autocomplete


### PR DESCRIPTION
This PR upgrades the `Autocomplete` component to use `createRoot` as is necessary for utilizing React 18. Fixes #364. It ended up being [documented by Algolia](https://www.algolia.com/doc/ui-libraries/autocomplete/integrations/using-react/?client=jsx#with-react-18) too.

Please note that I changed the file from `.tsx` to `.jsx` - there were some Typescript errors I did not know how to work around at this point:

```
Property 'unmount' does not exist on type 'never'.
```

So if anyone knows their Typescript and can help work around this - I would love your help!

Note: Does not fix #326 - makes it seem a tiny bit less of an issue though?