### PR TITLE
Show supporting files instead of downloading, when clicking their title 

### DIFF
--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -13,7 +13,6 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
         href={url}
         className="mr-1 flex flex-grow rounded border border-gray-100 px-2 py-1 text-xs font-normal leading-4 text-gray-900 shadow-sm hover:bg-gray-100 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
         target="_blank"
-        download
         rel="noreferrer"
       >
         <span className="inline-block  flex-grow align-middle">{name}</span>

--- a/app/modules/components/ViewFiles.tsx
+++ b/app/modules/components/ViewFiles.tsx
@@ -8,7 +8,6 @@ const ViewFiles = ({ name, size, url }) => {
         href={url}
         className="mr-1 flex flex-grow rounded border border-gray-100 px-2 py-1 text-sm font-normal leading-4 text-gray-900 shadow-sm hover:bg-gray-100 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
         target="_blank"
-        download
         rel="noreferrer"
       >
         <span className="inline-block  flex-grow align-middle">{name}</span>


### PR DESCRIPTION
This PR will make clicking the supporting title show the file, instead of downloading. Fixes #566 