### PR TITLE
Add admin reminting for collections

### DIFF
--- a/app/collections/mutations/updateCrossRefCollection.ts
+++ b/app/collections/mutations/updateCrossRefCollection.ts
@@ -1,0 +1,46 @@
+import { resolver } from "blitz"
+import db from "db"
+import { isURI } from "../../core/crossref/ai_program"
+import submitToCrossRef from "app/core/utils/submitToCrossRef"
+import { generateCollectionXml } from "../../core/crossref/generateCrossRefXml"
+
+export default resolver.pipe(resolver.authorize(), async ({ id }: { id: number }) => {
+  const datetime = Date.now()
+
+  // TODO: Can be simplified along with stripe_webhook.ts and publishModule.ts
+  const collection = await db.collection.findFirst({
+    where: {
+      id,
+    },
+    include: {
+      editors: {
+        include: {
+          workspace: true,
+        },
+      },
+    },
+  })
+
+  const resolveUrl = `${process.env.APP_ORIGIN}/collections/${collection!.suffix}`
+
+  if (!isURI(resolveUrl)) throw Error("Resolve URL is not a valid URI")
+  // Add DOI minting
+  const xmlData = generateCollectionXml({
+    schema: "5.3.1",
+    title: collection!.title as string,
+    subtitle: collection!.subtitle as string,
+    doi: `${process.env.DOI_PREFIX}/${collection!.suffix}`,
+    resolve_url: resolveUrl,
+    authors: collection!.editors.map((editor) => {
+      const js = {
+        firstName: editor.workspace?.firstName,
+        lastName: editor.workspace?.lastName,
+        orcid: editor.workspace?.orcid,
+      }
+
+      return js
+    }),
+  })
+  await submitToCrossRef({ xmlData, suffix: collection!.suffix })
+  return true
+})

--- a/app/core/queries/getAdminInfo.ts
+++ b/app/core/queries/getAdminInfo.ts
@@ -20,5 +20,11 @@ export default resolver.pipe(resolver.authorize(), async (input, ctx: Ctx) => {
     },
   })
 
-  return modules
+  const collections = await db.collection.findMany({
+    where: {
+      public: true,
+    },
+  })
+
+  return { modules, collections }
 })

--- a/app/pages/admin.tsx
+++ b/app/pages/admin.tsx
@@ -114,7 +114,7 @@ const Admin: BlitzPage = () => {
           </div>
         </div>
         <div>
-          <h2 className="mx-auto my-8 text-center text-lg font-normal">DOI reminting</h2>
+          <h2 className="mx-auto my-8 text-center text-lg font-normal">Module DOI reminting</h2>
           <div className="flex flex-col">
             <div className="">
               <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
@@ -152,7 +152,7 @@ const Admin: BlitzPage = () => {
                       </tr>
                     </thead>
                     <tbody>
-                      {adminInfo.map((module, moduleIdx) => (
+                      {adminInfo.modules.map((module, moduleIdx) => (
                         <tr
                           key={module.title}
                           className={
@@ -188,6 +188,79 @@ const Admin: BlitzPage = () => {
                                   success: "Updated metadata with CrossRef",
                                   error: "That did not work",
                                 })
+                              }}
+                              className="whitespace-nowrap rounded border-0 bg-indigo-100 px-4 py-2 text-sm font-normal leading-5 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                            >
+                              Update CrossRef
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* Collection DOI reminting */}
+        <div>
+          <h2 className="mx-auto my-8 text-center text-lg font-normal">Collection reminting</h2>
+          <div className="flex flex-col">
+            <div className="">
+              <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                <div className="overflow-hidden border-b border-gray-200 shadow sm:rounded-lg">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50 dark:bg-gray-800">
+                      <tr>
+                        <th
+                          scope="col"
+                          className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white"
+                        >
+                          DOI
+                        </th>
+                        <th
+                          scope="col"
+                          className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-900 dark:text-white"
+                        >
+                          Name
+                        </th>
+                        <th scope="col" className="relative px-6 py-3">
+                          <span className="sr-only">Update DOI registration</span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {adminInfo.collections.map((collection, collectionIdx) => (
+                        <tr
+                          key={collection.title}
+                          className={
+                            collectionIdx % 2 === 0
+                              ? "bg-white dark:bg-gray-900"
+                              : "bg-gray-50 dark:bg-gray-800"
+                          }
+                        >
+                          <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900 dark:text-white ">
+                            <Link
+                              href={`https://api.crossref.org/works/${process.env.DOI_PREFIX}/${collection.suffix}`}
+                            >
+                              <a
+                                target="_blank"
+                                className="underline"
+                              >{`${process.env.DOI_PREFIX}/${collection.suffix}`}</a>
+                            </Link>
+                          </td>
+                          <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900 dark:text-white">
+                            {collection.title}
+                          </td>
+                          <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                            <button
+                              onClick={async () => {
+                                // toast.promise(updateCrossRefMutation({ id: module.id }), {
+                                //   loading: "Updating...",
+                                //   success: "Updated metadata with CrossRef",
+                                //   error: "That did not work",
+                                // })
                               }}
                               className="whitespace-nowrap rounded border-0 bg-indigo-100 px-4 py-2 text-sm font-normal leading-5 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                             >

--- a/app/pages/admin.tsx
+++ b/app/pages/admin.tsx
@@ -9,6 +9,8 @@ import {
 } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import { useQuill } from "react-quilljs"
+import updateCrossRefCollection from "../collections/mutations/updateCrossRefCollection"
+
 import "quill/dist/quill.snow.css"
 
 import Navbar from "../core/components/Navbar"
@@ -34,6 +36,7 @@ const Admin: BlitzPage = () => {
   const [invitations] = useQuery(getInvitedModules, { session })
   const [adminInfo] = useQuery(getAdminInfo, null)
   const [updateCrossRefMutation] = useMutation(updateCrossRef)
+  const [updateCrossRefCollectionMutation] = useMutation(updateCrossRefCollection)
   const [broadcastMutation] = useMutation(broadcastMessage)
   const { quill, quillRef } = useQuill()
   const [countSubmit, setCountSubmit] = useState(0)
@@ -205,7 +208,7 @@ const Admin: BlitzPage = () => {
         </div>
         {/* Collection DOI reminting */}
         <div>
-          <h2 className="mx-auto my-8 text-center text-lg font-normal">Collection reminting</h2>
+          <h2 className="mx-auto my-8 text-center text-lg font-normal">Collection DOI reminting</h2>
           <div className="flex flex-col">
             <div className="">
               <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
@@ -256,11 +259,14 @@ const Admin: BlitzPage = () => {
                           <td className="whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
                             <button
                               onClick={async () => {
-                                // toast.promise(updateCrossRefMutation({ id: module.id }), {
-                                //   loading: "Updating...",
-                                //   success: "Updated metadata with CrossRef",
-                                //   error: "That did not work",
-                                // })
+                                toast.promise(
+                                  updateCrossRefCollectionMutation({ id: collection.id }),
+                                  {
+                                    loading: "Updating...",
+                                    success: "Updated collection metadata with CrossRef",
+                                    error: "That did not work",
+                                  }
+                                )
                               }}
                               className="whitespace-nowrap rounded border-0 bg-indigo-100 px-4 py-2 text-sm font-normal leading-5 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                             >


### PR DESCRIPTION
This PR adds reminting for collections in the `/admin` (superadmin) portal.

<img width="1092" alt="Screenshot 2022-10-26 at 10 58 22" src="https://user-images.githubusercontent.com/2946344/197982513-7bf45c39-c0bd-452c-980e-c9575b548704.png">

This allows for straightforward reminting of the DOI metadata such that errors can be remedied, or metadata updated (e.g., author names changed).

Steps taken:

1. Display collections in the admin page
2. Create the `updateCrossRefCollection` mutation
3. Add the functionality of the mutation to the admin page

This is a pattern we've previously setup for reminting the DOI metadata for modules.

Note: The `/admin` page is getting crowded and could benefit from an improvement :) But this isn't user facing so not super urgent right now.