### PR TITLE
Upgrading typescript once more

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: npx blitz prisma migrate deploy
+release: npx blitz prisma migrate deploy && npx blitz db seed
 web: npm run start:production

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "remark-math": "5.1.1",
         "stripe": "9.14.0",
         "tailwindcss": "3.1.6",
-        "typescript": "~4.5",
+        "typescript": "~4.7",
         "xml-js": "1.6.11",
         "zod": "3.17.9"
       },
@@ -19675,9 +19675,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -34834,9 +34834,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "remark-math": "5.1.1",
     "stripe": "9.14.0",
     "tailwindcss": "3.1.6",
-    "typescript": "~4.5",
+    "typescript": "~4.7",
     "xml-js": "1.6.11",
     "zod": "3.17.9"
   },


### PR DESCRIPTION
A redo of #461. 😓 

I forgot to document that the issue was in the seeding procedure, which still hasn't been resolved.

```
No pending migrations to apply.
--
463 | Loaded env from /var/www/app/.env
464 | Seeding database
465 | - Loading seeds
466 |  
467 | ERROR Couldn't import default from db/seeds
468 | ERROR Could not seed database:
469 |  
470 | Error  Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, 
likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is 
probably not a problem in TS itself.
```

## Checklist

- [ ] Deploy & seed local works
- [ ] Deploy & seed Heroku works