### PR TITLE
Add mailto (fixes #689)

### DIFF
--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -13,7 +13,7 @@ function capitalizeFirstLetter(string) {
 export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
   try {
     // Will auto-throw if resource not found
-    const cr = await axios.get(`https://api.crossref.org/works/${doi}`)
+    const cr = await axios.get(`https://api.crossref.org/works/${doi}&mailto=info@libscie.org`)
     const metadata = cr.data.message
 
     const crType = capitalizeFirstLetter(metadata.type.replace("-", " "))


### PR DESCRIPTION
This adds the mailto argument to the API calls for CrossRef.

It should've been there. Sorry CrossRef!