### PR TITLE
Add FilePreviewer to drafts

### DIFF
--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -1,0 +1,113 @@
+import { Viewer, Worker } from "@react-pdf-viewer/core"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
+import { a11yLight, a11yDark } from "react-syntax-highlighter/dist/cjs/styles/prism"
+import { useMediaPredicate } from "react-media-hook"
+
+import "@react-pdf-viewer/core/lib/styles/index.css"
+import remarkMath from "remark-math"
+import rehypeKatex from "rehype-katex"
+import "katex/dist/katex.min.css" // `rehype-katex` does not import the CSS for you
+import { useEffect, useState } from "react"
+
+const MainFileViewer = ({ mainFile, module }) => {
+  const prefersDarkMode = useMediaPredicate("(prefers-color-scheme: dark)")
+  const [mainFileMarkdown, setMarkdown] = useState("")
+
+  useEffect(() => {
+    if (mainFile.mimeType === "text/markdown") {
+      fetch(mainFile.cdnUrl)
+        .then((response) => response.text())
+        .then((body) => setMarkdown(body))
+        .then((res) => console.log(mainFileMarkdown))
+    }
+  }, [])
+  return (
+    <>
+      {mainFile.name ? (
+        <>
+          {/* Preview image */}
+          {mainFile.isImage ? (
+            <img src={mainFile.cdnUrl} className="mx-auto my-2 h-auto w-full" />
+          ) : (
+            ""
+          )}
+          {/* Preview PDF */}
+          {mainFile.mimeType.startsWith("application/pdf") ? (
+            <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.14.305/build/pdf.worker.min.js">
+              <div style={{ height: "750px" }} className="max-w-screen text-gray-900">
+                <Viewer fileUrl={mainFile.cdnUrl} />
+              </div>
+            </Worker>
+          ) : (
+            ""
+          )}
+          {/* Preview Markdown */}
+          {mainFile.mimeType.startsWith("text/markdown") ? (
+            <div className="coc">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkMath]}
+                rehypePlugins={[rehypeKatex]}
+                linkTarget="_blank"
+                components={{
+                  code({ node, inline, className, children, ...props }) {
+                    const match = /language-(\w+)/.exec(className || "")
+                    return !inline && match ? (
+                      <SyntaxHighlighter
+                        style={prefersDarkMode ? a11yDark : a11yLight}
+                        language={match[1]}
+                        PreTag="div"
+                        class="coc"
+                        customStyle={{
+                          backgroundColor: prefersDarkMode ? "#374151" : "#f3f4f6",
+                          padding: "0",
+                          margin: "0",
+                        }}
+                        {...props}
+                      >
+                        {String(children).replace(/\n$/, "")}
+                      </SyntaxHighlighter>
+                    ) : (
+                      <code className={className} {...props}>
+                        {children}
+                      </code>
+                    )
+                  },
+                }}
+              >
+                {mainFileMarkdown}
+              </ReactMarkdown>
+            </div>
+          ) : (
+            ""
+          )}
+          {/* Preview Office files */}
+          {mainFile.mimeType.startsWith("application/vnd.ms-excel") ||
+          mainFile.mimeType.startsWith(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          ) ||
+          mainFile.mimeType.startsWith(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          ) ||
+          mainFile.mimeType.startsWith(
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+          ) ? (
+            <iframe
+              src={`https://view.officeapps.live.com/op/embed.aspx?src=${mainFile.cdnUrl}`}
+              width="100%"
+              height="800px"
+              frameBorder="0"
+            ></iframe>
+          ) : (
+            ""
+          )}
+        </>
+      ) : (
+        ""
+      )}
+    </>
+  )
+}
+
+export default MainFileViewer

--- a/app/modules/components/EditMainFile.jsx
+++ b/app/modules/components/EditMainFile.jsx
@@ -8,6 +8,7 @@ import addMain from "../mutations/addMain"
 import EditMainFileDisplay from "../../core/components/EditMainFileDisplay"
 import { fileSizeLimit, fileTypeLimit } from "../../core/utils/fileTypeLimit"
 import uploadcareError from "../../core/utils/uploadcareError"
+import FilePreviewer from "../../core/components/FilePreviewer"
 
 const validators = [fileTypeLimit, fileSizeLimit]
 
@@ -26,14 +27,17 @@ const EditMainFile = ({
   return (
     <>
       {Object.keys(mainFile).length > 0 ? (
-        <EditMainFileDisplay
-          name={mainFile.name}
-          size={mainFile.size}
-          url={mainFile.cdnUrl}
-          uuid={mainFile.uuid}
-          moduleId={moduleEdit.id}
-          setQueryData={setQueryData}
-        />
+        <>
+          <EditMainFileDisplay
+            name={mainFile.name}
+            size={mainFile.size}
+            url={mainFile.cdnUrl}
+            uuid={mainFile.uuid}
+            moduleId={moduleEdit.id}
+            setQueryData={setQueryData}
+          />
+          <FilePreviewer module={module} mainFile={mainFile} />
+        </>
       ) : user.emailIsVerified ? (
         <>
           <button

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -4,15 +4,7 @@ import { AddAlt, NextFilled, PreviousFilled } from "@carbon/icons-react"
 import Xarrows from "react-xarrows"
 import { useEffect, useState } from "react"
 import Helmet from "react-helmet"
-import { Viewer, Worker } from "@react-pdf-viewer/core"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
-import { a11yLight, a11yDark } from "react-syntax-highlighter/dist/cjs/styles/prism"
-import "@react-pdf-viewer/core/lib/styles/index.css"
-import remarkMath from "remark-math"
-import rehypeKatex from "rehype-katex"
-import "katex/dist/katex.min.css" // `rehype-katex` does not import the CSS for you
+import FilePreviewer from "../../core/components/FilePreviewer"
 
 import Layout from "../../core/layouts/Layout"
 import db from "db"
@@ -268,93 +260,15 @@ const Module = ({ module, mainFile, supportingRaw }) => {
       </div>
       <article className="my-4 mx-4 max-w-3xl md:mx-auto">
         <MetadataImmutable module={module} />
-        {mainFile.name ? (
-          <div className="my-8">
-            <h2 className="text-lg">Main file</h2>
-            <ViewFiles
-              name={mainFile.name}
-              size={mainFile.size}
-              url={`/api/modules/main/${module.suffix}`}
-            />
-            {/* Preview image */}
-            {mainFile.isImage ? (
-              <img src={mainFile.cdnUrl} className="mx-auto my-2 h-auto w-full" />
-            ) : (
-              ""
-            )}
-            {/* Preview PDF */}
-            {mainFile.mimeType.startsWith("application/pdf") ? (
-              <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.14.305/build/pdf.worker.min.js">
-                <div style={{ height: "750px" }} className="max-w-screen text-gray-900">
-                  <Viewer fileUrl={mainFile.cdnUrl} />
-                </div>
-              </Worker>
-            ) : (
-              ""
-            )}
-            {/* Preview Markdown */}
-            {mainFile.mimeType.startsWith("text/markdown") ? (
-              <div className="coc">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkMath]}
-                  rehypePlugins={[rehypeKatex]}
-                  linkTarget="_blank"
-                  components={{
-                    code({ node, inline, className, children, ...props }) {
-                      const match = /language-(\w+)/.exec(className || "")
-                      return !inline && match ? (
-                        <SyntaxHighlighter
-                          style={prefersDarkMode ? a11yDark : a11yLight}
-                          language={match[1]}
-                          PreTag="div"
-                          class="coc"
-                          customStyle={{
-                            backgroundColor: prefersDarkMode ? "#374151" : "#f3f4f6",
-                            padding: "0",
-                            margin: "0",
-                          }}
-                          {...props}
-                        >
-                          {String(children).replace(/\n$/, "")}
-                        </SyntaxHighlighter>
-                      ) : (
-                        <code className={className} {...props}>
-                          {children}
-                        </code>
-                      )
-                    },
-                  }}
-                >
-                  {mainFileMarkdown}
-                </ReactMarkdown>
-              </div>
-            ) : (
-              ""
-            )}
-            {/* Preview Office files */}
-            {mainFile.mimeType.startsWith("application/vnd.ms-excel") ||
-            mainFile.mimeType.startsWith(
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ) ||
-            mainFile.mimeType.startsWith(
-              "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ) ||
-            mainFile.mimeType.startsWith(
-              "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            ) ? (
-              <iframe
-                src={`https://view.officeapps.live.com/op/embed.aspx?src=${mainFile.cdnUrl}`}
-                width="100%"
-                height="800px"
-                frameBorder="0"
-              ></iframe>
-            ) : (
-              ""
-            )}
-          </div>
-        ) : (
-          ""
-        )}
+        <div className="my-8">
+          <h2 className="text-lg">Main file</h2>
+          <ViewFiles
+            name={mainFile.name}
+            size={mainFile.size}
+            url={`/api/modules/main/${module.suffix}`}
+          />
+          <FilePreviewer module={module} mainFile={mainFile} />
+        </div>
         <div className="mb-28 grid-cols-2 gap-x-4 md:grid">
           {supportingRaw.files.length > 0 ? (
             <div className="">


### PR DESCRIPTION
This PR adds a file previewer to the drafts page.

In this change, I factored out the already existing preview code for the published page into it's own component. This is now reused in the `/drafts` page - upgrades to file previews will that way also upgrade in both places 😊 

I'm closing out July's milestones so I might end up merging this without review if deployment and testing works.

Fixes #488.