### PR TITLE
Add Zotero metadata for modules

### DIFF
--- a/app/pages/modules/[suffix].tsx
+++ b/app/pages/modules/[suffix].tsx
@@ -116,7 +116,6 @@ const Module = ({ module, mainFile, supportingRaw }) => {
     arrowColor = "transparent"
   }
 
-  console.log(mainFile)
   useEffect(() => {
     if (mainFile.mimeType === "text/markdown") {
       fetch(mainFile.cdnUrl)


### PR DESCRIPTION
This PR adds Zotero metadata for modules. I see this as an experimental PR since we may need to tweak what information we want to add, as we discuss in #626. Nevertheless, I wanted to open a PR to show what I got so far. 

Fixes #626.