### PR TITLE
Update the `faker` seeding script

### DIFF
--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -390,8 +390,8 @@ const seed = async () => {
                   create: {
                     handle: faker.internet.userName().toLowerCase(),
                     avatar: `https://eu.ui-avatars.com/api/?rounded=true&background=574cfa&color=ffffff&name=${faker.internet.userName()}`,
-                    firstName: faker.name.findName(),
-                    lastName: faker.name.findName(),
+                    firstName: faker.name.firstName(),
+                    lastName: faker.name.lastName(),
                     url: faker.internet.url(),
                   },
                 },


### PR DESCRIPTION
This PR updates the `faker` seeding script for the test data, since the `faker` package is deprecating the function we are using (`faker.name.findName()`). I updated the script a bit so that we will get fake first names for the `firstName` field, and fake last name for the `lastName` field.


Fixes #621 



<img width="220" alt="image" src="https://user-images.githubusercontent.com/17035406/191545702-738101a2-8486-4f10-ba44-8226d59b883f.png">


-----
On a side note, I noticed that the avatar image does not correspond to the handle. I realized that this is an expected behavior given that the seeding script is generating `avatar` independent of the handle:

```js
avatar: `https://eu.ui-avatars.com/api/?rounded=true&background=574cfa&color=ffffff&name=${faker.internet.userName()}`,
```
