### PR TITLE
Fix the height of the draft container to 100% to prevent the white space appearing at the bottom

### DIFF
--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -55,7 +55,7 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
           </Link>{" "}
           Publishing not possible until resolved.
         </div> */}
-          <div className="flex-grow">{children}</div>
+          <div className="flex flex-grow flex-col">{children}</div>
         </div>
       </RecoilRoot>
       <Footer />

--- a/app/pages/drafts.tsx
+++ b/app/pages/drafts.tsx
@@ -49,12 +49,7 @@ const DraftsContents = ({ expire, signature, currentWorkspace, session, user }) 
 
   return (
     <>
-      <div
-        className="flex w-screen divide-x divide-gray-100 dark:divide-gray-600"
-        style={{
-          height: biggerWindow ? "calc(100vh - 73px - 55px)" : "100%",
-        }}
-      >
+      <div className="flex h-full w-screen divide-x divide-gray-100 dark:divide-gray-600">
         {drafts.length > 0 ? (
           <>
             <div

--- a/app/pages/drafts.tsx
+++ b/app/pages/drafts.tsx
@@ -49,7 +49,7 @@ const DraftsContents = ({ expire, signature, currentWorkspace, session, user }) 
 
   return (
     <>
-      <div className="flex h-full w-screen divide-x divide-gray-100 dark:divide-gray-600">
+      <div className="flex w-screen flex-grow divide-x divide-gray-100 dark:divide-gray-600">
         {drafts.length > 0 ? (
           <>
             <div
@@ -117,7 +117,7 @@ const DraftsContents = ({ expire, signature, currentWorkspace, session, user }) 
             </div>
           </>
         ) : (
-          <div className="relative my-4 mx-4 flex w-full flex-grow flex-col rounded-lg border-2 border-dashed border-gray-800 text-center focus:outline-none focus:ring-2 focus:ring-indigo-500  focus:ring-offset-2 dark:border-white">
+          <div className="relative my-4 mx-4 flex w-full flex-col rounded-lg border-2 border-dashed border-gray-800 text-center focus:outline-none focus:ring-2 focus:ring-indigo-500  focus:ring-offset-2 dark:border-white">
             <div className="table h-full w-full flex-grow">
               <div className="h-28 w-1/4 sm:table-cell"></div>
               <span className="mx-auto table-cell align-middle text-sm font-medium leading-4">
@@ -153,7 +153,7 @@ const DraftsPage = ({ expire, signature }) => {
         invitations={invitations}
         refetchFn={refetch}
       />
-      <main className="relative flex">
+      <main className="relative flex flex-grow">
         <DraftsContents
           expire={expire}
           signature={signature}


### PR DESCRIPTION
This PR fixes the height of the draft container to 100%, to fix the issue of a white space appearing below the page when the main file is tall. 

@chartgerink I was not 100% sure of the reasoning behind the existing code to calculate the height of the element (`calc(100vh - 73px - 55px)`) when the window is big. Removing that and just using `h-full` seems to be working. That said, it's possible that I may be missing something—let me know 🙏 

Fixes #696 