### PR TITLE
Seed DB when releasing on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: npx blitz prisma migrate deploy
+release: npx blitz prisma migrate deploy && npx blitz db seed
 web: npm run start:production


### PR DESCRIPTION
This PR adds a seeding script, when releasing an app on Heroku (for test apps). This is to sync up the release script between the review app and the production environment, to prevent any problems pushed to the production (e.g., https://github.com/libscie/ResearchEquals.com/pull/679, which is reverted by https://github.com/libscie/ResearchEquals.com/pull/723)

Fixes #724 