### PR TITLE
Add key props to the mapped elements on the root page

### DIFF
--- a/app/core/components/NavbarFullwidthMenu.tsx
+++ b/app/core/components/NavbarFullwidthMenu.tsx
@@ -65,9 +65,7 @@ const FullWidthMenu = ({
                 <Popover.Panel className="max-w-72 absolute left-1/2 z-10 mt-3 w-72 -translate-x-1/2 transform rounded-md bg-white px-4 shadow-lg ring-1 ring-gray-400 ring-opacity-5 dark:bg-gray-800 dark:ring-gray-600 dark:ring-opacity-100 sm:px-0">
                   <ul className="divide-y dark:divide-gray-600">
                     {invitedModules.map((invited) => (
-                      <>
-                        <InvitationNotification invited={invited} />
-                      </>
+                      <InvitationNotification key={invited.id} invited={invited} />
                     ))}
                   </ul>
                 </Popover.Panel>

--- a/app/modules/components/QuickDraft.tsx
+++ b/app/modules/components/QuickDraft.tsx
@@ -210,11 +210,9 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                             >
                               <option className="text-gray-900" value=""></option>
                               {moduleTypes.map((type) => (
-                                <>
-                                  <option value={type.id} className="text-gray-900">
-                                    {type.name}
-                                  </option>
-                                </>
+                                <option key={type.id} value={type.id} className="text-gray-900">
+                                  {type.name}
+                                </option>
                               ))}
                             </select>
                           </div>
@@ -255,15 +253,17 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                             >
                               <option className="text-gray-900" value=""></option>
                               {licenses.map((license) => (
-                                <>
-                                  <option value={license.id} className="text-gray-900">
-                                    {license.name} (
-                                    {license.price > 0
-                                      ? `${license.price / 100}EUR incl. VAT`
-                                      : "Free"}
-                                    )
-                                  </option>
-                                </>
+                                <option
+                                  key={license.id}
+                                  value={license.id}
+                                  className="text-gray-900"
+                                >
+                                  {license.name} (
+                                  {license.price > 0
+                                    ? `${license.price / 100}EUR incl. VAT`
+                                    : "Free"}
+                                  )
+                                </option>
                               ))}
                             </select>
                           </div>
@@ -336,11 +336,13 @@ const QuickDraft = ({ buttonText, buttonStyle, refetchFn }) => {
                               {...formik.getFieldProps("language")}
                             >
                               {ISO6391.getAllNames().map((lang) => (
-                                <>
-                                  <option value={ISO6391.getCode(lang)} className="text-gray-900">
-                                    {ISO6391.getCode(lang) + " - " + lang}
-                                  </option>
-                                </>
+                                <option
+                                  key={lang}
+                                  value={ISO6391.getCode(lang)}
+                                  className="text-gray-900"
+                                >
+                                  {ISO6391.getCode(lang) + " - " + lang}
+                                </option>
                               ))}
                             </select>
                           </div>


### PR DESCRIPTION
This PR adds key props to the mapped elements on the root page, to fix the missing props warning. Fixes #757. 