### PR TITLE
Prevent the buttons from shifting on the Collections modal

### DIFF
--- a/app/core/modals/CollectionsModal.tsx
+++ b/app/core/modals/CollectionsModal.tsx
@@ -150,8 +150,8 @@ export default function CollectionsModal({ button, styling, user, workspace }) {
                               className={({ active, checked }) =>
                                 `${
                                   active || checked
-                                    ? "ring-2 ring-indigo-600 ring-opacity-60 ring-offset-2 ring-offset-indigo-300"
-                                    : "border border-dashed border-gray-400"
+                                    ? "border border-transparent ring-2 ring-indigo-600 ring-opacity-60 ring-offset-2 ring-offset-indigo-300"
+                                    : "border border-dashed border-gray-400 ring-2 ring-transparent ring-offset-2 ring-offset-transparent"
                                 }
                           ${
                             active || checked


### PR DESCRIPTION
This PR adds transparent borders and rings to the collections buttons to prevent them from shifting.

Fixes #662.


https://user-images.githubusercontent.com/17035406/188479896-4b3be1f9-263e-4efe-bdb0-04d62cf14c2f.mov

