### PR TITLE
Revert "Bump typescript from 4.5.5 to 4.8.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "remark-math": "5.1.1",
         "stripe": "10.2.0",
         "tailwindcss": "3.1.8",
-        "typescript": "~4.8",
+        "typescript": "~4.5",
         "xast-util-to-xml": "3.0.0",
         "xml-js": "1.6.11",
         "zod": "3.19.1"
@@ -23142,9 +23142,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -42069,9 +42069,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "remark-math": "5.1.1",
     "stripe": "10.2.0",
     "tailwindcss": "3.1.8",
-    "typescript": "~4.8",
+    "typescript": "~4.5",
     "xast-util-to-xml": "3.0.0",
     "xml-js": "1.6.11",
     "zod": "3.19.1"


### PR DESCRIPTION
Reverts libscie/ResearchEquals.com#679.

Should not have been merged as #533 is blocked.