### PR TITLE
Only include the drafts in the email digest

### DIFF
--- a/app/api/weekly-digest-mailer.ts
+++ b/app/api/weekly-digest-mailer.ts
@@ -107,6 +107,7 @@ export default CronJob(
       const myDrafts = await db.authorship.findMany({
         where: {
           acceptedInvitation: true,
+          module: { published: false },
           workspaceId: workspace.id,
         },
         include: {

--- a/app/api/weekly-digest-mailer.ts
+++ b/app/api/weekly-digest-mailer.ts
@@ -26,9 +26,6 @@ export default CronJob(
 
     // find workspaces
     const workspaces = await db.workspace.findMany({
-      // where: {
-      //   id: 101,
-      // },
       include: {
         members: {
           include: {


### PR DESCRIPTION
This PR fixes the issue where the email digest shows publish modules under the drafts. Fixes #780.

This PR also deletes the commented code in a prisma query that is currently unused. 