### PR TITLE
Add algolia updatedAt indexing

### DIFF
--- a/app/api/update-index.ts
+++ b/app/api/update-index.ts
@@ -1,0 +1,24 @@
+import db from "db"
+import { CronJob } from "quirrel/blitz"
+import algoliasearch from "algoliasearch"
+import moment from "moment"
+
+const client = algoliasearch(process.env.ALGOLIA_APP_ID!, process.env.ALGOLIA_API_ADMIN_KEY!)
+const index = client.initIndex(`${process.env.ALGOLIA_PREFIX}_workspaces`)
+
+export default CronJob(
+  "api/update-authors-sort", // 👈 the route that it's reachable on
+  "0 0 * * *", // “At 00:00 every day.”
+  async () => {
+    const authors = await db.workspace.findMany()
+
+    const updateAuthors = authors.map((author) => {
+      return {
+        objectID: author.id,
+        updatedAt: moment(author.updatedAt).format(),
+      }
+    })
+
+    await index.partialUpdateObjects(updateAuthors)
+  }
+)

--- a/app/auth/mutations/verify-email.ts
+++ b/app/auth/mutations/verify-email.ts
@@ -27,10 +27,10 @@ export default resolver.pipe(
     const isValid = await verifyCode(code, hashedPassword)
     if (isValid) {
       await db.user.update({ where: { id: parseInt(userId) }, data: { emailIsVerified: true } })
-
       user!.memberships!.map(async (membership) => {
         await index.saveObject({
           objectID: membership.workspace.id,
+          updatedAt: user?.updatedAt,
           firstName: membership.workspace.firstName,
           lastName: membership.workspace.lastName,
           handle: membership.workspace.handle,


### PR DESCRIPTION
This PR adds the `updatedAt` property to Algolia for workspaces. This happens when:

1. Email is verified and a workspace is indexed for the first time
2. Every midnight

Fixes #505.