### PR TITLE
Wrap the edit icon on the draft page as a button

### DIFF
--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -333,25 +333,27 @@ const ModuleEdit = ({
           </div>
         </div>
         <div className="items-middle pt-8">
-          {isEditing ? (
-            <EditOff
-              size={24}
-              className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
-              onClick={() => {
-                setIsEditing(false)
-              }}
-              aria-label="End editing mode without saving"
-            />
-          ) : (
-            <Edit
-              size={24}
-              className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
-              onClick={() => {
-                setIsEditing(true)
-              }}
-              aria-label="Start editing mode"
-            />
-          )}
+          <button>
+            {isEditing ? (
+              <EditOff
+                size={24}
+                className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
+                onClick={() => {
+                  setIsEditing(false)
+                }}
+                aria-label="End editing mode without saving"
+              />
+            ) : (
+              <Edit
+                size={24}
+                className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
+                onClick={() => {
+                  setIsEditing(true)
+                }}
+                aria-label="Start editing mode"
+              />
+            )}
+          </button>
         </div>
       </div>
       <div className="relative">

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -333,25 +333,19 @@ const ModuleEdit = ({
           </div>
         </div>
         <div className="items-middle pt-8">
-          <button>
+          <button
+            onClick={() => {
+              setIsEditing(!isEditing)
+            }}
+            aria-label={isEditing ? "End editing mode without saving" : "Start editing mode"}
+          >
             {isEditing ? (
               <EditOff
                 size={24}
                 className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
-                onClick={() => {
-                  setIsEditing(false)
-                }}
-                aria-label="End editing mode without saving"
               />
             ) : (
-              <Edit
-                size={24}
-                className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200"
-                onClick={() => {
-                  setIsEditing(true)
-                }}
-                aria-label="Start editing mode"
-              />
+              <Edit size={24} className="h-6 w-6 fill-current text-gray-900 dark:text-gray-200" />
             )}
           </button>
         </div>


### PR DESCRIPTION
This PR wraps the edit icon in a `button` element so that it appears as a button. This will enable focus and hover:cursor-pointer by itself (+ has an added benefit of focusing by tab).

Fixes #579.