### PR TITLE
Use named imports for `filesize` 

### DIFF
--- a/app/core/components/EditMainFileDisplay.tsx
+++ b/app/core/components/EditMainFileDisplay.tsx
@@ -1,7 +1,7 @@
 import { Download, TrashCan } from "@carbon/icons-react"
 import { useMutation } from "blitz"
 import toast from "react-hot-toast"
-import filesize from "filesize"
+import { filesize } from "filesize"
 
 import deleteMainFile from "../../modules/mutations/deleteMainFile"
 

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -1,7 +1,7 @@
 import { Download, TrashCan } from "@carbon/icons-react"
 import { useMutation } from "blitz"
 import toast from "react-hot-toast"
-import filesize from "filesize"
+import { filesize } from "filesize"
 
 import deleteSupportingFile from "../../modules/mutations/deleteSupportingFile"
 

--- a/app/modules/components/ViewFiles.tsx
+++ b/app/modules/components/ViewFiles.tsx
@@ -1,5 +1,5 @@
 import { Download } from "@carbon/icons-react"
-import filesize from "filesize"
+import { filesize } from "filesize"
 
 const ViewFiles = ({ name, size, url }) => {
   return (


### PR DESCRIPTION
This PR converts the default imports for `filesize` into the named imports, fixing the issue introduced by the dependency upgrade (observed in this PR #771 ).

Fixes #799 