### PR TITLE
Add enum for ISO 639-1 language codes

### DIFF
--- a/app/modules/components/MetadataEdit.tsx
+++ b/app/modules/components/MetadataEdit.tsx
@@ -32,7 +32,7 @@ const MetadataEdit = ({ module, setQueryData, setIsEditing }) => {
         description: z.string(),
         license: z.string().min(1),
         displayColor: z.string().min(1),
-        language: z.string().min(1).max(2),
+        language: z.enum([...ISO6391.getAllCodes()] as any),
       })
     ),
     onSubmit: async (values) => {

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -12,6 +12,7 @@ import createModule from "../mutations/createModule"
 import toast from "react-hot-toast"
 
 const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
+  console.log([...ISO6391.getAllCodes()])
   const [openCreate, setCreateOpen] = useState(false)
   const [moduleTypes] = useQuery(getTypes, undefined)
   const [licenses] = useQuery(getLicenses, undefined)
@@ -33,7 +34,7 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
         description: z.string(),
         type: z.string().min(1),
         license: z.string().min(1),
-        language: z.string().min(1).max(2),
+        language: z.enum([...ISO6391.getAllCodes()] as any),
         displayColor: z.string().min(1),
       })
     ),


### PR DESCRIPTION
This PR adds improved validation of language codes to the 
platform.

Fixes #544.
