### PR TITLE
Soft-code `pdfjs-dist`'s version number

### DIFF
--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -11,6 +11,8 @@ import rehypeKatex from "rehype-katex"
 import "katex/dist/katex.min.css" // `rehype-katex` does not import the CSS for you
 import { useEffect, useState } from "react"
 
+const PDFJS_DIST_VERSION = process.env.PDFJS_DIST_VERSION
+
 const MainFileViewer = ({ mainFile, module }) => {
   const prefersDarkMode = useMediaPredicate("(prefers-color-scheme: dark)")
   const [mainFileMarkdown, setMarkdown] = useState("")
@@ -34,7 +36,9 @@ const MainFileViewer = ({ mainFile, module }) => {
           )}
           {/* Preview PDF */}
           {mainFile.mimeType.startsWith("application/pdf") ? (
-            <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js">
+            <Worker
+              workerUrl={`https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/build/pdf.worker.min.js`}
+            >
               <div style={{ height: "750px" }} className="max-w-screen text-gray-900">
                 <Viewer fileUrl={mainFile.cdnUrl} />
               </div>

--- a/blitz.config.ts
+++ b/blitz.config.ts
@@ -1,4 +1,7 @@
 import { BlitzConfig, sessionMiddleware, simpleRolesIsAuthorized } from "blitz"
+import pjson from "./package.json"
+
+const PDFJS_DIST_VERSION = pjson.dependencies["pdfjs-dist"]
 
 const config: BlitzConfig = {
   images: {
@@ -20,6 +23,7 @@ const config: BlitzConfig = {
     ALGOLIA_PREFIX: process.env.ALGOLIA_PREFIX,
     DOI_PREFIX: process.env.DOI_PREFIX,
     STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY,
+    PDFJS_DIST_VERSION: PDFJS_DIST_VERSION,
   },
   pageExtensions: ["tsx", "ts", "jsx", "js"],
   webpack(config, options) {


### PR DESCRIPTION
This PR soft-codes `pdfjs-dist`'s version number to the argument to the `<Worker>` component. I did so by exposing the relevant entry for the `package.json` to the client (achieved via the `blitz.config.ts`).  The new environment variable is called `PDFJS_DIST_VERSION`.

Fixes #714. 