### PR TITLE
Convert ternary operators to short-circuits in the `FilePreviewer` component

### DIFF
--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -29,6 +29,7 @@ const MainFileViewer = ({ mainFile }) => {
           {/* Preview image */}
           {mainFile.isImage && (
             <img
+              alt="An image of the main file"
               src={mainFile.cdnUrl}
               className="mx-auto my-2 h-auto w-full"
             />

--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -42,7 +42,7 @@ const MainFileViewer = ({ mainFile }) => {
             </Worker>
           )}
           {/* Preview Markdown */}
-          {mainFile.mimeType.startsWith("text/markdown") ? (
+          {mainFile.mimeType.startsWith("text/markdown") && (
             <div className="coc">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
@@ -77,8 +77,6 @@ const MainFileViewer = ({ mainFile }) => {
                 {mainFileMarkdown}
               </ReactMarkdown>
             </div>
-          ) : (
-            ""
           )}
           {/* Preview Office files */}
           {mainFile.mimeType.startsWith("application/vnd.ms-excel") ||

--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -79,24 +79,22 @@ const MainFileViewer = ({ mainFile }) => {
             </div>
           )}
           {/* Preview Office files */}
-          {mainFile.mimeType.startsWith("application/vnd.ms-excel") ||
-          mainFile.mimeType.startsWith(
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-          ) ||
-          mainFile.mimeType.startsWith(
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-          ) ||
-          mainFile.mimeType.startsWith(
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-          ) ? (
+          {(mainFile.mimeType.startsWith("application/vnd.ms-excel") ||
+            mainFile.mimeType.startsWith(
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ) ||
+            mainFile.mimeType.startsWith(
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ) ||
+            mainFile.mimeType.startsWith(
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            )) && (
             <iframe
               src={`https://view.officeapps.live.com/op/embed.aspx?src=${mainFile.cdnUrl}`}
               width="100%"
               height="800px"
               frameBorder="0"
             ></iframe>
-          ) : (
-            ""
           )}
         </>
       )}

--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -11,7 +11,7 @@ import rehypeKatex from "rehype-katex"
 import "katex/dist/katex.min.css" // `rehype-katex` does not import the CSS for you
 import { useEffect, useState } from "react"
 
-const MainFileViewer = ({ mainFile, module }) => {
+const MainFileViewer = ({ mainFile }) => {
   const prefersDarkMode = useMediaPredicate("(prefers-color-scheme: dark)")
   const [mainFileMarkdown, setMarkdown] = useState("")
 

--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -24,23 +24,22 @@ const MainFileViewer = ({ mainFile }) => {
   }, [])
   return (
     <>
-      {mainFile.name ? (
+      {mainFile.name && (
         <>
           {/* Preview image */}
-          {mainFile.isImage ? (
-            <img src={mainFile.cdnUrl} className="mx-auto my-2 h-auto w-full" />
-          ) : (
-            ""
+          {mainFile.isImage && (
+            <img
+              src={mainFile.cdnUrl}
+              className="mx-auto my-2 h-auto w-full"
+            />
           )}
           {/* Preview PDF */}
-          {mainFile.mimeType.startsWith("application/pdf") ? (
+          {mainFile.mimeType.startsWith("application/pdf") && (
             <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.16.105/build/pdf.worker.min.js">
               <div style={{ height: "750px" }} className="max-w-screen text-gray-900">
                 <Viewer fileUrl={mainFile.cdnUrl} />
               </div>
             </Worker>
-          ) : (
-            ""
           )}
           {/* Preview Markdown */}
           {mainFile.mimeType.startsWith("text/markdown") ? (
@@ -102,8 +101,6 @@ const MainFileViewer = ({ mainFile }) => {
             ""
           )}
         </>
-      ) : (
-        ""
       )}
     </>
   )

--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -266,7 +266,7 @@ const Module = ({ module, mainFile, supportingRaw }) => {
             size={mainFile.size}
             url={`/api/modules/main/${module.suffix}`}
           />
-          <FilePreviewer module={module} mainFile={mainFile} />
+          <FilePreviewer mainFile={mainFile} />
         </div>
         <div className="mb-28 grid-cols-2 gap-x-4 md:grid">
           {supportingRaw.files.length > 0 ? (


### PR DESCRIPTION
This PR converts ternary operators to short-circuits in the `FilePreviewer` component. Fixes #754.

I'm marking this PR as a draft, since I found that Markdown files are not previewing during the testing. (See Issue #781)
I doubt that this PR introduces this issue, but I'd appreciate another person's look on this. 

Files checked:

1. Image ✅ 
2. Office file ✅ 
3. Markdown 🚫  (Issue #781)