### PR TITLE
Fix encoding of filenames in Content-Disposition

### DIFF
--- a/app/api/modules/main/[suffix].ts
+++ b/app/api/modules/main/[suffix].ts
@@ -22,7 +22,7 @@ const handler: BlitzApiHandler = async (req, res) => {
           .on("end", function () {
             res.statusCode = 200
             res.setHeader("Content-Type", module?.main!["mimeType"])
-            res.setHeader("Content-Disposition", `filename=${module?.main!["name"]}`)
+            res.setHeader("Content-Disposition", `filename=${encodeURI(module?.main!["name"])}`)
             var buffer = Buffer.concat(data)
             res.end(buffer)
             resolve()

--- a/app/api/modules/supporting/[suffix]/[filename].ts
+++ b/app/api/modules/supporting/[suffix]/[filename].ts
@@ -28,7 +28,10 @@ const handler: BlitzApiHandler = async (req, res) => {
               .on("end", function () {
                 res.statusCode = 200
                 res.setHeader("Content-Type", file.mime_type)
-                res.setHeader("Content-Disposition", `filename=${file.original_filename}`)
+                res.setHeader(
+                  "Content-Disposition",
+                  `filename=${encodeURI(file.original_filename)}`
+                )
                 var buffer = Buffer.concat(data)
                 res.end(buffer)
                 resolve()


### PR DESCRIPTION
This PR adds encoding of the filename in the `Content-Disposition` of the following API routes:

- `/api/modules/supporting/[suffix]/[filename]`
- `/api/modules/main/[suffix]`

Fixes #528.
