### PR TITLE
Make the quick draft appear above the collections banner & make the collections modal appear above everything

### DIFF
--- a/app/core/components/Navbar.tsx
+++ b/app/core/components/Navbar.tsx
@@ -23,7 +23,7 @@ const Navbar = ({
 }) => {
   return (
     <>
-      <div className="z-50 mx-auto w-full border-b border-gray-100 bg-white px-4 dark:border-gray-600 dark:bg-gray-900 sm:px-6 lg:px-8">
+      <div className="z-10 mx-auto w-full border-b border-gray-100 bg-white px-4 dark:border-gray-600 dark:bg-gray-900 sm:px-6 lg:px-8">
         <div className="relative flex justify-between lg:gap-8 xl:grid xl:grid-cols-12">
           <div className="flex md:absolute md:inset-y-0 md:left-0 lg:static xl:col-span-2">
             <div className="my-2 flex shrink-0 items-center">

--- a/app/core/modals/CollectionsModal.tsx
+++ b/app/core/modals/CollectionsModal.tsx
@@ -70,7 +70,7 @@ export default function CollectionsModal({ button, styling, user, workspace }) {
       <Transition appear show={isOpen} as={Fragment}>
         <Dialog
           as="div"
-          className="z-999 fixed inset-0 overflow-y-auto"
+          className="fixed inset-0 z-50 overflow-y-auto"
           onClose={() => {
             setIsOpen(false)
           }}

--- a/app/modules/components/ManageAuthors.tsx
+++ b/app/modules/components/ManageAuthors.tsx
@@ -13,7 +13,7 @@ const ManageAuthors = ({ open, setOpen, moduleEdit, setQueryData }) => {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="fixed inset-0 overflow-hidden" onClose={setOpen}>
+      <Dialog as="div" className="fixed inset-0 z-10 overflow-hidden" onClose={setOpen}>
         <div className="absolute inset-0 overflow-hidden">
           <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-25 transition-opacity" />
 

--- a/app/pages/browse.jsx
+++ b/app/pages/browse.jsx
@@ -103,7 +103,7 @@ const Browse = () => {
         invitations={invitations}
         refetchFn={refetch}
       />
-      <div className="sticky top-0 z-50 flex w-full bg-rose-50 py-4 px-2 text-center dark:bg-rose-800">
+      <div className="sticky top-0 z-10 flex w-full bg-rose-50 py-4 px-2 text-center dark:bg-rose-800">
         <div className="mx-auto flex">
           <div className="inline-block align-middle">
             <Fire


### PR DESCRIPTION
This PR fixes two points related to z-indices:

1. This PR makes the quick draft appear above the collections banner. To do so, I adjusted the z-index of the collections banner itself to `z-10`. I previously set to `z-50`, but in retrospect, that was too high for the banner. 😓  (We still want modals and slide-outs to show up on top, for example 🤞 ).

2. This PR makes the collections modal appear on top, by setting `z-50`. (Fixing the point mentioned by @chartgerink on https://github.com/libscie/ResearchEquals.com/issues/847#issuecomment-1288655909) Previously, the class name was `z-999`, but I think it was not a valid Tailwind class, and thus it was not applied.

(I did not separate the PRs because we identified these issues in #847. I'm open to separating if you think that's better, @chartgerink 👍 )


Fixes #847 ✅ 