### PR TITLE
Increase stale PR to 10 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
         exempt-issue-labels: 'blocked,wontfix'
         exempt-pr-labels: 'blocked,wontfix'
         days-before-issue-stale: 60
-        days-before-pr-stale: 2
+        days-before-pr-stale: 10
         days-before-issue-close: -1
         days-before-pr-close: -1
 


### PR DESCRIPTION
Marking PRs as stale after 2 days felt like it was a bit much. This PR proposes to change it to 10 days and see how that feels.

The auto-deployments will self-destruct after two days regardless.

@nsunami any thoughts?