### PR TITLE
Fix Autocomplete's React 18 compatibility

### DIFF
--- a/app/core/components/Autocomplete.tsx
+++ b/app/core/components/Autocomplete.tsx
@@ -1,9 +1,12 @@
 import { autocomplete } from "@algolia/autocomplete-js"
 import React, { createElement, Fragment, useEffect, useRef } from "react"
-import { render } from "react-dom"
+import { createRoot } from "react-dom/client"
+import type { Root } from "react-dom"
 
 function Autocomplete(props) {
-  const containerRef = useRef(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const panelRootRef = useRef<Root | null>(null)
+  const rootRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -12,9 +15,16 @@ function Autocomplete(props) {
 
     const search = autocomplete({
       container: containerRef.current,
-      renderer: { createElement, Fragment },
+      renderer: { createElement, Fragment, render: () => {} },
       render({ children }, root) {
-        render(children, root)
+        if (!panelRootRef.current || rootRef.current !== root) {
+          rootRef.current = root
+
+          panelRootRef.current?.unmount()
+          panelRootRef.current = createRoot(root)
+        }
+
+        panelRootRef.current.render(children)
       },
       ...props,
     })


### PR DESCRIPTION
This PR makes the Autocomplete component compatible with React 18, addressing the warning messages. Fixes #364.

The solution was taken from here: https://github.com/algolia/autocomplete/blob/next/examples/react-18/src/App.tsx