### PR TITLE
Remove @stripe/stripe-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@headlessui/react": "1.6.6",
         "@prisma/client": "4.1.0",
         "@react-pdf-viewer/core": "3.6.0",
-        "@stripe/stripe-js": "1.32.0",
         "@tailwindcss/forms": "0.5.2",
         "@tailwindcss/line-clamp": "0.4.0",
         "@uploadcare/react-widget": "2.1.5",
@@ -3371,11 +3370,6 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "node_modules/@stripe/stripe-js": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.32.0.tgz",
-      "integrity": "sha512-7EvBnbBfS1aynfLRmBFcuumHNGjKxnNkO47rorFBktqDYHwo7Yw6pfDW2iqq0R8r7i7XiJEdWPvvEgQAiDrx3A=="
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -23340,11 +23334,6 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "@stripe/stripe-js": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.32.0.tgz",
-      "integrity": "sha512-7EvBnbBfS1aynfLRmBFcuumHNGjKxnNkO47rorFBktqDYHwo7Yw6pfDW2iqq0R8r7i7XiJEdWPvvEgQAiDrx3A=="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@headlessui/react": "1.6.6",
     "@prisma/client": "4.1.0",
     "@react-pdf-viewer/core": "3.6.0",
-    "@stripe/stripe-js": "1.32.0",
     "@tailwindcss/forms": "0.5.2",
     "@tailwindcss/line-clamp": "0.4.0",
     "@uploadcare/react-widget": "2.1.5",


### PR DESCRIPTION
Replaces  #554.

This dependency was previously marked for deletion - and after testing it locally it seemed like it was indeed unnecessary. The `stripe` dependency is sufficient.

## To do
- [x] Remove from wiki

