### PR TITLE
Add a confirmation modal when removing a supplementary file (& add an abstracted modal component)

### DIFF
--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -4,9 +4,13 @@ import toast from "react-hot-toast"
 import filesize from "filesize"
 
 import deleteSupportingFile from "../../modules/mutations/deleteSupportingFile"
+import { useState } from "react"
+import { Modal } from "../modals/Modal"
 
 const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryData }) => {
   const [deleteMutation] = useMutation(deleteSupportingFile)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+
   return (
     <div className="my-2 flex">
       <a
@@ -24,7 +28,23 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
           <TrashCan
             size={24}
             className="inline-block h-6 w-6 fill-current align-middle text-red-500"
-            onClick={async () => {
+            onClick={() => setConfirmDeleteOpen(true)}
+            aria-label="Delete file"
+          />
+          <Modal
+            title="Confirm removing a supporting file"
+            body={
+              <span>
+                The supporting file, &quot;<span className="font-bold">{name}</span>&quot;, will be
+                removed.
+              </span>
+            }
+            primaryAction="Remove"
+            primaryButtonClass="text-red-700 hover:bg-red-200 focus:ring-red-500 focus:ring-offset-0 focus:ring-2 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+            isOpen={confirmDeleteOpen}
+            setIsOpen={setConfirmDeleteOpen}
+            onSubmit={async () => {
+              console.log("Deleting")
               toast.promise(deleteMutation({ id: moduleId, uuid }), {
                 loading: "Deleting...",
                 success: (data) => {
@@ -34,7 +54,6 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
                 error: "Something went wrong...",
               })
             }}
-            aria-label="Delete file"
           />
         </button>
         <a href={url} target="_blank" download rel="noreferrer">

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -35,11 +35,12 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
             title="Confirm deletion"
             body={
               <span>
-            Upon confirmation, the supporting file &quot;{name}&quot; will be permanently deleted. Are you sure you want to delete this file?
+                Upon confirmation, the supporting file &quot;{name}&quot; will be permanently
+                deleted. Are you sure you want to delete this file?
               </span>
             }
             primaryAction="Delete File"
-            primaryButtonClass="text-red-700 hover:bg-red-200 focus:ring-red-500 focus:ring-offset-0 focus:ring-2 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+            primaryButtonClass="rounded-md bg-red-50 py-2 px-4 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
             isOpen={confirmDeleteOpen}
             setIsOpen={setConfirmDeleteOpen}
             onSubmit={async () => {

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -32,7 +32,7 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
             aria-label="Delete file"
           />
           <Modal
-            title="Confirm removing a supporting file"
+            title="Confirm deletion"
             body={
               <span>
                 The supporting file, &quot;<span className="font-bold">{name}</span>&quot;, will be

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -39,7 +39,7 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
                 removed.
               </span>
             }
-            primaryAction="Remove"
+            primaryAction="Delete File"
             primaryButtonClass="text-red-700 hover:bg-red-200 focus:ring-red-500 focus:ring-offset-0 focus:ring-2 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
             isOpen={confirmDeleteOpen}
             setIsOpen={setConfirmDeleteOpen}

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -35,8 +35,7 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
             title="Confirm deletion"
             body={
               <span>
-                The supporting file, &quot;<span className="font-bold">{name}</span>&quot;, will be
-                removed.
+            Upon confirmation, the supporting file &quot;{name}&quot; will be permanently deleted. Are you sure you want to delete this file?
               </span>
             }
             primaryAction="Delete File"

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -44,7 +44,6 @@ const EditSupportingFileDisplay = ({ name, size, url, uuid, moduleId, setQueryDa
             isOpen={confirmDeleteOpen}
             setIsOpen={setConfirmDeleteOpen}
             onSubmit={async () => {
-              console.log("Deleting")
               toast.promise(deleteMutation({ id: moduleId, uuid }), {
                 loading: "Deleting...",
                 success: (data) => {

--- a/app/core/modals/Modal.tsx
+++ b/app/core/modals/Modal.tsx
@@ -1,18 +1,18 @@
 import { Dialog, Transition } from "@headlessui/react"
 import React, { Fragment } from "react"
+import PropTypes from "prop-types"
 
-export const Modal = (props) => {
-  const {
-    isOpen,
-    setIsOpen,
-    title,
-    body,
-    onSubmit,
-    primaryAction = "Ok",
-    primaryButtonClass,
-    secondaryAction = "Cancel",
-    secondaryButtonClass,
-  } = props
+export const Modal = ({
+  isOpen,
+  setIsOpen,
+  title,
+  body,
+  onSubmit,
+  primaryAction = "Ok",
+  primaryButtonClass,
+  secondaryAction = "Cancel",
+  secondaryButtonClass,
+}) => {
   return (
     <>
       <Transition appear show={isOpen} as={Fragment}>
@@ -88,4 +88,16 @@ export const Modal = (props) => {
       </Transition>
     </>
   )
+}
+
+Modal.propTypes = {
+  isOpen: PropTypes.bool,
+  setIsOpen: PropTypes.func,
+  title: PropTypes.string,
+  body: PropTypes.element,
+  onSubmit: PropTypes.func,
+  primaryAction: PropTypes.string,
+  primaryButtonClass: PropTypes.string,
+  secondaryAction: PropTypes.string,
+  secondaryButtonClass: PropTypes.string,
 }

--- a/app/core/modals/Modal.tsx
+++ b/app/core/modals/Modal.tsx
@@ -1,0 +1,91 @@
+import { Dialog, Transition } from "@headlessui/react"
+import React, { Fragment } from "react"
+
+export const Modal = (props) => {
+  const {
+    isOpen,
+    setIsOpen,
+    title,
+    body,
+    onSubmit,
+    primaryAction = "Ok",
+    primaryButtonClass,
+    secondaryAction = "Cancel",
+    secondaryButtonClass,
+  } = props
+  return (
+    <>
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="fixed inset-0 z-10 overflow-y-auto"
+          onClose={() => setIsOpen(false)}
+        >
+          <div className="min-h-screen px-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-75 transition-opacity" />
+            </Transition.Child>
+
+            {/* This element is to trick the browser into centering the modal contents. */}
+            <span className="inline-block h-screen align-middle" aria-hidden="true">
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <div className="my-8 inline-block w-full max-w-md transform overflow-hidden rounded border-gray-300 bg-white p-6 text-left align-middle text-gray-900 shadow-xl transition-all dark:border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200">
+                <Dialog.Title as="h3" className="text-lg font-medium leading-6">
+                  {title}
+                </Dialog.Title>
+                <div className="mt-2">{body}</div>
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    className={`mr-2 inline-flex rounded-md border py-2 px-4 text-sm font-medium ${
+                      primaryButtonClass
+                        ? primaryButtonClass
+                        : // Style the primary button (default is success)
+                          `border-emerald-500 text-emerald-500 hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 focus:ring-offset-emerald-50 dark:border-emerald-200 dark:text-emerald-200 dark:hover:bg-emerald-900`
+                    }`}
+                    onClick={async () => {
+                      onSubmit()
+                      setIsOpen(false)
+                    }}
+                  >
+                    {primaryAction}
+                  </button>
+                  <button
+                    type="button"
+                    className={`rounded-md py-2 px-4 text-sm font-medium ${
+                      secondaryButtonClass
+                        ? secondaryButtonClass
+                        : // Style the secondary button (default is cancel)
+                          `bg-indigo-100 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-gray-400 dark:hover:bg-gray-700`
+                    }`}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    {secondaryAction}
+                  </button>
+                </div>
+              </div>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  )
+}

--- a/app/core/modals/Modal.tsx
+++ b/app/core/modals/Modal.tsx
@@ -59,7 +59,7 @@ export const Modal = ({
                       primaryButtonClass
                         ? primaryButtonClass
                         : // Style the primary button (default is success)
-                          `border-emerald-500 text-emerald-500 hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 focus:ring-offset-emerald-50 dark:border-emerald-200 dark:text-emerald-200 dark:hover:bg-emerald-900`
+                          `bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700`
                     }`}
                     onClick={async () => {
                       onSubmit()


### PR DESCRIPTION
This PR adds a confirmation modal when removing a supplementary file. 

![image](https://user-images.githubusercontent.com/17035406/192295634-5e830f20-e023-4425-b7b1-c6014fcb2d08.png)

By implementing this, I abstracted a modal component and created the `Modal.tsx` file. I referred to the existing modal component for deleting a module (`deleteModuleModal.tsx`) for styles.

Fixes #695.