### PR TITLE
Add DataCite as data source for DOIs

### DIFF
--- a/app/core/queries/getTypes.ts
+++ b/app/core/queries/getTypes.ts
@@ -2,6 +2,9 @@ import db from "db"
 
 export default async function getTypes() {
   const types = await db.moduleType.findMany({
+    where: {
+      originType: "ResearchEquals",
+    },
     orderBy: [
       {
         name: "asc",

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -46,6 +46,7 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
             },
             create: {
               name: crType,
+              originType: "CrossRef",
             },
           },
         },
@@ -110,6 +111,7 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
             },
             create: {
               name: metadata.data.attributes.types.resourceType || "Other",
+              originType: "DataCite",
             },
           },
         },

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -98,8 +98,11 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
         suffix: metadata.data.attributes.suffix,
         isbn: undefined, // Not used in schema
         url: `https://doi.org/${metadata.data.id}`,
+        language: metadata.data.attributes.language || "en",
         title: metadata.data.attributes.titles[0].title,
-        description: metadata.data.attributes.descriptions[0].description,
+        description: metadata.data.attributes.descriptions[0]
+          ? metadata.data.attributes.descriptions[0].description
+          : undefined,
         type: {
           connectOrCreate: {
             where: {
@@ -113,9 +116,9 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
         license: metadata.data.attributes.rightsList[0]
           ? {
               connectOrCreate: {
-                where: { url: metadata.data.attributes.rightsList[0].rightsUri },
+                where: { url: metadata.data.attributes.rightsList[0].rightsUri || "undefined" },
                 create: {
-                  url: metadata.data.attributes.rightsList[0].rightsUri,
+                  url: metadata.data.attributes.rightsList[0].rightsUri || "undefined",
                   source: "DataCite",
                 },
               },

--- a/db/migrations/20220810125921_add_originmetadata/migration.sql
+++ b/db/migrations/20220810125921_add_originmetadata/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Module" ADD COLUMN     "originMetadata" TEXT NOT NULL DEFAULT 'ResearchEquals';

--- a/db/migrations/20220811115022_add_origin_type/migration.sql
+++ b/db/migrations/20220811115022_add_origin_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ModuleType" ADD COLUMN     "originType" TEXT NOT NULL DEFAULT 'ResearchEquals';

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -62,12 +62,13 @@ model License {
 }
 
 model ModuleType {
-  id        Int      @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  wikidata  String?
-  name      String   @unique
-  schema    String   @default("CreativeWork")
-  Module    Module[]
+  id         Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  originType String   @default("ResearchEquals")
+  wikidata   String?
+  name       String   @unique
+  schema     String   @default("CreativeWork")
+  Module     Module[]
 }
 
 model Authorship {

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -20,6 +20,7 @@ model Module {
   published      Boolean   @default(false)
   publishedAt    DateTime?
   publishedWhere String?
+  originMetadata String    @default("ResearchEquals")
   url            String?
   isbn           String?
   prefix         String?


### PR DESCRIPTION
This PR adds DataCite as source for DOIs, in references and for linking modules.

This expands our range of DOIs that we can ingest, spanning both CrossRef and DataCite (two of the largest registration agencies I think).

Fixes #545 .

## To-Do

- [ ] Update production database for
  - [ ] `Module` now has `originMetadata` - need to ensure all existing non-ResearchEquals ones are named CrossRef appropriately.
  - [ ] `ModuleType` now has `originType` - need to ensure all existing ones without Wikidata identifier are named CrossRef appropriately.