### PR TITLE
Fix the z-indices of the collections CTA modal & the make-public modal

### DIFF
--- a/app/core/modals/MakeCollectionPublicModal.tsx
+++ b/app/core/modals/MakeCollectionPublicModal.tsx
@@ -20,7 +20,7 @@ export default function MakeCollectionPublicModal({ collection, refetchFn }) {
 
   return (
     <>
-      <div className="z-100 sticky top-0 flex  w-full bg-amber-50 py-4 px-2 text-center dark:bg-amber-800">
+      <div className="sticky top-0 z-50 flex w-full bg-amber-50 py-4 px-2 text-center dark:bg-amber-800">
         <div className="mx-auto flex">
           <div className="inline-block align-middle">
             <CheckmarkOutline

--- a/app/pages/browse.jsx
+++ b/app/pages/browse.jsx
@@ -107,7 +107,7 @@ const Browse = () => {
         invitations={invitations}
         refetchFn={refetch}
       />
-      <div className="z-100 sticky top-0 flex  w-full bg-rose-50 py-4 px-2 text-center dark:bg-rose-800">
+      <div className="sticky top-0 z-50 flex w-full bg-rose-50 py-4 px-2 text-center dark:bg-rose-800">
         <div className="mx-auto flex">
           <div className="inline-block align-middle">
             <Fire


### PR DESCRIPTION
This PR fixes the issue where the call-to-action modal for the collections on the browse page was showing behind the module cards. Fixes #791 

The visual bug was due to the undefined class `z-100`. I searched the app, and I found that `z-100` was used in the `MakeCollectionsPublicModal` as well. This PR also replaces `z-100` there with `z-50`. 

