### PR TITLE
Update default values for (sub)title

### DIFF
--- a/app/collections/components/AdminSubtitle.tsx
+++ b/app/collections/components/AdminSubtitle.tsx
@@ -12,7 +12,7 @@ const Subtitle = ({ collection, refetchFn, isAdmin }) => {
         <>
           <Formik
             initialValues={{
-              subtitle: "",
+              subtitle: collection.subtitle,
             }}
             onSubmit={() => {}}
           >

--- a/app/collections/components/AdminTitle.tsx
+++ b/app/collections/components/AdminTitle.tsx
@@ -12,7 +12,7 @@ const AdminTitle = ({ collection, refetchFn, isAdmin }) => {
         <>
           <Formik
             initialValues={{
-              title: "",
+              title: collection.title,
             }}
             onSubmit={() => {}}
           >


### PR DESCRIPTION
This PR attempts to improve the editing of a collection's (sub)title. Was having some issues in production where the title emptied out (reproduced in test) and did not save properly (reset to old value upon refresh...).