### PR TITLE
Match the breakpoint for showing the full nav bar tabs with the folding of the nav bar dropdown

### DIFF
--- a/app/core/components/NavbarTabs.tsx
+++ b/app/core/components/NavbarTabs.tsx
@@ -54,7 +54,7 @@ const NavTabs = ({ currentUser, currentWorkspace, session, router, drafts, invit
     return (
       <>
         <div className="mx-auto w-full overflow-x-auto border-b border-gray-100 bg-white px-4 text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200 sm:px-6 lg:px-8">
-          <div className="hidden sm:block">
+          <div className="hidden lg:block">
             <nav className="flex space-x-8" aria-label="Tabs">
               <button
                 onClick={() => {


### PR DESCRIPTION
This PR matches the breakpoint for the nav bar tab menu with the breakpoint for the main menu. By doing so, this PR fixes the issue of the horizontal scroll bar appearing on medium screens. (Fixes #713)

https://user-images.githubusercontent.com/17035406/192373051-59fe9ec4-4037-48dd-95d4-9c751dc30d22.mov

