### PR TITLE
Add logic to include remote

### DIFF
--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -150,7 +150,8 @@ const OnboardingProfile = ({ data }) => {
 
   return (
     <>
-      {!workspaceFirstName ||
+      {!data.workspace.bio ||
+      !workspaceFirstName ||
       !workspaceLastName ||
       !workspaceBio ||
       !workspacePronouns ||


### PR DESCRIPTION
This PR reintroduces the original logic as an additional OR component. This way the onboarding quest for profile information won't show in a new browser if the `localStorage` hasn't been set (yet).

Fixes #570.