### PR TITLE
Add `/api/avatars/[handle]` route

### DIFF
--- a/app/api/avatars/[handle].ts
+++ b/app/api/avatars/[handle].ts
@@ -1,0 +1,39 @@
+import { BlitzApiHandler } from "blitz"
+import db from "db"
+import https from "https"
+
+const handler: BlitzApiHandler = async (req, res) => {
+  const {
+    query: { handle },
+  } = req
+
+  const author = await db.workspace.findFirst({
+    where: { handle: handle?.toString() },
+  })
+  return new Promise((resolve, reject) => {
+    https
+      .get(author?.avatar!, (response) => {
+        var data = [] as any
+
+        let buffer
+        response
+          .on("data", function (chunk) {
+            data.push(chunk)
+          })
+          .on("end", function () {
+            res.statusCode = 200
+            res.setHeader("Content-Type", "image")
+            res.setHeader("Content-Disposition", `filename=avatar-${author?.handle}`)
+            var buffer = Buffer.concat(data)
+            res.end(buffer)
+            resolve()
+          })
+      })
+      .on("error", (e) => {
+        res.status(404).end()
+        resolve()
+      })
+  })
+}
+
+export default handler

--- a/app/api/avatars/[handle].ts
+++ b/app/api/avatars/[handle].ts
@@ -10,6 +10,8 @@ const handler: BlitzApiHandler = async (req, res) => {
   const author = await db.workspace.findFirst({
     where: { handle: handle?.toString() },
   })
+
+  const mimetype = !author?.avatar!.match(/ucarecdn/g) ? "image/svg+xml" : "image"
   return new Promise((resolve, reject) => {
     https
       .get(author?.avatar!, (response) => {
@@ -22,7 +24,7 @@ const handler: BlitzApiHandler = async (req, res) => {
           })
           .on("end", function () {
             res.statusCode = 200
-            res.setHeader("Content-Type", "image")
+            res.setHeader("Content-Type", mimetype)
             res.setHeader("Content-Disposition", `filename=avatar-${author?.handle}`)
             var buffer = Buffer.concat(data)
             res.end(buffer)

--- a/app/core/components/HandleAvatar.jsx
+++ b/app/core/components/HandleAvatar.jsx
@@ -14,7 +14,7 @@ const HandleAvatar = ({ params, workspace, ownWorkspace, expire, signature, refe
         ownWorkspace.handle === params.handle ? (
           <>
             <img
-              src={workspace.avatar}
+              src={`/api/avatars/${workspace.handle}`}
               className="max-w-28 h-28 max-h-28 w-28 rounded-full border border-2 border-gray-900 hover:cursor-pointer hover:border-4 hover:border-indigo-600 dark:border-white"
               alt={`Avatar of ${workspace.handle}`}
               onClick={() => {
@@ -53,7 +53,7 @@ const HandleAvatar = ({ params, workspace, ownWorkspace, expire, signature, refe
         ) : (
           <>
             <img
-              src={workspace.avatar}
+              src={`/api/avatars/${workspace.handle}`}
               className="max-w-28 h-28 max-h-28 w-28 rounded-full border border-2 border-gray-900 dark:border-white "
               alt={`Avatar of ${workspace.handle}`}
             />
@@ -62,7 +62,7 @@ const HandleAvatar = ({ params, workspace, ownWorkspace, expire, signature, refe
       ) : (
         <>
           <img
-            src={workspace.avatar}
+            src={`/api/avatars/${workspace.handle}`}
             className="max-w-28 h-28 max-h-28 w-28 rounded-full border border-2 border-gray-900 dark:border-white "
             alt={`Avatar of ${workspace.handle}`}
           />

--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -388,7 +388,7 @@ const seed = async () => {
                 workspace: {
                   create: {
                     handle: faker.internet.userName().toLowerCase(),
-                    avatar: faker.image.abstract(),
+                    avatar: `https://eu.ui-avatars.com/api/?rounded=true&background=574cfa&color=ffffff&name=${faker.internet.userName()}`,
                     firstName: faker.name.findName(),
                     lastName: faker.name.findName(),
                     url: faker.internet.url(),


### PR DESCRIPTION
This PR adds an API route for avatars - this is similar to #473 and #467.

The main reason to do this is to allow for permalinking to avatars - for example like github does. This means that whenever somebody embeds an avatar based on this route, the link won't break when a person updates their avatar. This is yet another step towards a CDN pretty much 😊 

The only quirks I detected are:
- We used faker to generate fake avatar links - these don't really work because each load of the URL generates something else and it doesn't have a clear mimetype 👇 
![Screenshot 2022-07-21 at 09 26 13](https://user-images.githubusercontent.com/2946344/180155891-81ed8457-c9ee-4b0b-b4e0-1fc96d061833.png)
- I ended up not using this everywhere, as there's a slight delay in the image being loaded. This is because every link goes through our server, which isn't optimized for high amounts of request (e.g., 30 avatars at once on `/browse`). I only implemented it on `/[handle]` as a result

I'm not 100% sure yet I want it in, but I had the thought of implementing this during the week and wanted to at least document the work!

@nsunami would much appreciate your opinion/questions/feedback on this - what do you think?
