### PR TITLE
Bring the "finalize upgrade" banner to front (`z-10`)

### DIFF
--- a/app/core/modals/FinalizeUpgradeModal.tsx
+++ b/app/core/modals/FinalizeUpgradeModal.tsx
@@ -21,7 +21,7 @@ export default function FinalizeUpgradeModal({ collection, refetchFn }) {
 
   return (
     <>
-      <div className="z-5 sticky top-0 flex  w-full bg-pink-50 py-4 px-2 text-center dark:bg-pink-800">
+      <div className="sticky top-0 z-10 flex  w-full bg-pink-50 py-4 px-2 text-center dark:bg-pink-800">
         <div className="mx-auto flex">
           <div className="inline-block align-middle">
             <CheckmarkOutline


### PR DESCRIPTION
This PR brings the banner for telling users to finalize upgrading a collection into front. Fixes #860.

Setting a banner `z-10` is consistent with https://github.com/libscie/ResearchEquals.com/pull/862 👍 

https://user-images.githubusercontent.com/17035406/198272242-27f40a35-83bc-4037-b69f-2589ac6a0a38.mov

