### PR TITLE
Use 404 as a basis for moving from CrossRef to DataCite when adding a reference

### DIFF
--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -83,77 +83,86 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
     })
 
     return module
-  } catch {
-    const cr = await axios.get(`https://api.datacite.org/dois/${doi}`)
-    const metadata = cr.data
-
-    const module = await db.module.create({
-      data: {
-        published: true,
-        publishedAt: new Date(
-          metadata.data.attributes.publicationYear.toString() || metadata.data.attributes.published
-        ),
-        publishedWhere: metadata.data.attributes.publisher,
-        originMetadata: "DataCite",
-        prefix: metadata.data.attributes.prefix,
-        suffix: metadata.data.attributes.suffix,
-        isbn: undefined, // Not used in schema
-        url: `https://doi.org/${metadata.data.id}`,
-        language: metadata.data.attributes.language || "en",
-        title: metadata.data.attributes.titles[0].title,
-        description: metadata.data.attributes.descriptions[0]
-          ? metadata.data.attributes.descriptions[0].description
-          : undefined,
-        type: {
-          connectOrCreate: {
-            where: {
-              name: metadata.data.attributes.types.resourceType || "Other",
-            },
-            create: {
-              name: metadata.data.attributes.types.resourceType || "Other",
-              originType: "DataCite",
-            },
-          },
-        },
-        license: metadata.data.attributes.rightsList[0]
-          ? {
+  } catch (error) {
+    if (error?.response?.status === 404) {
+      try {
+        const cr = await axios.get(`https://api.datacite.org/dois/${doi}`)
+        const metadata = cr.data
+        const module = await db.module.create({
+          data: {
+            published: true,
+            publishedAt: new Date(
+              metadata.data.attributes.publicationYear.toString() ||
+                metadata.data.attributes.published
+            ),
+            publishedWhere: metadata.data.attributes.publisher,
+            originMetadata: "DataCite",
+            prefix: metadata.data.attributes.prefix,
+            suffix: metadata.data.attributes.suffix,
+            isbn: undefined, // Not used in schema
+            url: `https://doi.org/${metadata.data.id}`,
+            language: metadata.data.attributes.language || "en",
+            title: metadata.data.attributes.titles[0].title,
+            description: metadata.data.attributes.descriptions[0]
+              ? metadata.data.attributes.descriptions[0].description
+              : undefined,
+            type: {
               connectOrCreate: {
-                where: { url: metadata.data.attributes.rightsList[0].rightsUri || "undefined" },
+                where: {
+                  name: metadata.data.attributes.types.resourceType || "Other",
+                },
                 create: {
-                  url: metadata.data.attributes.rightsList[0].rightsUri || "undefined",
-                  source: "DataCite",
+                  name: metadata.data.attributes.types.resourceType || "Other",
+                  originType: "DataCite",
                 },
               },
-            }
-          : undefined,
-        authorsRaw: { object: metadata.data.attributes.creators },
-        referencesRaw:
-          metadata.data.attributes.relatedIdentifiers.map(
-            (x) => x.relationType === "Reference" && x
-          ).length > 0
-            ? metadata.data.attributes.relatedIdentifiers.map(
+            },
+            license: metadata.data.attributes.rightsList[0]
+              ? {
+                  connectOrCreate: {
+                    where: { url: metadata.data.attributes.rightsList[0].rightsUri || "undefined" },
+                    create: {
+                      url: metadata.data.attributes.rightsList[0].rightsUri || "undefined",
+                      source: "DataCite",
+                    },
+                  },
+                }
+              : undefined,
+            authorsRaw: { object: metadata.data.attributes.creators },
+            referencesRaw:
+              metadata.data.attributes.relatedIdentifiers.map(
                 (x) => x.relationType === "Reference" && x
-              )
-            : undefined,
-      },
-      include: {
-        license: true,
-        type: true,
-      },
-    })
-    await index.saveObject({
-      objectID: module.id,
-      doi: `${module.prefix}/${module.suffix}`,
-      suffix: module.suffix,
-      license: module.license?.url,
-      type: module.type.name,
-      // It's called name and not title to improve Algolia search
-      name: module.title,
-      description: module.description,
-      publishedAt: module.publishedAt,
-      displayColor: module.displayColor,
-    })
-
-    return module
+              ).length > 0
+                ? metadata.data.attributes.relatedIdentifiers.map(
+                    (x) => x.relationType === "Reference" && x
+                  )
+                : undefined,
+          },
+          include: {
+            license: true,
+            type: true,
+          },
+        })
+        await index.saveObject({
+          objectID: module.id,
+          doi: `${module.prefix}/${module.suffix}`,
+          suffix: module.suffix,
+          license: module.license?.url,
+          type: module.type.name,
+          // It's called name and not title to improve Algolia search
+          name: module.title,
+          description: module.description,
+          publishedAt: module.publishedAt,
+          displayColor: module.displayColor,
+        })
+        return module
+      } catch (error) {
+        if (error?.response?.status === 404)
+          throw new Error("Cannot find the reference in CrossRef or DataCite")
+        // Print out the error message when the error is not related to 404
+        throw new Error(error.message)
+      }
+    }
+    throw new Error(error.message)
   }
 })

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -10,7 +10,11 @@ function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
 
-export default resolver.pipe(resolver.authorize(), async ({ doi }, ctx) => {
+interface Input {
+  doi: string
+}
+
+export default resolver.pipe(resolver.authorize(), async ({ doi }: Input, ctx) => {
   try {
     // Will auto-throw if resource not found
     const cr = await axios.get(`https://api.crossref.org/works/${doi}?mailto=info@libscie.org`)

--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -1,5 +1,5 @@
 import { resolver } from "blitz"
-import db, { Prisma } from "db"
+import db from "db"
 import axios from "axios"
 import algoliasearch from "algoliasearch"
 


### PR DESCRIPTION
This PR revises the logic when adding a reference via DOI. The logic tries CrossRef first, then if the error code was 404, it tries DataCite. If the error was other than 404, it will throw a new error with a message.

Previously, the logic was to use DataCite for all errors. 

Fixes #787 