### PR TITLE
Remove `@floating-ui/dom` from dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@algolia/autocomplete-js": "1.7.1",
         "@carbon/icons-react": "11.10.0",
         "@faker-js/faker": "7.5.0",
-        "@floating-ui/dom": "1.0.2",
         "@headlessui/react": "1.7.3",
         "@prisma/client": "4.4.0",
         "@react-pdf-viewer/core": "3.7.0",
@@ -1545,19 +1544,6 @@
       "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
       "dependencies": {
         "ajv": "^6.12.6"
-      }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
-      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
-      "dependencies": {
-        "@floating-ui/core": "^1.0.1"
       }
     },
     "node_modules/@hapi/accept": {
@@ -17000,13 +16986,11 @@
     },
     "node_modules/node-libxml/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17015,13 +16999,11 @@
     },
     "node_modules/node-libxml/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17031,13 +17013,11 @@
     },
     "node_modules/node-libxml/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17047,7 +17027,6 @@
     },
     "node_modules/node-libxml/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17056,25 +17035,21 @@
     },
     "node_modules/node-libxml/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17083,13 +17058,11 @@
     },
     "node_modules/node-libxml/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17101,13 +17074,11 @@
     },
     "node_modules/node-libxml/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17123,13 +17094,11 @@
     },
     "node_modules/node-libxml/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17141,7 +17110,6 @@
     },
     "node_modules/node-libxml/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17150,7 +17118,6 @@
     },
     "node_modules/node-libxml/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17160,19 +17127,16 @@
     },
     "node_modules/node-libxml/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/ini": {
       "version": "1.3.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17184,13 +17148,11 @@
     },
     "node_modules/node-libxml/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17202,7 +17164,6 @@
     },
     "node_modules/node-libxml/node_modules/needle": {
       "version": "2.5.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17219,7 +17180,6 @@
     },
     "node_modules/node-libxml/node_modules/needle/node_modules/debug": {
       "version": "3.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17228,7 +17188,6 @@
     },
     "node_modules/node-libxml/node_modules/needle/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -17245,7 +17204,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp": {
       "version": "0.17.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17266,13 +17224,11 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17281,7 +17237,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17301,13 +17256,11 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17317,7 +17270,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17326,7 +17278,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/mkdirp": {
       "version": "0.5.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17338,7 +17289,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/nopt": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17351,7 +17301,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17363,7 +17312,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -17372,7 +17320,6 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17390,13 +17337,11 @@
     },
     "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17405,13 +17350,11 @@
     },
     "node_modules/node-libxml/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17422,7 +17365,6 @@
     },
     "node_modules/node-libxml/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17434,7 +17376,6 @@
     },
     "node_modules/node-libxml/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17443,7 +17384,6 @@
     },
     "node_modules/node-libxml/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17452,7 +17392,6 @@
     },
     "node_modules/node-libxml/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17461,7 +17400,6 @@
     },
     "node_modules/node-libxml/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17470,7 +17408,6 @@
     },
     "node_modules/node-libxml/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17479,7 +17416,6 @@
     },
     "node_modules/node-libxml/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17489,7 +17425,6 @@
     },
     "node_modules/node-libxml/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17498,13 +17433,11 @@
     },
     "node_modules/node-libxml/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
@@ -17519,13 +17452,11 @@
     },
     "node_modules/node-libxml/node_modules/rc/node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17540,37 +17471,31 @@
     },
     "node_modules/node-libxml/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/signal-exit": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-libxml/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17579,7 +17504,6 @@
     },
     "node_modules/node-libxml/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17593,7 +17517,6 @@
     },
     "node_modules/node-libxml/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17605,7 +17528,6 @@
     },
     "node_modules/node-libxml/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17614,13 +17536,11 @@
     },
     "node_modules/node-libxml/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-libxml/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17629,7 +17549,6 @@
     },
     "node_modules/node-libxml/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -25937,19 +25856,6 @@
       "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
       "requires": {
         "ajv": "^6.12.6"
-      }
-    },
-    "@floating-ui/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
-    },
-    "@floating-ui/dom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
-      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
-      "requires": {
-        "@floating-ui/core": "^1.0.1"
       }
     },
     "@hapi/accept": {
@@ -37753,23 +37659,19 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -37777,13 +37679,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -37791,48 +37691,39 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -37846,13 +37737,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -37860,7 +37749,6 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -37868,7 +37756,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -37876,31 +37763,26 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -37908,7 +37790,6 @@
         "needle": {
           "version": "2.5.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -37918,15 +37799,13 @@
             "debug": {
               "version": "3.2.7",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "ms": {
               "version": "2.1.3",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
@@ -37939,7 +37818,6 @@
         "node-pre-gyp": {
           "version": "0.17.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "detect-libc": "^1.0.3",
             "mkdirp": "^0.5.5",
@@ -37955,13 +37833,11 @@
           "dependencies": {
             "chownr": {
               "version": "1.1.4",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "fs-minipass": {
               "version": "1.2.7",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "minipass": "^2.6.0"
               }
@@ -37969,7 +37845,6 @@
             "glob": {
               "version": "7.1.6",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -37981,13 +37856,11 @@
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -37996,7 +37869,6 @@
             "minizlib": {
               "version": "1.3.3",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "minipass": "^2.9.0"
               }
@@ -38004,7 +37876,6 @@
             "mkdirp": {
               "version": "0.5.5",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -38012,7 +37883,6 @@
             "nopt": {
               "version": "4.0.3",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -38021,20 +37891,17 @@
             "rimraf": {
               "version": "2.7.1",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "glob": "^7.1.3"
               }
             },
             "semver": {
               "version": "5.7.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             },
             "tar": {
               "version": "4.4.13",
               "bundled": true,
-              "dev": true,
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -38047,28 +37914,24 @@
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -38078,7 +37941,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -38088,36 +37950,30 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -38125,18 +37981,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -38146,15 +37999,13 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -38167,33 +38018,27 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -38201,7 +38046,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -38211,33 +38055,28 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@algolia/autocomplete-js": "1.7.1",
     "@carbon/icons-react": "11.10.0",
     "@faker-js/faker": "7.5.0",
-    "@floating-ui/dom": "1.0.2",
     "@headlessui/react": "1.7.3",
     "@prisma/client": "4.4.0",
     "@react-pdf-viewer/core": "3.7.0",


### PR DESCRIPTION
We found that `@floating-ui/dom` is not being used for the tooltips on the marketing page in our discussion in Issue #725 (instead `react-tooltip` is being used). So, we want to remove it from the dependency.

This PR removes `@floating-ui/dom` from the dependency. 

Fixes #725 

The front page works without this package 👍 


https://user-images.githubusercontent.com/17035406/196627638-7ddf570c-49c8-428c-ae3e-ac6c74c57c57.mov



[] We need to update our Wiki if this gets merged ⏩ 