### PR TITLE
Add email notifications

### DIFF
--- a/app/api/approval-mailer.ts
+++ b/app/api/approval-mailer.ts
@@ -18,6 +18,7 @@ export default Queue("api/approval-mailer", async (moduleId) => {
                     select: {
                       emailConsent: true,
                       email: true,
+                      emailIsVerified: true,
                     },
                   },
                 },
@@ -31,10 +32,18 @@ export default Queue("api/approval-mailer", async (moduleId) => {
 
   module?.authors.map(async (author) => {
     author.workspace?.members.map(async (member) => {
-      if (member.emailApprovals && member.user?.emailConsent && author.acceptedInvitation) {
+      if (
+        member.emailApprovals &&
+        member.user?.emailConsent &&
+        member.user.emailIsVerified &&
+        author.acceptedInvitation
+      ) {
         await sendApproval(
-          `${author.workspace?.firstName} ${author.workspace?.lastName}`,
-          module.title,
+          {
+            name: `${author.workspace?.firstName} ${author.workspace?.lastName}`,
+            title: module.title,
+            url: `${process.env.APP_ORIGIN}/drafts?suffix=${module.suffix}`,
+          },
           member.user?.email
         )
       }

--- a/app/api/approval-mailer.ts
+++ b/app/api/approval-mailer.ts
@@ -1,0 +1,43 @@
+import { sendApproval } from "app/postmark"
+import { Queue } from "quirrel/next"
+import db from "../../db"
+
+export default Queue("api/approval-mailer", async (moduleId) => {
+  const module = await db.module.findFirst({
+    where: {
+      id: moduleId!,
+    },
+    include: {
+      authors: {
+        include: {
+          workspace: {
+            include: {
+              members: {
+                include: {
+                  user: {
+                    select: {
+                      emailConsent: true,
+                      email: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  module?.authors.map(async (author) => {
+    author.workspace?.members.map(async (member) => {
+      if (member.emailApprovals && member.user?.emailConsent && author.acceptedInvitation) {
+        await sendApproval(
+          `${author.workspace?.firstName} ${author.workspace?.lastName}`,
+          module.title,
+          member.user?.email
+        )
+      }
+    })
+  })
+})

--- a/app/api/approval-mailer.ts
+++ b/app/api/approval-mailer.ts
@@ -2,10 +2,10 @@ import { sendApproval } from "app/postmark"
 import { Queue } from "quirrel/next"
 import db from "../../db"
 
-export default Queue("api/approval-mailer", async (moduleId) => {
+export default Queue("api/approval-mailer", async (moduleId: number) => {
   const module = await db.module.findFirst({
     where: {
-      id: moduleId!,
+      id: moduleId,
     },
     include: {
       authors: {

--- a/app/api/invitation-mailer.ts
+++ b/app/api/invitation-mailer.ts
@@ -8,7 +8,28 @@ export default Queue("api/invitation-mailer", async (authorshipId: number) => {
     where: {
       id: authorshipId,
     },
+    include: {
+      workspace: {
+        include: {
+          members: {
+            include: {
+              user: {
+                select: {
+                  emailConsent: true,
+                  email: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   })
-  // send email
-  await sendInvitation()
+
+  // Send to all members who have consented to receive invitations
+  authorship?.workspace?.members.map(async (member) => {
+    if (member.emailInvitations && member.user?.emailConsent) {
+      await sendInvitation()
+    }
+  })
 })

--- a/app/api/invitation-mailer.ts
+++ b/app/api/invitation-mailer.ts
@@ -1,0 +1,14 @@
+import { Queue } from "quirrel/next"
+import db from "../../db"
+import { sendInvitation } from "../postmark"
+
+export default Queue("api/invitation-mailer", async (authorshipId: number) => {
+  // find authorship with module
+  const authorship = await db.authorship.findFirst({
+    where: {
+      id: authorshipId,
+    },
+  })
+  // send email
+  await sendInvitation()
+})

--- a/app/api/invitation-mailer.ts
+++ b/app/api/invitation-mailer.ts
@@ -18,6 +18,7 @@ export default Queue("api/invitation-mailer", async (authorshipId: number) => {
                 select: {
                   emailConsent: true,
                   email: true,
+                  emailIsVerified: true,
                 },
               },
             },
@@ -28,9 +29,16 @@ export default Queue("api/invitation-mailer", async (authorshipId: number) => {
   })
 
   // Send to all members who have consented to receive invitations
+  // TODO COLLECTIONS: Add conditional logic to those who CAN accept/decline
   authorship?.workspace?.members.map(async (member) => {
-    if (member.emailInvitations && member.user?.emailConsent) {
-      await sendInvitation(member.user.email, authorship.module.title)
+    if (member.emailInvitations && member.user?.emailConsent && member.user.emailIsVerified) {
+      await sendInvitation(member.user.email, {
+        title: authorship.module.title,
+        url: `${process.env.APP_ORIGIN}/invitations?suffix=${authorship.module.suffix}`,
+        product_url: process.env.APP_ORIGIN,
+        product_name: "ResearchEquals",
+        company_name: "Liberate Science GmbH",
+      })
     }
   })
 })

--- a/app/api/invitation-mailer.ts
+++ b/app/api/invitation-mailer.ts
@@ -9,6 +9,7 @@ export default Queue("api/invitation-mailer", async (authorshipId: number) => {
       id: authorshipId,
     },
     include: {
+      module: true,
       workspace: {
         include: {
           members: {
@@ -29,7 +30,7 @@ export default Queue("api/invitation-mailer", async (authorshipId: number) => {
   // Send to all members who have consented to receive invitations
   authorship?.workspace?.members.map(async (member) => {
     if (member.emailInvitations && member.user?.emailConsent) {
-      await sendInvitation()
+      await sendInvitation(member.user.email, authorship.module.title)
     }
   })
 })

--- a/app/api/weekly-digest-mailer.ts
+++ b/app/api/weekly-digest-mailer.ts
@@ -58,7 +58,6 @@ export default CronJob(
     })
 
     workspaces.map(async (workspace) => {
-      // new published modules past week you followd
       const followedWorkspaces = await db.workspace.findFirst({
         where: {
           id: workspace.id,
@@ -75,6 +74,7 @@ export default CronJob(
           },
         },
       })
+
       let newModules = [] as any
       followedWorkspaces?.following.map((following) => {
         return following.authorships.map((author) => {
@@ -89,8 +89,7 @@ export default CronJob(
           }
         })
       })
-      console.log(newModules)
-      // awaiting your approval
+
       const myDrafts = await db.authorship.findMany({
         where: {
           acceptedInvitation: true,
@@ -120,7 +119,12 @@ export default CronJob(
       })
 
       workspace.members.map(async (member) => {
-        if (member.emailInvitations && member.user?.emailConsent && member.user.emailIsVerified) {
+        if (
+          member.emailInvitations &&
+          member.user?.emailConsent &&
+          member.user.emailIsVerified &&
+          (newModules.length > 0 || myDrafts.length > 0 || invitations.length > 0)
+        ) {
           // TODO: conditional on that there is something to provide a digest on!
           await sendDigest(
             {

--- a/app/api/weekly-digest-mailer.ts
+++ b/app/api/weekly-digest-mailer.ts
@@ -1,0 +1,168 @@
+import db from "db"
+import { CronJob } from "quirrel/blitz"
+import { sendDigest } from "../postmark"
+
+// https://stackoverflow.com/questions/6117814/get-week-of-year-in-javascript-like-in-php
+function getWeekNumber(d) {
+  // Copy date so don't modify original
+  d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
+  // Set to nearest Thursday: current date + 4 - current day number
+  // Make Sunday's day number 7
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7))
+  // Get first day of year
+  var yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+  // Calculate full weeks to nearest Thursday
+  var weekNo = Math.ceil(((d - yearStart.getTime()) / 86400000 + 1) / 7)
+  // Return array of year and week number
+  return weekNo
+}
+
+export default CronJob(
+  "api/weekly-digest-mailer", // 👈 the route that it's reachable on
+  "0 7 * * 1", // every monday at 7AM
+  async () => {
+    const datetime = new Date()
+    const lastWeek = new Date(datetime.getTime() - 24 * 60 * 60 * 1000 * 7)
+
+    // find workspaces
+    const workspaces = await db.workspace.findMany({
+      where: {
+        id: 52, // TODO: Remove because this was for testing
+      },
+      include: {
+        members: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                emailConsent: true,
+                email: true,
+                emailIsVerified: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const latestWorkspaces = await db.workspace.findMany({
+      where: {
+        createdAt: {
+          gt: lastWeek,
+        },
+        NOT: {
+          firstName: null,
+          lastName: null,
+        },
+      },
+    })
+
+    workspaces.map(async (workspace) => {
+      // new published modules past week you followd
+      const followedWorkspaces = await db.workspace.findFirst({
+        where: {
+          id: workspace.id,
+        },
+        include: {
+          following: {
+            include: {
+              authorships: {
+                include: {
+                  module: true,
+                },
+              },
+            },
+          },
+        },
+      })
+      let newModules = [] as any
+      followedWorkspaces?.following.map((following) => {
+        return following.authorships.map((author) => {
+          if (
+            author.module.published &&
+            author.module.publishedAt?.getTime()! > lastWeek.getTime()
+          ) {
+            newModules.push({
+              title: author.module.title,
+              url: `https://doi.org/${author.module.prefix}/${author.module.suffix}`,
+            })
+          }
+        })
+      })
+      console.log(newModules)
+      // awaiting your approval
+      const myDrafts = await db.authorship.findMany({
+        where: {
+          acceptedInvitation: true,
+          workspaceId: workspace.id,
+        },
+        include: {
+          module: {
+            select: { title: true, suffix: true },
+          },
+        },
+      })
+
+      // invitations
+      const invitations = await db.authorship.findMany({
+        where: {
+          acceptedInvitation: null,
+          workspaceId: workspace.id,
+        },
+        include: {
+          module: {
+            select: {
+              title: true,
+              suffix: true,
+            },
+          },
+        },
+      })
+
+      workspace.members.map(async (member) => {
+        if (member.emailInvitations && member.user?.emailConsent && member.user.emailIsVerified) {
+          // TODO: conditional on that there is something to provide a digest on!
+          await sendDigest(
+            {
+              title: "ResearchEquals weekly",
+              name:
+                workspace.name ||
+                `${workspace.firstName} ${workspace.lastName}` ||
+                `@${workspace.handle}`,
+              week: getWeekNumber(datetime),
+              year: datetime.getFullYear(),
+              modules: newModules.map((module) => {
+                return {
+                  name: module.title,
+                  url: module.url,
+                }
+              }),
+              drafts: myDrafts.map((draft) => {
+                return {
+                  name: draft.module.title,
+                  url: `${process.env.APP_ORIGIN}/drafts?suffix=${draft.module.suffix}`,
+                }
+              }),
+              invitations: invitations.map((invite) => {
+                return {
+                  name: invite.module.title,
+                  url: `${process.env.APP_ORIGIN}/invitations?suffix=${invite.module.suffix}`,
+                }
+              }),
+              newWorkspaces: latestWorkspaces.map((workspace) => {
+                return {
+                  name: workspace.name || `${workspace.firstName} ${workspace.lastName}`,
+                  url: `${process.env.APP_ORIGIN}/${workspace.handle}`,
+                }
+              }),
+              product_url: process.env.APP_ORIGIN,
+              product_name: "ResearchEquals",
+              company_name: "Liberate Science GmbH",
+            },
+            member.user.email
+          )
+        }
+      })
+    })
+  }
+)

--- a/app/authorship/mutations/approveAuthorship.ts
+++ b/app/authorship/mutations/approveAuthorship.ts
@@ -1,5 +1,6 @@
 import { resolver } from "blitz"
 import db from "db"
+import approvalMailer from "../../api/approval-mailer"
 
 export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
   await db.authorship.update({
@@ -62,6 +63,10 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
         },
       },
     },
+  })
+
+  await approvalMailer.enqueue(module!.id, {
+    id: module!.id.toString(),
   })
 
   return module!

--- a/app/authorship/mutations/removeInvitation.ts
+++ b/app/authorship/mutations/removeInvitation.ts
@@ -1,7 +1,17 @@
 import { resolver } from "blitz"
 import db from "db"
+import invitationMailer from "../../api/invitation-mailer"
 
 export default resolver.pipe(resolver.authorize(), async ({ workspaceId, moduleId }) => {
+  // Cancel email queue
+  const createdAuthor = await db.authorship.findFirst({
+    where: {
+      moduleId,
+      workspaceId,
+    },
+  })
+  await invitationMailer.delete(createdAuthor!.id.toString())
+
   await db.authorship.delete({
     where: {
       moduleId_workspaceId: { workspaceId, moduleId },

--- a/app/core/components/EmailSettings.tsx
+++ b/app/core/components/EmailSettings.tsx
@@ -5,24 +5,16 @@ import { z } from "zod"
 import { Checkmark, Close } from "@carbon/icons-react"
 import changeEmailConsent from "../../users/mutations/changeEmailConsent"
 import changeMemberEmails from "../../memberships/mutations/changeMemberEmails"
+import { emailNotificationsAtom } from "../utils/Atoms"
+import { useRecoilState } from "recoil"
 
 const EmailSettings = ({ user, setIsOpen }) => {
+  const [emailNotifications, setEmailNotifications] = useRecoilState(emailNotificationsAtom)
   const [changeEmailMutation] = useMutation(changeEmailConsent)
   const [changeMemberEmailsMutation] = useMutation(changeMemberEmails)
-  let x = user.memberships.map((membership) => {
-    return {
-      [`${membership.workspace.handle}-invitations`]: membership.emailInvitations,
-      [`${membership.workspace.handle}-approvals`]: membership.emailApprovals,
-      [`${membership.workspace.handle}-weeklyDigest`]: membership.emailWeeklyDigest,
-    }
-  })[0]
 
   const formik = useFormik({
-    initialValues: {
-      emailConsent: user.emailConsent,
-      marketingConsent: user.marketingConsent,
-      ...x,
-    },
+    initialValues: emailNotifications,
     validate: validateZodSchema(
       z.object({
         emailConsent: z.boolean(),
@@ -31,8 +23,11 @@ const EmailSettings = ({ user, setIsOpen }) => {
     ),
     onSubmit: async (values) => {
       try {
-        console.log(values)
-        if (values.emailConsent != user.emailConsent) {
+        setEmailNotifications(values)
+        if (
+          values.emailConsent != user.emailConsent ||
+          values.marketingConsent != user.marketingConsent
+        ) {
           toast.promise(
             changeEmailMutation({
               emailConsent: values.emailConsent,
@@ -106,7 +101,6 @@ const EmailSettings = ({ user, setIsOpen }) => {
               <input
                 type="checkbox"
                 id="marketingEmails"
-                className=""
                 defaultChecked={formik.values.marketingConsent}
                 {...formik.getFieldProps("marketingConsent")}
               />
@@ -149,13 +143,18 @@ const EmailSettings = ({ user, setIsOpen }) => {
                       <input
                         type="checkbox"
                         id={`${membership.workspace.handle}-invitations`}
-                        className=""
                         defaultChecked={formik.values[`${membership.workspace.handle}-invitations`]}
                         {...formik.getFieldProps(`${membership.workspace.handle}-invitations`)}
                       />
                     ) : (
                       // <input type="checkbox" className="w-fullalign-middle" />
-                      <input type="checkbox" disabled className="disabled:opacity-25" />
+                      <input
+                        type="checkbox"
+                        disabled
+                        className="disabled:opacity-25"
+                        defaultChecked={formik.values[`${membership.workspace.handle}-invitations`]}
+                        {...formik.getFieldProps(`${membership.workspace.handle}-invitations`)}
+                      />
                     )}
                   </td>
                   <td className="">
@@ -163,12 +162,17 @@ const EmailSettings = ({ user, setIsOpen }) => {
                       <input
                         type="checkbox"
                         id={`${membership.workspace.handle}-approvals`}
-                        className=""
                         defaultChecked={formik.values[`${membership.workspace.handle}-approvals`]}
                         {...formik.getFieldProps(`${membership.workspace.handle}-approvals`)}
                       />
                     ) : (
-                      <input type="checkbox" disabled className="disabled:opacity-25" />
+                      <input
+                        type="checkbox"
+                        disabled
+                        className="disabled:opacity-25"
+                        defaultChecked={formik.values[`${membership.workspace.handle}-approvals`]}
+                        {...formik.getFieldProps(`${membership.workspace.handle}-approvals`)}
+                      />
                     )}
                   </td>
                   <td className="">
@@ -176,14 +180,21 @@ const EmailSettings = ({ user, setIsOpen }) => {
                       <input
                         type="checkbox"
                         id={`${membership.workspace.handle}-weeklyDigest`}
-                        className=""
                         defaultChecked={
                           formik.values[`${membership.workspace.handle}-weeklyDigest`]
                         }
                         {...formik.getFieldProps(`${membership.workspace.handle}-weeklyDigest`)}
                       />
                     ) : (
-                      <input type="checkbox" disabled className="disabled:opacity-25" />
+                      <input
+                        type="checkbox"
+                        disabled
+                        className="disabled:opacity-25"
+                        defaultChecked={
+                          formik.values[`${membership.workspace.handle}-weeklyDigest`]
+                        }
+                        {...formik.getFieldProps(`${membership.workspace.handle}-weeklyDigest`)}
+                      />
                     )}
                   </td>
                 </tr>

--- a/app/core/components/EmailSettings.tsx
+++ b/app/core/components/EmailSettings.tsx
@@ -1,0 +1,230 @@
+import { useMutation, validateZodSchema } from "blitz"
+import { useFormik } from "formik"
+import toast from "react-hot-toast"
+import { z } from "zod"
+import { Checkmark, Close } from "@carbon/icons-react"
+import changeEmailConsent from "../../users/mutations/changeEmailConsent"
+import changeMemberEmails from "../../memberships/mutations/changeMemberEmails"
+
+const EmailSettings = ({ user, setIsOpen }) => {
+  const [changeEmailMutation] = useMutation(changeEmailConsent)
+  const [changeMemberEmailsMutation] = useMutation(changeMemberEmails)
+  let x = user.memberships.map((membership) => {
+    return {
+      [`${membership.workspace.handle}-invitations`]: membership.emailInvitations,
+      [`${membership.workspace.handle}-approvals`]: membership.emailApprovals,
+      [`${membership.workspace.handle}-weeklyDigest`]: membership.emailWeeklyDigest,
+    }
+  })[0]
+
+  const formik = useFormik({
+    initialValues: {
+      emailConsent: user.emailConsent,
+      marketingConsent: user.marketingConsent,
+      ...x,
+    },
+    validate: validateZodSchema(
+      z.object({
+        emailConsent: z.boolean(),
+        marketingConsent: z.boolean(),
+      })
+    ),
+    onSubmit: async (values) => {
+      try {
+        console.log(values)
+        if (values.emailConsent != user.emailConsent) {
+          toast.promise(
+            changeEmailMutation({
+              emailConsent: values.emailConsent,
+              marketingConsent: values.marketingConsent,
+            }),
+            {
+              loading: "Updating email settings...",
+              success: "Updated email settings!",
+              error: "Please check your settings",
+            }
+          )
+          if (values.emailConsent) {
+            user.memberships.map((membership) => {
+              toast.promise(
+                changeMemberEmailsMutation({
+                  id: membership.id,
+                  invitations: values[`${membership.workspace.handle}-invitations`],
+                  approvals: values[`${membership.workspace.handle}-approvals`],
+                  weeklyDigest: values[`${membership.workspace.handle}-weeklyDigest`],
+                }),
+                {
+                  loading: `Updating @${membership.workspace.handle}...`,
+                  success: `Updated @${membership.workspace.handle}!`,
+                  error: "Please check your settings",
+                }
+              )
+            })
+          }
+        }
+        setIsOpen(false)
+      } catch (error) {
+        alert(error.toString())
+      }
+    },
+  })
+
+  return (
+    <>
+      <form onSubmit={formik.handleSubmit}>
+        <div className="my-4 flex w-full px-2">
+          <label
+            htmlFor="emailConsent"
+            className="my-1 flex-grow text-sm font-medium  text-gray-900 dark:text-gray-200"
+          >
+            Consent to receiving emails{" "}
+            <p className="my-1 text-xs text-gray-900 dark:text-gray-200">
+              Critical service emails are sent regardless (e.g., changes to the terms).
+            </p>
+          </label>
+          <span className="float-right m-1">
+            <input
+              type="checkbox"
+              id="emailConsent"
+              defaultChecked={formik.values.emailConsent}
+              {...formik.getFieldProps("emailConsent")}
+            />
+          </span>
+        </div>
+        <div className="my-4 flex w-full px-2">
+          <label
+            htmlFor="marketingEmails"
+            className="my-1 flex-grow text-sm font-medium  text-gray-900 dark:text-gray-200"
+          >
+            Marketing emails{" "}
+            <p className="my-1 text-xs text-gray-900 dark:text-gray-200">
+              Stay up-to-date with our developments, discounts, and more!
+            </p>
+          </label>
+          <div className="max-w-11/12 float-right m-1">
+            {formik.values.emailConsent ? (
+              <input
+                type="checkbox"
+                id="marketingEmails"
+                className=""
+                defaultChecked={formik.values.marketingConsent}
+                {...formik.getFieldProps("marketingConsent")}
+              />
+            ) : (
+              <input
+                type="checkbox"
+                id="marketingEmails"
+                className="disabled:opacity-25"
+                defaultChecked={formik.values.marketingConsent}
+                disabled
+              />
+            )}
+          </div>
+        </div>
+        <table className="m-2 w-full">
+          <thead>
+            <tr>
+              <th className=""></th>
+              <th className="text-sm font-medium underline">Invitations</th>
+              <th className="text-sm font-medium underline">Approvals</th>
+              <th className="text-sm font-medium underline">Weekly Digest</th>
+            </tr>
+          </thead>
+          <tbody>
+            {user.memberships.map((membership) => (
+              <>
+                <tr>
+                  <td className="flex">
+                    <img
+                      src={membership.workspace.avatar}
+                      className="mx-1 inline-block h-6 h-full w-6 align-middle"
+                    />
+                    <span className="inline-block h-full align-middle"> </span>
+                    <p className="inline-block align-middle text-sm line-clamp-1">
+                      @{membership.workspace.handle}
+                    </p>
+                  </td>
+                  <td className="">
+                    {formik.values.emailConsent ? (
+                      <input
+                        type="checkbox"
+                        id={`${membership.workspace.handle}-invitations`}
+                        className=""
+                        defaultChecked={formik.values[`${membership.workspace.handle}-invitations`]}
+                        {...formik.getFieldProps(`${membership.workspace.handle}-invitations`)}
+                      />
+                    ) : (
+                      // <input type="checkbox" className="w-fullalign-middle" />
+                      <input type="checkbox" disabled className="disabled:opacity-25" />
+                    )}
+                  </td>
+                  <td className="">
+                    {formik.values.emailConsent ? (
+                      <input
+                        type="checkbox"
+                        id={`${membership.workspace.handle}-approvals`}
+                        className=""
+                        defaultChecked={formik.values[`${membership.workspace.handle}-approvals`]}
+                        {...formik.getFieldProps(`${membership.workspace.handle}-approvals`)}
+                      />
+                    ) : (
+                      <input type="checkbox" disabled className="disabled:opacity-25" />
+                    )}
+                  </td>
+                  <td className="">
+                    {formik.values.emailConsent ? (
+                      <input
+                        type="checkbox"
+                        id={`${membership.workspace.handle}-weeklyDigest`}
+                        className=""
+                        defaultChecked={
+                          formik.values[`${membership.workspace.handle}-weeklyDigest`]
+                        }
+                        {...formik.getFieldProps(`${membership.workspace.handle}-weeklyDigest`)}
+                      />
+                    ) : (
+                      <input type="checkbox" disabled className="disabled:opacity-25" />
+                    )}
+                  </td>
+                </tr>
+              </>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="absolute right-0 bottom-0 flex w-full border-t border-gray-300 bg-white py-2 text-right dark:border-gray-600 dark:bg-gray-900 sm:sticky">
+          <span className="flex-grow"></span>
+          <div className="">
+            <button
+              type="reset"
+              className="mx-4 flex rounded-md bg-red-50 py-2 px-4 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+              onClick={() => {
+                setIsOpen(false)
+              }}
+            >
+              <Close
+                size={32}
+                className="h-4 w-4 fill-current pt-1 text-red-500"
+                aria-hidden="true"
+              />
+              Cancel
+            </button>
+          </div>
+          <button
+            type="submit"
+            className="mr-4 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+          >
+            <Checkmark
+              size={32}
+              className="h-4 w-4 fill-current pt-1 text-emerald-500"
+              aria-hidden="true"
+            />
+            Save
+          </button>
+        </div>
+      </form>
+    </>
+  )
+}
+
+export default EmailSettings

--- a/app/core/components/EmailSettings.tsx
+++ b/app/core/components/EmailSettings.tsx
@@ -39,24 +39,32 @@ const EmailSettings = ({ user, setIsOpen }) => {
               error: "Please check your settings",
             }
           )
-          if (values.emailConsent) {
-            user.memberships.map((membership) => {
-              toast.promise(
-                changeMemberEmailsMutation({
-                  id: membership.id,
-                  invitations: values[`${membership.workspace.handle}-invitations`],
-                  approvals: values[`${membership.workspace.handle}-approvals`],
-                  weeklyDigest: values[`${membership.workspace.handle}-weeklyDigest`],
-                }),
-                {
-                  loading: `Updating @${membership.workspace.handle}...`,
-                  success: `Updated @${membership.workspace.handle}!`,
-                  error: "Please check your settings",
-                }
-              )
-            })
-          }
         }
+
+        user.memberships.map((membership) => {
+          if (
+            values[`${membership.workspace.handle}-invitations`] !=
+              emailNotifications[`${membership.workspace.handle}-invitations`] ||
+            values[`${membership.workspace.handle}-approvals`] !=
+              emailNotifications[`${membership.workspace.handle}-approvals`] ||
+            values[`${membership.workspace.handle}-weeklyDigest`] !=
+              emailNotifications[`${membership.workspace.handle}-weeklyDigest`]
+          )
+            toast.promise(
+              changeMemberEmailsMutation({
+                id: membership.id,
+                invitations: values[`${membership.workspace.handle}-invitations`],
+                approvals: values[`${membership.workspace.handle}-approvals`],
+                weeklyDigest: values[`${membership.workspace.handle}-weeklyDigest`],
+              }),
+              {
+                loading: `Updating emails for @${membership.workspace.handle}...`,
+                success: `Updated emails for @${membership.workspace.handle}!`,
+                error: "Please check your settings",
+              }
+            )
+        })
+
         setIsOpen(false)
       } catch (error) {
         alert(error.toString())

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -2,7 +2,15 @@ import { useMutation, useQuery, Link } from "blitz"
 import { Widget } from "@uploadcare/react-widget"
 import { useRef } from "react"
 import { Formik, Form } from "formik"
-import { Email, UserAvatar, User, Parameter, LogoDiscord } from "@carbon/icons-react"
+import {
+  Email,
+  UserAvatar,
+  User,
+  Parameter,
+  LogoDiscord,
+  ThumbsDown,
+  ThumbsUp,
+} from "@carbon/icons-react"
 import { useRecoilValue, useRecoilState } from "recoil"
 
 import changeAvatar from "../../workspaces/mutations/changeAvatar"
@@ -18,11 +26,13 @@ import {
   settingsModalAtom,
   userDiscordAtom,
 } from "../utils/Atoms"
+import changeEmailConsent from "../../users/mutations/changeEmailConsent"
 
 const OnboardingQuests = ({ data, expire, signature, refetch }) => {
   return (
     <>
       <OnboardingEmail data={data.user.emailIsVerified} />
+      <OnboardingEmailAccept data={data.user} />
       {/* <OnboardingOrcid data={data.workspace.orcid} /> */}
       <OnboardingAvatar
         data={data.workspace}
@@ -85,6 +95,68 @@ const OnboardingEmail = ({ data }) => {
                   </Form>
                 </Formik>
               )}
+            </p>
+          </div>
+        </div>
+      ) : (
+        ""
+      )}
+    </>
+  )
+}
+
+const OnboardingEmailAccept = ({ data }) => {
+  const [emailConsentMutation, { isSuccess }] = useMutation(changeEmailConsent)
+  return (
+    <>
+      {data.emailConsent === null ? (
+        <div className="onboarding my-2 flex w-full flex-col rounded-r border-l-4 border-cyan-400 bg-cyan-50 p-4 dark:border-cyan-200 dark:bg-cyan-900 lg:my-0">
+          <div className="flex flex-grow">
+            <div className="">
+              <Email
+                size={32}
+                className="h-5 w-5 text-cyan-400 dark:text-cyan-200"
+                aria-hidden="true"
+              />
+            </div>
+            <div className="ml-3 flex-1 text-cyan-800 dark:text-cyan-200 md:flex">
+              <p className="mr-2 text-sm">
+                <span className="font-bold">Email notifications</span>{" "}
+                <span>
+                  Would you like to receive emails about ResearchEquals? You can manage which in
+                  your settings.
+                </span>
+              </p>
+            </div>
+          </div>
+          <div className="block text-right text-cyan-700 dark:text-cyan-200">
+            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+              {isSuccess ? (
+                <p className="whitespace-nowrap font-medium  underline">Got it!</p>
+              ) : (
+                <p className="whitespace-nowrap font-medium  underline">
+                  <button
+                    className="mx-2 whitespace-nowrap font-medium  underline"
+                    type="submit"
+                    onClick={async () => {
+                      await emailConsentMutation({ emailConsent: true, marketingConsent: true })
+                    }}
+                  >
+                    Yes
+                    <ThumbsUp size={16} className="inline" />
+                  </button>
+                  <button
+                    className="whitespace-nowrap font-medium  underline"
+                    type="submit"
+                    onClick={async () => {
+                      await emailConsentMutation({ emailConsent: false, marketingConsent: false })
+                    }}
+                  >
+                    No
+                    <ThumbsDown size={16} className="inline" />
+                  </button>
+                </p>
+              )}{" "}
             </p>
           </div>
         </div>

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -25,6 +25,7 @@ import {
   workspaceUrlAtom,
   settingsModalAtom,
   userDiscordAtom,
+  emailNotificationsAtom,
 } from "../utils/Atoms"
 import changeEmailConsent from "../../users/mutations/changeEmailConsent"
 
@@ -107,6 +108,8 @@ const OnboardingEmail = ({ data }) => {
 
 const OnboardingEmailAccept = ({ data }) => {
   const [emailConsentMutation, { isSuccess }] = useMutation(changeEmailConsent)
+  const [emailNotifications, setEmailNotifications] = useRecoilState(emailNotificationsAtom)
+
   return (
     <>
       {data.emailConsent === null ? (
@@ -140,6 +143,10 @@ const OnboardingEmailAccept = ({ data }) => {
                     type="submit"
                     onClick={async () => {
                       await emailConsentMutation({ emailConsent: true, marketingConsent: true })
+                      let emailNotis = { ...emailNotifications }
+                      emailNotis.emailConsent = true
+                      emailNotis.marketingConsent = true
+                      setEmailNotifications(emailNotis)
                     }}
                   >
                     Yes
@@ -150,6 +157,10 @@ const OnboardingEmailAccept = ({ data }) => {
                     type="submit"
                     onClick={async () => {
                       await emailConsentMutation({ emailConsent: false, marketingConsent: false })
+                      let emailNotis = { ...emailNotifications }
+                      emailNotis.emailConsent = false
+                      emailNotis.marketingConsent = false
+                      setEmailNotifications(emailNotis)
                     }}
                   >
                     No

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -112,7 +112,7 @@ const OnboardingEmailAccept = ({ data }) => {
 
   return (
     <>
-      {data.emailConsent === null ? (
+      {data.emailConsent === null || emailNotifications.emailConsent === null ? (
         <div className="onboarding my-2 flex w-full flex-col rounded-r border-l-4 border-cyan-400 bg-cyan-50 p-4 dark:border-cyan-200 dark:bg-cyan-900 lg:my-0">
           <div className="flex flex-grow">
             <div className="">

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -6,6 +6,7 @@ import { settingsModalAtom } from "../utils/Atoms"
 
 import WorkspaceSettings from "../components/WorkspaceSettings"
 import AccountSettings from "../components/AccountSettings"
+import EmailSettings from "../components/EmailSettings"
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
@@ -13,7 +14,7 @@ function classNames(...classes) {
 
 export default function SettingsModal({ button, styling, user, workspace }) {
   let [isOpen, setIsOpen] = useRecoilState(settingsModalAtom)
-  let [categories] = useState(["Workspace", "Account"])
+  let [categories] = useState(["Workspace", "Account", "Emails"])
 
   return (
     <>
@@ -111,6 +112,9 @@ export default function SettingsModal({ button, styling, user, workspace }) {
                       </Tab.Panel>
                       <Tab.Panel key="account-panel" className="">
                         <AccountSettings user={user} setIsOpen={setIsOpen} />
+                      </Tab.Panel>
+                      <Tab.Panel key="emails-panel" className="">
+                        <EmailSettings user={user} setIsOpen={setIsOpen} />
                       </Tab.Panel>
                     </Tab.Panels>
                   </Tab.Group>

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -1,8 +1,8 @@
 import { Dialog, Transition, Tab } from "@headlessui/react"
-import { Fragment, useState } from "react"
+import { Fragment, useEffect, useState } from "react"
 import { Close } from "@carbon/icons-react"
 import { useRecoilState } from "recoil"
-import { settingsModalAtom } from "../utils/Atoms"
+import { emailNotificationsAtom, settingsModalAtom } from "../utils/Atoms"
 
 import WorkspaceSettings from "../components/WorkspaceSettings"
 import AccountSettings from "../components/AccountSettings"
@@ -15,7 +15,24 @@ function classNames(...classes) {
 export default function SettingsModal({ button, styling, user, workspace }) {
   let [isOpen, setIsOpen] = useRecoilState(settingsModalAtom)
   let [categories] = useState(["Workspace", "Account", "Emails"])
+  const [emailNotifications, setEmailNotifications] = useRecoilState(emailNotificationsAtom)
+  let x = user.memberships.map((membership) => {
+    return {
+      [`${membership.workspace.handle}-invitations`]: membership.emailInvitations,
+      [`${membership.workspace.handle}-approvals`]: membership.emailApprovals,
+      [`${membership.workspace.handle}-weeklyDigest`]: membership.emailWeeklyDigest,
+    }
+  })[0]
 
+  useEffect(() => {
+    if (JSON.stringify(emailNotifications) === "{}") {
+      setEmailNotifications({
+        emailConsent: user.emailConsent,
+        marketingConsent: user.marketingConsent,
+        ...x,
+      })
+    }
+  }, [])
   return (
     <>
       <button

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -27,8 +27,8 @@ export default function SettingsModal({ button, styling, user, workspace }) {
   useEffect(() => {
     if (JSON.stringify(emailNotifications) === "{}") {
       setEmailNotifications({
-        emailConsent: user.emailConsent,
-        marketingConsent: user.marketingConsent,
+        emailConsent: false,
+        marketingConsent: false,
         ...x,
       })
     }

--- a/app/core/queries/getDashboardData.ts
+++ b/app/core/queries/getDashboardData.ts
@@ -12,6 +12,8 @@ export default async function getSignature({ session, changeDays }) {
       hashedPassword: false,
       email: true,
       emailIsVerified: true,
+      emailConsent: true,
+      marketingConsent: true,
     },
   })
 

--- a/app/core/utils/Atoms.tsx
+++ b/app/core/utils/Atoms.tsx
@@ -45,6 +45,12 @@ const userDiscordAtom = atom({
   effects_UNSTABLE: [persistAtom],
 })
 
+const emailNotificationsAtom = atom({
+  key: "emailNotifications",
+  default: {},
+  effects_UNSTABLE: [persistAtom],
+})
+
 export {
   workspaceFirstNameAtom,
   workspaceLastNameAtom,
@@ -53,4 +59,5 @@ export {
   workspaceUrlAtom,
   settingsModalAtom,
   userDiscordAtom,
+  emailNotificationsAtom,
 }

--- a/app/memberships/mutations/changeMemberEmails.ts
+++ b/app/memberships/mutations/changeMemberEmails.ts
@@ -1,0 +1,22 @@
+import { NotFoundError, resolver } from "blitz"
+import db from "db"
+import { Ctx } from "blitz"
+
+export default resolver.pipe(
+  resolver.authorize(),
+  async ({ id, invitations, approvals, weeklyDigest }, ctx: Ctx) => {
+    const membership = await db.membership.update({
+      where: {
+        id,
+      },
+      data: {
+        emailInvitations: invitations,
+        emailApprovals: approvals,
+        emailWeeklyDigest: weeklyDigest,
+      },
+    })
+    if (!membership) throw new NotFoundError()
+
+    return true
+  }
+)

--- a/app/postmark.ts
+++ b/app/postmark.ts
@@ -21,13 +21,9 @@ export async function sendInvitation(to: string, title: string) {
   await postmark().sendEmailWithTemplate(message)
 }
 
-export async function sendApprovals() {
-  await postmark().sendEmail({
-    From: "chris@libscie.org",
-    To: "chris@libscie.org",
-    Subject: "Hello from Postmark2121!!!!!!",
-    HtmlBody: "<strong>Hello</strong> dear Postmark user.",
-    TextBody: "Hello from Postmark!",
-    MessageStream: "broadcast",
-  })
+export async function sendApproval(name: string, title: string, to: string) {
+  const message = new TemplatedMessage(from, "approval-mail", { title, name }, to)
+  message.MessageStream = "broadcast"
+  message.ReplyTo = "Chris Hartgerink <ceo@libscie.org>"
+  await postmark().sendEmailWithTemplate(message)
 }

--- a/app/postmark.ts
+++ b/app/postmark.ts
@@ -13,3 +13,35 @@ export async function sendEmailWithTemplate(
 
   await postmark().sendEmailWithTemplate(message)
 }
+
+export async function sendInvitation() {
+  const message = new TemplatedMessage(
+    from,
+    "invitation-mail",
+    {
+      title: "Testing",
+    },
+    "chris@libscie.org"
+  )
+
+  await postmark().sendEmail({
+    From: "chris@libscie.org",
+    To: "chris@libscie.org",
+    Subject: "Hello from Postmark2121!!!!!!",
+    HtmlBody: "<strong>Hello</strong> dear Postmark user.",
+    TextBody: "Hello from Postmark!",
+    MessageStream: "broadcast",
+  })
+
+  // await postmark().sendEmail({
+  //   From: "chris@libscie.org",
+  //   To: "chris@libscie.org",
+  //   Subject: "Hello from Postmark",
+  //   HtmlBody: "<strong>Hello</strong> dear Postmark user.",
+  //   TextBody: "Hello from Postmark!",
+  //   MessageStream: "broadcast",
+  // })
+  // await postmark().sendEmailWithTemplate(message, {
+  //   MessageStream: "broadcast",
+  // })
+}

--- a/app/postmark.ts
+++ b/app/postmark.ts
@@ -21,8 +21,8 @@ export async function sendInvitation(to: string, data: Object) {
   await postmark().sendEmailWithTemplate(message)
 }
 
-export async function sendApproval(name: string, title: string, to: string) {
-  const message = new TemplatedMessage(from, "approval-mail", { title, name }, to)
+export async function sendApproval(data: Object, to: string) {
+  const message = new TemplatedMessage(from, "approval-mail", data, to)
   message.MessageStream = "broadcast"
   message.ReplyTo = "Chris Hartgerink <ceo@libscie.org>"
   await postmark().sendEmailWithTemplate(message)

--- a/app/postmark.ts
+++ b/app/postmark.ts
@@ -14,8 +14,8 @@ export async function sendEmailWithTemplate(
   await postmark().sendEmailWithTemplate(message)
 }
 
-export async function sendInvitation(to: string, title: string) {
-  const message = new TemplatedMessage(from, "invitation-mail", { title }, to)
+export async function sendInvitation(to: string, data: Object) {
+  const message = new TemplatedMessage(from, "invitation-mail", data, to)
   message.MessageStream = "broadcast"
   message.ReplyTo = "Chris Hartgerink <ceo@libscie.org>"
   await postmark().sendEmailWithTemplate(message)
@@ -23,6 +23,13 @@ export async function sendInvitation(to: string, title: string) {
 
 export async function sendApproval(name: string, title: string, to: string) {
   const message = new TemplatedMessage(from, "approval-mail", { title, name }, to)
+  message.MessageStream = "broadcast"
+  message.ReplyTo = "Chris Hartgerink <ceo@libscie.org>"
+  await postmark().sendEmailWithTemplate(message)
+}
+
+export async function sendDigest(data: Object, to: string) {
+  const message = new TemplatedMessage(from, "weekly-digest", data, to)
   message.MessageStream = "broadcast"
   message.ReplyTo = "Chris Hartgerink <ceo@libscie.org>"
   await postmark().sendEmailWithTemplate(message)

--- a/app/postmark.ts
+++ b/app/postmark.ts
@@ -1,6 +1,6 @@
 import { ServerClient, TemplatedMessage } from "postmark"
 
-const from = process.env.MAIL_FROM ?? "no-reply@libscie.org"
+const from = process.env.MAIL_FROM ?? "ResearchEquals <no-reply@libscie.org>"
 
 export const postmark = () => new ServerClient(process.env.POSTMARK_TOKEN ?? "")
 
@@ -14,16 +14,14 @@ export async function sendEmailWithTemplate(
   await postmark().sendEmailWithTemplate(message)
 }
 
-export async function sendInvitation() {
-  const message = new TemplatedMessage(
-    from,
-    "invitation-mail",
-    {
-      title: "Testing",
-    },
-    "chris@libscie.org"
-  )
+export async function sendInvitation(to: string, title: string) {
+  const message = new TemplatedMessage(from, "invitation-mail", { title }, to)
+  message.MessageStream = "broadcast"
+  message.ReplyTo = "Chris Hartgerink <ceo@libscie.org>"
+  await postmark().sendEmailWithTemplate(message)
+}
 
+export async function sendApprovals() {
   await postmark().sendEmail({
     From: "chris@libscie.org",
     To: "chris@libscie.org",
@@ -32,16 +30,4 @@ export async function sendInvitation() {
     TextBody: "Hello from Postmark!",
     MessageStream: "broadcast",
   })
-
-  // await postmark().sendEmail({
-  //   From: "chris@libscie.org",
-  //   To: "chris@libscie.org",
-  //   Subject: "Hello from Postmark",
-  //   HtmlBody: "<strong>Hello</strong> dear Postmark user.",
-  //   TextBody: "Hello from Postmark!",
-  //   MessageStream: "broadcast",
-  // })
-  // await postmark().sendEmailWithTemplate(message, {
-  //   MessageStream: "broadcast",
-  // })
 }

--- a/app/users/mutations/changeEmailConsent.ts
+++ b/app/users/mutations/changeEmailConsent.ts
@@ -1,0 +1,18 @@
+import { NotFoundError, resolver } from "blitz"
+import db from "db"
+import { Ctx } from "blitz"
+
+export default resolver.pipe(
+  resolver.authorize(),
+  async ({ emailConsent, marketingConsent }, ctx: Ctx) => {
+    const user = await db.user.findFirst({ where: { id: ctx.session.userId! } })
+    if (!user) throw new NotFoundError()
+
+    await db.user.update({
+      where: { id: user.id },
+      data: { emailConsent, marketingConsent },
+    })
+
+    return true
+  }
+)

--- a/app/users/queries/getCurrentUser.ts
+++ b/app/users/queries/getCurrentUser.ts
@@ -11,10 +11,16 @@ export default async function getCurrentUser(_ = null, { session }: Ctx) {
       name: true,
       email: true,
       emailIsVerified: true,
+      emailConsent: true,
+      marketingConsent: true,
       role: true,
       memberships: {
         select: {
+          id: true,
           role: true,
+          emailInvitations: true,
+          emailApprovals: true,
+          emailWeeklyDigest: true,
           workspace: {
             select: {
               avatar: true,

--- a/db/migrations/20220905092350_add_email_consent_to_user/migration.sql
+++ b/db/migrations/20220905092350_add_email_consent_to_user/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "emailConsent" BOOLEAN,
+ADD COLUMN     "marketingConsent" BOOLEAN;

--- a/db/migrations/20220906081910_add_emails_to_membership/migration.sql
+++ b/db/migrations/20220906081910_add_emails_to_membership/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Membership" ADD COLUMN     "emailApprovals" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "emailInvitations" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "emailWeeklyDigest" BOOLEAN NOT NULL DEFAULT true;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -129,6 +129,10 @@ model Membership {
   invitedName  String?
   invitedEmail String?
 
+  emailInvitations  Boolean @default(true)
+  emailApprovals    Boolean @default(true)
+  emailWeeklyDigest Boolean @default(true)
+
   @@unique([workspaceId, invitedEmail])
 }
 
@@ -144,14 +148,16 @@ enum GlobalRole {
 }
 
 model User {
-  id              Int        @id @default(autoincrement())
-  createdAt       DateTime   @default(now())
-  updatedAt       DateTime   @updatedAt
-  name            String?
-  email           String     @unique
-  emailIsVerified Boolean    @default(false)
-  hashedPassword  String?
-  role            GlobalRole
+  id               Int        @id @default(autoincrement())
+  createdAt        DateTime   @default(now())
+  updatedAt        DateTime   @updatedAt
+  name             String?
+  email            String     @unique
+  emailIsVerified  Boolean    @default(false)
+  hashedPassword   String?
+  role             GlobalRole
+  emailConsent     Boolean?
+  marketingConsent Boolean?
 
   tokens      Token[]
   sessions    Session[]

--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -51,6 +51,9 @@
             "POSTMARK_TOKEN": {
               "fromParameterStore": "POSTMARK_TOKEN"
             },
+            "POSTMARK_SECRET": {
+              "fromParameterStore": "POSTMARK_SECRET"
+            },
             "PORT": "3000",
             "MAIL_FROM": "no-reply@libscie.org",
             "QUIRREL_BASE_URL": "https://www.researchequals.com/",


### PR DESCRIPTION
This PR adds email notifications. Fixes #628.

It was a beast of a PR I've been working on for the past three days. It seemed straightforward, but there was always another thing. But here it is!

Emails are sent for:

1. When you approve a module to all authors
2. When you invite an author
3. Weekly digest with new modules by people you follow, open drafts, open invitations.

There's still a bunch to iterate on, but it's a first good go at it. See for example #672 that is a next step.

## Screenshots

### Onboarding quest

![Screenshot 2022-09-07 at 14 53 21](https://user-images.githubusercontent.com/2946344/188883194-b9950245-73ab-4d06-bd56-cefb0fd3e8ec.png)

### Settings screen 
![Screenshot 2022-09-07 at 14 55 37](https://user-images.githubusercontent.com/2946344/188883516-668952cb-fd46-45c3-a352-0797f009ce00.png)

### Email templates

![Screenshot 2022-09-07 at 14 54 38](https://user-images.githubusercontent.com/2946344/188883356-1646407b-5867-40ff-9cb7-cdbc34217397.png)
![Screenshot 2022-09-07 at 14 55 05](https://user-images.githubusercontent.com/2946344/188883407-bfbdf3d7-b8ec-4217-8704-c59b6c6a1161.png)

