### PR TITLE
Bump filesize and use named imports for filesize (API update)

### DIFF
--- a/app/core/components/EditMainFileDisplay.tsx
+++ b/app/core/components/EditMainFileDisplay.tsx
@@ -1,7 +1,7 @@
 import { Download, TrashCan } from "@carbon/icons-react"
 import { useMutation } from "blitz"
 import toast from "react-hot-toast"
-import filesize from "filesize"
+import { filesize } from "filesize"
 
 import deleteMainFile from "../../modules/mutations/deleteMainFile"
 

--- a/app/core/components/EditSupportingFileDisplay.tsx
+++ b/app/core/components/EditSupportingFileDisplay.tsx
@@ -1,7 +1,7 @@
 import { Download, TrashCan } from "@carbon/icons-react"
 import { useMutation } from "blitz"
 import toast from "react-hot-toast"
-import filesize from "filesize"
+import { filesize } from "filesize"
 
 import deleteSupportingFile from "../../modules/mutations/deleteSupportingFile"
 

--- a/app/modules/components/ViewFiles.tsx
+++ b/app/modules/components/ViewFiles.tsx
@@ -1,5 +1,5 @@
 import { Download } from "@carbon/icons-react"
-import filesize from "filesize"
+import { filesize } from "filesize"
 
 const ViewFiles = ({ name, size, url }) => {
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "lint-staged": "13.0.3",
         "node-libxml": "4.1.2",
         "prettier": "2.7.1",
-        "prettier-plugin-prisma": "4.2.0",
+        "prettier-plugin-prisma": "4.4.0",
         "prettier-plugin-tailwindcss": "0.1.13",
         "pretty-quick": "3.1.3",
         "tsx": "3.9.0"
@@ -2924,9 +2924,9 @@
       }
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826.tgz",
-      "integrity": "sha512-xXE4vjNMlvY2T0MqyOpUwcKnuajn3SDksF23PWtd3mODP5J3rtf1QoqSk99CX1i8Opap/UN0L0VHvPwgE49O7g==",
+      "version": "4.4.0-66.f352a33b70356f46311da8b00d83386dd9f145d6",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.4.0-66.f352a33b70356f46311da8b00d83386dd9f145d6.tgz",
+      "integrity": "sha512-Hc2i5nfAt3nLDUkQNWJcKFJaA9Avd5zz6t85w9SW7P0vGtFXScQ+xIu6znbULr9bc0pgTWejY1We2u/7EMxHWw==",
       "dev": true
     },
     "node_modules/@prisma/sdk": {
@@ -18688,12 +18688,12 @@
       }
     },
     "node_modules/prettier-plugin-prisma": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-prisma/-/prettier-plugin-prisma-4.2.0.tgz",
-      "integrity": "sha512-7KWA1L1p7PeSLOZJvDFKaik4z9c4SddgMGBkCzwzqUK13LhFhrIq3nyFBMZxoY3jt2gl8HfOiTT44/tCdjIBIQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-prisma/-/prettier-plugin-prisma-4.4.0.tgz",
+      "integrity": "sha512-631zwtvHUjcuS+i83wkxE3LqizazojWie4Pkha9GL6r1UsochNUedvxfvWPCdw6Dpyawvc5UKkmxcb9aT9+xfg==",
       "dev": true,
       "dependencies": {
-        "@prisma/prisma-fmt-wasm": "4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826"
+        "@prisma/prisma-fmt-wasm": "4.4.0-66.f352a33b70356f46311da8b00d83386dd9f145d6"
       },
       "engines": {
         "node": ">=12",
@@ -26637,9 +26637,9 @@
       }
     },
     "@prisma/prisma-fmt-wasm": {
-      "version": "4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826.tgz",
-      "integrity": "sha512-xXE4vjNMlvY2T0MqyOpUwcKnuajn3SDksF23PWtd3mODP5J3rtf1QoqSk99CX1i8Opap/UN0L0VHvPwgE49O7g==",
+      "version": "4.4.0-66.f352a33b70356f46311da8b00d83386dd9f145d6",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.4.0-66.f352a33b70356f46311da8b00d83386dd9f145d6.tgz",
+      "integrity": "sha512-Hc2i5nfAt3nLDUkQNWJcKFJaA9Avd5zz6t85w9SW7P0vGtFXScQ+xIu6znbULr9bc0pgTWejY1We2u/7EMxHWw==",
       "dev": true
     },
     "@prisma/sdk": {
@@ -38670,12 +38670,12 @@
       "dev": true
     },
     "prettier-plugin-prisma": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-prisma/-/prettier-plugin-prisma-4.2.0.tgz",
-      "integrity": "sha512-7KWA1L1p7PeSLOZJvDFKaik4z9c4SddgMGBkCzwzqUK13LhFhrIq3nyFBMZxoY3jt2gl8HfOiTT44/tCdjIBIQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-prisma/-/prettier-plugin-prisma-4.4.0.tgz",
+      "integrity": "sha512-631zwtvHUjcuS+i83wkxE3LqizazojWie4Pkha9GL6r1UsochNUedvxfvWPCdw6Dpyawvc5UKkmxcb9aT9+xfg==",
       "dev": true,
       "requires": {
-        "@prisma/prisma-fmt-wasm": "4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826"
+        "@prisma/prisma-fmt-wasm": "4.4.0-66.f352a33b70356f46311da8b00d83386dd9f145d6"
       }
     },
     "prettier-plugin-tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "dagre": "0.8.5",
         "eslint": "8.24.0",
         "feed": "4.2.2",
-        "filesize": "9.0.11",
+        "filesize": "10.0.5",
         "form-data": "4.0.0",
         "formik": "2.2.9",
         "husky": "8.0.1",
@@ -9809,11 +9809,11 @@
       }
     },
     "node_modules/filesize": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-9.0.11.tgz",
-      "integrity": "sha512-gTAiTtI0STpKa5xesyTA9hA3LX4ga8sm2nWRcffEa1L/5vQwb4mj2MdzMkoHoGv4QzfDshQZuYscQSf8c4TKOA==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.5.tgz",
+      "integrity": "sha512-qrzyt8gLh86nsyYiC3ibI5KyIYRCWg2yqIklYrWF4a0qNfekik4OQfn7AoPJG2hRrPMSlH6fET4VEITweZAzjA==",
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -32139,9 +32139,9 @@
       }
     },
     "filesize": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-9.0.11.tgz",
-      "integrity": "sha512-gTAiTtI0STpKa5xesyTA9hA3LX4ga8sm2nWRcffEa1L/5vQwb4mj2MdzMkoHoGv4QzfDshQZuYscQSf8c4TKOA=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.5.tgz",
+      "integrity": "sha512-qrzyt8gLh86nsyYiC3ibI5KyIYRCWg2yqIklYrWF4a0qNfekik4OQfn7AoPJG2hRrPMSlH6fET4VEITweZAzjA=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dagre": "0.8.5",
     "eslint": "8.24.0",
     "feed": "4.2.2",
-    "filesize": "9.0.11",
+    "filesize": "10.0.5",
     "form-data": "4.0.0",
     "formik": "2.2.9",
     "husky": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "lint-staged": "13.0.3",
     "node-libxml": "4.1.2",
     "prettier": "2.7.1",
-    "prettier-plugin-prisma": "4.2.0",
+    "prettier-plugin-prisma": "4.4.0",
     "prettier-plugin-tailwindcss": "0.1.13",
     "pretty-quick": "3.1.3",
     "tsx": "3.9.0"


### PR DESCRIPTION
(This PR is the revision of #800 where I forgot to merge the filesize dependabot update) 

This PR updates the `filesize` (dependabot update), and converts the default imports into the named imports to follow the API change https://github.com/libscie/ResearchEquals.com/pull/771.

Fixes https://github.com/libscie/ResearchEquals.com/issues/799