### PR TITLE
Remove workspaces without memberships and authorships

### DIFF
--- a/app/api/remove-unverified-accounts.ts
+++ b/app/api/remove-unverified-accounts.ts
@@ -50,6 +50,17 @@ export default CronJob(
       })
     })
 
-    //  TODO: Remove workspaces without memberships and authorships
+    // Remove workspaces without memberships and authorships
+    // This helps clean up any unused author profiles.
+    await db.workspace.findMany({
+      where: {
+        members: {
+          none: {},
+        },
+        authorships: {
+          none: {},
+        },
+      },
+    })
   }
 )

--- a/app/api/remove-unverified-accounts.ts
+++ b/app/api/remove-unverified-accounts.ts
@@ -52,7 +52,7 @@ export default CronJob(
 
     // Remove workspaces without memberships and authorships
     // This helps clean up any unused author profiles.
-    await db.workspace.findMany({
+    await db.workspace.deleteMany({
       where: {
         members: {
           none: {},


### PR DESCRIPTION
This PR adds an additional call to the CRON job that runs every 1st day of the month, to also delete workspaces that have no memberships (i.e., no linked accounts) and no authorships (no drafts or published modules).

This cleans out the authorspace, primarily in the following scenario:
1. Somebody signs up
2. Doesn't verify email in 30 days
3. Account gets deleted
4. Workspace now would remain, with this PR it will also be deleted if there are no drafts.

Fixes #475.