### PR TITLE
Add language to module

### DIFF
--- a/app/api/stripe_webhook.ts
+++ b/app/api/stripe_webhook.ts
@@ -84,6 +84,7 @@ const webhook = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
         schema: "5.3.1",
         type: module!.type!.name,
         title: module!.title,
+        language: module!.language,
         authors: module!.authors!.map((author) => {
           const js = {
             firstName: author.workspace?.firstName,
@@ -178,6 +179,7 @@ const webhook = async (req: BlitzApiRequest, res: BlitzApiResponse) => {
         description: publishedModule.description,
         publishedAt: publishedModule.publishedAt,
         displayColor: publishedModule.displayColor,
+        language: publishedModule.language,
       })
       console.log(`[STRIPE WEBHOOK]: Publication complete; type ${event.type}, id: ${event.id}.`)
 

--- a/app/core/crossref/body.tsx
+++ b/app/core/crossref/body.tsx
@@ -1,10 +1,22 @@
 import book from "./book"
 
-const body = ({ type, title, authors, abstractText, license_url, doi, resolve_url, citations }) => {
+const body = ({
+  type,
+  title,
+  language,
+  authors,
+  abstractText,
+  license_url,
+  doi,
+  resolve_url,
+  citations,
+}) => {
   const js = {
     type: "element",
     name: "body",
-    elements: [book({ title, authors, abstractText, license_url, doi, resolve_url, citations })],
+    elements: [
+      book({ title, language, authors, abstractText, license_url, doi, resolve_url, citations }),
+    ],
   }
 
   return js

--- a/app/core/crossref/book.tsx
+++ b/app/core/crossref/book.tsx
@@ -9,7 +9,16 @@ import contributors from "./contributors"
 import citationList from "./citation_list"
 import componentList from "./component_list"
 
-const book = ({ title, authors, abstractText, license_url, doi, resolve_url, citations }) => {
+const book = ({
+  title,
+  language,
+  authors,
+  abstractText,
+  license_url,
+  doi,
+  resolve_url,
+  citations,
+}) => {
   const js = {
     type: "element",
     name: "book",
@@ -41,6 +50,7 @@ const book = ({ title, authors, abstractText, license_url, doi, resolve_url, cit
         name: "content_item",
         attributes: {
           component_type: "other",
+          language,
         },
         elements: [
           contributors(authors),

--- a/app/core/crossref/generateCrossRefObject.js
+++ b/app/core/crossref/generateCrossRefObject.js
@@ -5,6 +5,7 @@ const generateCrossRef = ({
   schema,
   type,
   title,
+  language,
   authors,
   abstractText,
   license_url,
@@ -38,6 +39,7 @@ const generateCrossRef = ({
           body({
             type,
             title,
+            language,
             authors,
             abstractText,
             license_url,

--- a/app/modules/components/MetadataEdit.tsx
+++ b/app/modules/components/MetadataEdit.tsx
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, validateZodSchema } from "blitz"
 import moment from "moment"
 import algoliasearch from "algoliasearch"
+import ISO6391 from "iso-639-1"
+
 import AuthorAvatarsNew from "./AuthorAvatarsNew"
 import { useEffect } from "react"
 import { useFormik } from "formik"
@@ -21,6 +23,7 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
       description: module.description,
       license: module.license?.id.toString(),
       displayColor: module.displayColor,
+      language: module.language,
     },
     validate: validateZodSchema(
       z.object({
@@ -29,6 +32,7 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
         description: z.string(),
         license: z.string().min(1),
         displayColor: z.string().min(1),
+        language: z.string().min(1).max(2),
       })
     ),
     onSubmit: async (values) => {
@@ -39,6 +43,7 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
         description: values.description,
         licenseId: parseInt(values.license),
         displayColor: values.displayColor,
+        language: values.language,
       })
       setQueryData(updatedModule)
       setIsEditing(false)
@@ -51,6 +56,7 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
     formik.setFieldValue("description", module.description)
     formik.setFieldValue("license", module.license!.id.toString())
     formik.setFieldValue("displayColor", module.displayColor)
+    formik.setFieldValue("language", module.language)
   }, [module])
 
   return (
@@ -187,6 +193,34 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
               <option value="#db2777" className="text-white" style={{ backgroundColor: "#db2777" }}>
                 Red
               </option>
+            </select>
+          </div>
+        </div>
+        <div className="px-2 py-2">
+          <label
+            htmlFor="language"
+            className="my-1 flex text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
+          >
+            Language{" "}
+            {formik.touched.language && formik.errors.language
+              ? " - " + formik.errors.language
+              : null}
+          </label>
+          <div className="mt-1">
+            <select
+              id="language"
+              required
+              className="placeholder-font-normal block w-full appearance-none rounded-md border border-gray-400 bg-white px-3 py-2 text-sm font-normal placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border-gray-600 dark:bg-transparent dark:text-gray-200"
+              {...formik.getFieldProps("language")}
+            >
+              {" "}
+              {ISO6391.getAllNames().map((lang) => (
+                <>
+                  <option value={ISO6391.getCode(lang)}>
+                    {ISO6391.getCode(lang) + " - " + lang}
+                  </option>
+                </>
+              ))}
             </select>
           </div>
         </div>

--- a/app/modules/components/MetadataEdit.tsx
+++ b/app/modules/components/MetadataEdit.tsx
@@ -68,37 +68,67 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
         <div className="divide-y divide-gray-100 text-center text-sm font-normal leading-4 text-gray-500 dark:divide-gray-600 dark:bg-gray-800 dark:text-gray-200 lg:flex lg:divide-y-0 lg:divide-x">
           <div className="flex-grow py-2">
             <span className="inline-block h-full align-middle"> </span>
-            <span className="">Last updated: {moment(module.updatedAt).fromNow()}</span>
+            <span className="">Updated: {moment(module.updatedAt).fromNow()}</span>
           </div>
           <div className="flex-grow py-2">
             <span className="inline-block h-full align-middle"> </span>
             <span className="">
-              DOI upon publish:{" "}
+              DOI:{" "}
               <span className="text-gray-300 dark:text-gray-600">{`${module.prefix}/${module.suffix}`}</span>
             </span>
           </div>
-
-          <div className="flex-grow py-1">
-            <label htmlFor="license">License: </label>
-            <select
-              className="rounded border border-gray-300 bg-transparent text-sm font-normal leading-4 dark:border-gray-600"
-              id="license"
-              {...formik.getFieldProps("license")}
+          <div className="px-2 py-2">
+            <label
+              htmlFor="license"
+              className="sr-only my-1 flex text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
             >
-              <option value="" className="text-gray-900">
-                --Please choose a license--
-              </option>
-              {licenses.map((license) => (
-                <>
-                  <option value={license.id} className="text-gray-900">
-                    {license.name} ({license.price > 0 ? `${license.price / 100}EUR` : "Free"})
-                  </option>
-                </>
-              ))}
-            </select>
-            {formik.touched.license && formik.errors.license ? (
-              <div>{formik.errors.license}</div>
-            ) : null}
+              License{" "}
+              {formik.touched.license && formik.errors.license
+                ? " - " + formik.errors.license
+                : null}
+            </label>
+            <div className="mt-1">
+              <select
+                className="placeholder-font-normal block w-full appearance-none rounded-md border border-gray-400 bg-white px-3 py-2 text-sm font-normal placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border-gray-600 dark:bg-transparent dark:text-gray-200"
+                id="license"
+                {...formik.getFieldProps("license")}
+              >
+                {licenses.map((license) => (
+                  <>
+                    <option value={license.id} className="text-gray-900">
+                      {license.name} ({license.price > 0 ? `${license.price / 100}EUR` : "Free"})
+                    </option>
+                  </>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="px-2 py-2">
+            <label
+              htmlFor="language"
+              className="sr-only my-1 flex text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
+            >
+              Language{" "}
+              {formik.touched.language && formik.errors.language
+                ? " - " + formik.errors.language
+                : null}
+            </label>
+            <div className="mt-1">
+              <select
+                id="language"
+                required
+                className="placeholder-font-normal block w-full appearance-none rounded-md border border-gray-400 bg-white px-3 py-2 text-sm font-normal placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border-gray-600 dark:bg-transparent dark:text-gray-200"
+                {...formik.getFieldProps("language")}
+              >
+                {ISO6391.getAllNames().map((lang) => (
+                  <>
+                    <option value={ISO6391.getCode(lang)}>
+                      {ISO6391.getCode(lang) + " - " + lang}
+                    </option>
+                  </>
+                ))}
+              </select>
+            </div>
           </div>
         </div>
         <div className="min-h-32 py-4 px-2">
@@ -196,34 +226,7 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
             </select>
           </div>
         </div>
-        <div className="px-2 py-2">
-          <label
-            htmlFor="language"
-            className="my-1 flex text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
-          >
-            Language{" "}
-            {formik.touched.language && formik.errors.language
-              ? " - " + formik.errors.language
-              : null}
-          </label>
-          <div className="mt-1">
-            <select
-              id="language"
-              required
-              className="placeholder-font-normal block w-full appearance-none rounded-md border border-gray-400 bg-white px-3 py-2 text-sm font-normal placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border-gray-600 dark:bg-transparent dark:text-gray-200"
-              {...formik.getFieldProps("language")}
-            >
-              {" "}
-              {ISO6391.getAllNames().map((lang) => (
-                <>
-                  <option value={ISO6391.getCode(lang)}>
-                    {ISO6391.getCode(lang) + " - " + lang}
-                  </option>
-                </>
-              ))}
-            </select>
-          </div>
-        </div>
+
         <div className="flex px-2 py-2">
           <button
             type="submit"

--- a/app/modules/components/MetadataImmutable.tsx
+++ b/app/modules/components/MetadataImmutable.tsx
@@ -1,5 +1,6 @@
 import { Link } from "blitz"
 import moment from "moment"
+import ISO6391 from "iso-639-1"
 
 import AuthorAvatarsNew from "./AuthorAvatarsNew"
 import ViewAuthors from "./ViewAuthors"
@@ -11,7 +12,7 @@ const MetadataImmutable = ({ module }) => {
       <div className="text-center text-sm font-normal leading-4 lg:flex">
         <div className="flex-grow py-2">
           {module.published ? (
-            <>Published: {module.publishedAt.toISOString().substring(0, 10)}</>
+            <>{module.publishedAt.toISOString().substring(0, 10)}</>
           ) : (
             <>Last updated: {moment(module.updatedAt).fromNow()}</>
           )}
@@ -20,7 +21,7 @@ const MetadataImmutable = ({ module }) => {
           {module.published ? (
             <>
               <Link href={`https://doi.org/${module.prefix}/${module.suffix}`}>
-                <a className="underline">DOI: {`${module.prefix}/${module.suffix}`}</a>
+                <a className="underline">{`${module.prefix}/${module.suffix}`}</a>
               </Link>
             </>
           ) : (
@@ -30,11 +31,13 @@ const MetadataImmutable = ({ module }) => {
           )}
         </div>
         <div className="flex-grow py-2">
-          License:{" "}
           <Link href={module.license!.url!}>
             <a target="_blank">{module.license!.name}</a>
           </Link>
         </div>
+        {ISO6391.getName(module.language) && (
+          <div className="flex-grow py-2">{ISO6391.getName(module.language)}</div>
+        )}
       </div>
       <div
         className="module my-4 py-2 px-4 text-white"

--- a/app/modules/components/MetadataImmutable.tsx
+++ b/app/modules/components/MetadataImmutable.tsx
@@ -14,7 +14,7 @@ const MetadataImmutable = ({ module }) => {
           {module.published ? (
             <>{module.publishedAt.toISOString().substring(0, 10)}</>
           ) : (
-            <>Last updated: {moment(module.updatedAt).fromNow()}</>
+            <>Updated: {moment(module.updatedAt).fromNow()}</>
           )}
         </div>
         <div className="flex-grow py-2">
@@ -26,7 +26,7 @@ const MetadataImmutable = ({ module }) => {
             </>
           ) : (
             <>
-              DOI upon publish: <span className="">{`${module.prefix}/${module.suffix}`}</span>
+              DOI: <span className="">{`${module.prefix}/${module.suffix}`}</span>
             </>
           )}
         </div>

--- a/app/modules/components/MetadataInvite.tsx
+++ b/app/modules/components/MetadataInvite.tsx
@@ -4,6 +4,7 @@ import moment from "moment"
 import AuthorAvatarsNew from "./AuthorAvatarsNew"
 import ViewAuthors from "./ViewAuthors"
 import { Suspense } from "react"
+import ISO6391 from "iso-639-1"
 
 const MetadataInvite = ({ module }) => {
   return (
@@ -15,9 +16,9 @@ const MetadataInvite = ({ module }) => {
       >
         <div className="module divide-y divide-gray-100 border-0 border-gray-100 bg-white dark:divide-gray-600 dark:border-gray-600 dark:bg-gray-900">
           <div className="divide-y divide-gray-100 text-center text-sm font-normal leading-4 text-gray-500 dark:divide-gray-600 dark:bg-gray-800 dark:text-gray-200 lg:flex lg:divide-y-0 lg:divide-x">
-            <div className="flex-grow py-2">Last updated: {moment(module.updatedAt).fromNow()}</div>
+            <div className="flex-grow py-2">Updated: {moment(module.updatedAt).fromNow()}</div>
             <div className="flex-grow py-2">
-              DOI upon publish:{" "}
+              DOI:{" "}
               <span className="text-gray-300 dark:text-gray-600">{`${module.prefix}/${module.suffix}`}</span>
             </div>
             <div className="flex-grow py-2">
@@ -26,6 +27,9 @@ const MetadataInvite = ({ module }) => {
                 <a target="_blank">{module.license!.name}</a>
               </Link>
             </div>
+            {ISO6391.getName(module.language) && (
+              <div className="flex-grow py-2">{ISO6391.getName(module.language)}</div>
+            )}
           </div>
           <div className="min-h-32 py-4 px-2">
             <p className="text-sm font-normal leading-4 text-gray-500 dark:text-white">

--- a/app/modules/components/MetadataView.tsx
+++ b/app/modules/components/MetadataView.tsx
@@ -5,6 +5,7 @@ import toast from "react-hot-toast"
 import algoliasearch from "algoliasearch"
 import { getAlgoliaResults } from "@algolia/autocomplete-js"
 import { Add } from "@carbon/icons-react"
+import ISO6391 from "iso-639-1"
 
 import addAuthor from "../mutations/addAuthor"
 import AuthorAvatarsNew from "./AuthorAvatarsNew"
@@ -27,9 +28,9 @@ const MetadataView = ({ module, addAuthors, setQueryData, setAddAuthors }) => {
     <div className="module my-4 bg-gray-100 dark:bg-gray-600" style={{ padding: "1px" }}>
       <div className="module divide-y divide-gray-100 border-0 border-gray-100 bg-white dark:divide-gray-600 dark:border-gray-600 dark:bg-gray-900">
         <div className="divide-y divide-gray-100 text-center text-sm font-normal leading-4 text-gray-500 dark:divide-gray-600 dark:bg-gray-800 dark:text-gray-200 lg:flex lg:divide-y-0 lg:divide-x">
-          <div className="flex-grow py-2">Last updated: {moment(module.updatedAt).fromNow()}</div>
+          <div className="flex-grow py-2">Updated: {moment(module.updatedAt).fromNow()}</div>
           <div className="flex-grow py-2">
-            DOI upon publish:{" "}
+            DOI:{" "}
             <span className="text-gray-300 dark:text-gray-600">{`${module.prefix}/${module.suffix}`}</span>
           </div>
           <div className="flex-grow py-2">
@@ -38,6 +39,9 @@ const MetadataView = ({ module, addAuthors, setQueryData, setAddAuthors }) => {
               <a target="_blank">{module.license!.name}</a>
             </Link>
           </div>
+          {ISO6391.getName(module.language) && (
+            <div className="flex-grow py-2">{ISO6391.getName(module.language)}</div>
+          )}
         </div>
         <div className="min-h-32 py-4 px-2">
           <p className="text-sm font-normal leading-4 text-gray-500 dark:text-white">

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -6,6 +6,7 @@ import { useFormik } from "formik"
 import { Fragment, useState } from "react"
 import { z } from "zod"
 import { Checkmark, Close, InformationSquareFilled } from "@carbon/icons-react"
+import ISO6391 from "iso-639-1"
 
 import createModule from "../mutations/createModule"
 import toast from "react-hot-toast"
@@ -23,6 +24,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
       main: "",
       type: "",
       license: "",
+      language: "en",
       displayColor: "#574cfa",
     },
     validate: validateZodSchema(
@@ -31,6 +33,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
         description: z.string(),
         type: z.string().min(1),
         license: z.string().min(1),
+        language: z.string().min(1).max(2),
         displayColor: z.string().min(1),
       })
     ),
@@ -41,6 +44,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
           description: values.description,
           typeId: parseInt(values.type),
           licenseId: parseInt(values.license),
+          language: values.language,
           authors: [],
           displayColor: values.displayColor,
         }),
@@ -82,6 +86,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
     formik.setFieldValue("main", "")
     formik.setFieldValue("type", "")
     formik.setFieldValue("license", "")
+    formik.setFieldValue("language", "en")
     formik.setFieldValue("displayColor", "#574cfa")
   }
 
@@ -309,6 +314,34 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                               >
                                 Pink
                               </option>
+                            </select>
+                          </div>
+                        </div>
+                        <div className="my-4">
+                          <label
+                            htmlFor="language"
+                            className="my-1 text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
+                          >
+                            Language{" "}
+                            {formik.touched.language && formik.errors.language
+                              ? " - " + formik.errors.language
+                              : null}
+                            <p className="text-xs">Publish in your preferred language.</p>
+                          </label>
+                          <div className="mt-1">
+                            <select
+                              id="language"
+                              required
+                              className="placeholder-font-normal block w-full appearance-none rounded-md border border-gray-400 bg-white px-3 py-2 text-sm font-normal placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border-gray-600 dark:bg-transparent dark:text-gray-200"
+                              {...formik.getFieldProps("language")}
+                            >
+                              {ISO6391.getAllNames().map((lang) => (
+                                <>
+                                  <option value={ISO6391.getCode(lang)}>
+                                    {ISO6391.getCode(lang) + " - " + lang}
+                                  </option>
+                                </>
+                              ))}
                             </select>
                           </div>
                         </div>

--- a/app/modules/mutations/createModule.ts
+++ b/app/modules/mutations/createModule.ts
@@ -4,7 +4,7 @@ import generateSuffix from "./generateSuffix"
 
 export default resolver.pipe(
   resolver.authorize(),
-  async ({ title, description, typeId, licenseId, authors, displayColor }, ctx) => {
+  async ({ title, description, typeId, licenseId, authors, language, displayColor }, ctx) => {
     const authorInvitations = authors.map((author) => {
       return {
         workspaceId: author,
@@ -25,6 +25,7 @@ export default resolver.pipe(
         displayColor,
         title,
         description,
+        language,
         type: {
           connect: { id: typeId },
         },

--- a/app/modules/mutations/editModuleScreen.ts
+++ b/app/modules/mutations/editModuleScreen.ts
@@ -3,7 +3,7 @@ import db from "db"
 
 export default resolver.pipe(
   resolver.authorize(),
-  async ({ id, typeId, title, description, licenseId, displayColor }) => {
+  async ({ id, typeId, title, description, licenseId, displayColor, language }) => {
     const module = await db.module.update({
       where: { id },
       data: {
@@ -20,6 +20,7 @@ export default resolver.pipe(
             id: licenseId,
           },
         },
+        language,
       },
     })
 

--- a/app/modules/mutations/publishModule.ts
+++ b/app/modules/mutations/publishModule.ts
@@ -48,6 +48,7 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     schema: "5.3.1",
     type: module!.type!.name,
     title: module!.title,
+    language: module!.language,
     authors: module!.authors!.map((author) => {
       const js = {
         firstName: author.workspace?.firstName,
@@ -142,6 +143,7 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     description: publishedModule.description,
     publishedAt: publishedModule.publishedAt,
     displayColor: publishedModule.displayColor,
+    language: publishedModule.language,
   })
 
   return true

--- a/app/modules/mutations/updateCrossRef.ts
+++ b/app/modules/mutations/updateCrossRef.ts
@@ -44,6 +44,7 @@ export default resolver.pipe(resolver.authorize(), async ({ id }) => {
     schema: "5.3.1",
     type: module!.type!.name,
     title: module!.title,
+    language: module!.language,
     authors: module!.authors!.map((author) => {
       const js = {
         firstName: author.workspace?.firstName,

--- a/db/migrations/20220725113224_add_language_to_module/migration.sql
+++ b/db/migrations/20220725113224_add_language_to_module/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Module" ADD COLUMN     "language" TEXT NOT NULL DEFAULT 'en';

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -25,7 +25,8 @@ model Module {
   prefix         String?
   suffix         String?
   title          String
-  description    String? // Could rename to abstract/summary
+  description    String?
+  language       String    @default("en")
   license        License?  @relation(fields: [licenseId], references: [id])
   licenseId      Int?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "form-data": "4.0.0",
         "formik": "2.2.9",
         "husky": "8.0.1",
+        "iso-639-1": "2.1.15",
         "markdown-it": "13.0.1",
         "moment": "2.29.4",
         "passport-orcid": "0.0.4",
@@ -11067,6 +11068,14 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
+    },
+    "node_modules/iso-639-1": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.15.tgz",
+      "integrity": "sha512-7c7mBznZu2ktfvyT582E2msM+Udc1EjOyhVRE/0ZsjD9LBtWSm23h3PtiRh2a35XoUsTQQjJXaJzuLjXsOdFDg==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -28818,6 +28827,11 @@
     },
     "isexe": {
       "version": "2.0.0"
+    },
+    "iso-639-1": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.15.tgz",
+      "integrity": "sha512-7c7mBznZu2ktfvyT582E2msM+Udc1EjOyhVRE/0ZsjD9LBtWSm23h3PtiRh2a35XoUsTQQjJXaJzuLjXsOdFDg=="
     },
     "isobject": {
       "version": "3.0.1"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "form-data": "4.0.0",
     "formik": "2.2.9",
     "husky": "8.0.1",
+    "iso-639-1": "2.1.15",
     "markdown-it": "13.0.1",
     "moment": "2.29.4",
     "passport-orcid": "0.0.4",


### PR DESCRIPTION
This PR adds the language code to modules.

Specifically, it uses the ISO 639-1 standard as implemented in the [`iso-639-1` npm package](https://www.npmjs.com/package/iso-639-1). The parent standard is also indicated in the [CrossRef metadata schema](https://data.crossref.org/reports/help/schema_doc/5.3.1/index.html).

![Screenshot 2022-07-25 at 14 11 19](https://user-images.githubusercontent.com/2946344/180774776-7c0b4786-3b3a-42ea-87db-b1349984e5b5.png)

This is still a work in progress, but it's ongoing in any case. 

When ready and merged: Fixes #363.