### PR TITLE
Add Discord invitation to onboarding

### DIFF
--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -1,8 +1,8 @@
-import { useMutation, useQuery } from "blitz"
+import { useMutation, useQuery, Link } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 import { Formik, Form } from "formik"
-import { Email, UserAvatar, User, Parameter } from "@carbon/icons-react"
+import { Email, UserAvatar, User, Parameter, LogoDiscord } from "@carbon/icons-react"
 import { useRecoilValue, useRecoilState } from "recoil"
 
 import changeAvatar from "../../workspaces/mutations/changeAvatar"
@@ -16,6 +16,7 @@ import {
   workspacePronounsAtom,
   workspaceUrlAtom,
   settingsModalAtom,
+  userDiscordAtom,
 } from "../utils/Atoms"
 
 const OnboardingQuests = ({ data, expire, signature, refetch }) => {
@@ -31,6 +32,7 @@ const OnboardingQuests = ({ data, expire, signature, refetch }) => {
       />
       <OnboardingProfile data={data} />
       <OnboardingDraft data={data.workspace} refetch={refetch} />
+      <OnboardingDiscord data={data.workspace} refetch={refetch} />
     </>
   )
 }
@@ -303,6 +305,57 @@ const OnboardingDraft = ({ data, refetch }) => {
                 buttonStyle="whitespace-nowrap font-medium hover:text-blue-600 underline"
                 refetchFn={refetch}
               />
+            </p>
+          </div>
+        </div>
+      ) : (
+        ""
+      )}
+    </>
+  )
+}
+
+const OnboardingDiscord = () => {
+  const [userDiscord, setUserDiscord] = useRecoilState(userDiscordAtom)
+
+  return (
+    <>
+      {userDiscord ? (
+        <div
+          key="draft-onboarding-quest"
+          className="onboarding my-2 flex w-full flex-col rounded-r border-l-4 border-fuchsia-400 bg-fuchsia-50 p-4 dark:border-fuchsia-200 dark:bg-fuchsia-900 lg:my-0"
+        >
+          <div className="flex flex-grow">
+            <div className="">
+              <LogoDiscord
+                size={32}
+                className="h-5 w-5 text-fuchsia-400 dark:text-fuchsia-200"
+                aria-hidden="true"
+              />
+            </div>
+            <div className="ml-3 flex-1 text-fuchsia-800 dark:text-fuchsia-200 md:flex">
+              <p className="mr-2 text-sm">
+                <span className=" font-bold">Meeting space</span>{" "}
+                <span>
+                  We informally chat with other people in the community, exchange best practices,
+                  and support each other!
+                </span>
+              </p>
+            </div>
+          </div>
+          <div className="block text-right text-fuchsia-700 dark:text-fuchsia-200">
+            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+              <Link href="https://discord.gg/SefsGJWWSw">
+                <a
+                  target="_blank"
+                  className="underline"
+                  onClick={() => {
+                    setUserDiscord(!userDiscord)
+                  }}
+                >
+                  Join chat <span aria-hidden="true">&rarr;</span>
+                </a>
+              </Link>
             </p>
           </div>
         </div>

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -337,8 +337,8 @@ const OnboardingDiscord = () => {
               <p className="mr-2 text-sm">
                 <span className=" font-bold">Meeting space</span>{" "}
                 <span>
-                  We informally chat with other people in the community, exchange best practices,
-                  and support each other!
+                  We have an informal chat room to exchange best practices, support each other, and
+                  find collaborators!
                 </span>
               </p>
             </div>

--- a/app/core/utils/Atoms.tsx
+++ b/app/core/utils/Atoms.tsx
@@ -39,6 +39,12 @@ const settingsModalAtom = atom({
   effects_UNSTABLE: [persistAtom],
 })
 
+const userDiscordAtom = atom({
+  key: "userDiscord",
+  default: true,
+  effects_UNSTABLE: [persistAtom],
+})
+
 export {
   workspaceFirstNameAtom,
   workspaceLastNameAtom,
@@ -46,4 +52,5 @@ export {
   workspacePronounsAtom,
   workspaceUrlAtom,
   settingsModalAtom,
+  userDiscordAtom,
 }


### PR DESCRIPTION
This PR adds an onboarding quest to promote users to join the Discord channel.

Previously it was buried in the footer, which made it easy to miss. As we try to scaffold and reduce barriers to participation in our community, this is a part to point people in the right direction more easily and provide the information in various spaces.

This is managed with a local state, so this will reappear when people login elsewhere or in a different browser. That may be annoying so we'll need to see how people respond. This was an easier implementation than going the route of adding a database item, adding a mutation, etc.

## Screenshot

<img width="1886" alt="Screenshot 2022-08-17 at 11 57 05" src="https://user-images.githubusercontent.com/2946344/185092021-fc252290-4a16-4b7f-a88a-5032d9fce8fc.png">
