### PR TITLE
Refactor collections admin to have save buttons

### DIFF
--- a/app/collections/components/AdminDescription.tsx
+++ b/app/collections/components/AdminDescription.tsx
@@ -22,47 +22,49 @@ const Description = ({ collection, refetchFn, isAdmin }) => {
     }
   }, [quill])
 
-  // console.log(quill.root.innerHTML)
   const formik = useFormik({
     initialValues: {
-      description: "",
+      description: collection.description,
     },
     validate: validateZodSchema(
       z.object({
         description: z.string(),
       })
     ),
-    onSubmit: async (values) => {},
+    onSubmit: async (values) => {
+      if (quill.root.innerHTML != collection.description) {
+        toast.promise(
+          changeDescriptionMutation({
+            id: collection.id,
+            description: quill.root.innerHTML,
+          }),
+          {
+            loading: "Saving description",
+            success: () => {
+              refetchFn()
+              return "Updated description"
+            },
+            error: "Update failed",
+          }
+        )
+      }
+    },
   })
 
   return (
     <div className="mx-4 my-8 xl:mx-0">
       <h2 className="text-xl">A message from your editor{collection.editors.length > 1 && "s"}</h2>
       {isAdmin ? (
-        <form
-          onSubmit={formik.handleSubmit}
-          onBlur={() => {
-            if (quill.root.innerHTML != collection.description) {
-              toast.promise(
-                changeDescriptionMutation({
-                  id: collection.id,
-                  description: quill.root.innerHTML,
-                }),
-                {
-                  loading: "Saving updates",
-                  success: () => {
-                    refetchFn()
-                    return "Updated description"
-                  },
-                  error: "Update failed",
-                }
-              )
-            }
-          }}
-        >
-          <div className="mt-4 mb-16 h-auto w-full">
+        <form onSubmit={formik.handleSubmit}>
+          <div className="my-4 h-auto w-full">
             <div ref={quillRef} className="" />
           </div>
+          <button
+            type="submit"
+            className="mx-auto my-1 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+          >
+            Save Description
+          </button>
         </form>
       ) : (
         <div dangerouslySetInnerHTML={{ __html: collection.description }} className="quilljs" />

--- a/app/collections/components/AdminSubtitle.tsx
+++ b/app/collections/components/AdminSubtitle.tsx
@@ -1,54 +1,64 @@
-import { useMutation } from "blitz"
+import { useMutation, validateZodSchema } from "blitz"
 import { Field, Form, Formik } from "formik"
 import toast from "react-hot-toast"
 import changeSubtitle from "../mutations/changeSubtitle"
+import { useFormik } from "formik"
+import { z } from "zod"
 
 const Subtitle = ({ collection, refetchFn, isAdmin }) => {
   const [changeSubtitleMutation, { isSuccess: isSubtitleSuccess }] = useMutation(changeSubtitle)
+
+  const formik = useFormik({
+    initialValues: {
+      subtitle: collection.subtitle,
+    },
+    validate: validateZodSchema(
+      z.object({
+        subtitle: z.string().min(1).max(300),
+      })
+    ),
+    onSubmit: async (values) => {
+      toast.promise(
+        changeSubtitleMutation({
+          id: collection.id,
+          subtitle: values.subtitle,
+        }),
+        {
+          loading: "Updating subtitle...",
+          success: () => {
+            refetchFn()
+            return "Updated subtitle"
+          },
+          error: "Failed to update subtitle",
+        }
+      )
+    },
+  })
 
   return (
     <>
       {(collection.subtitle === null || !collection.public || collection.upgraded) && isAdmin ? (
         <>
-          <Formik
-            initialValues={{
-              subtitle: collection.subtitle,
-            }}
-            onSubmit={() => {}}
+          <form
+            className="module my-2 bg-white pb-2 dark:border-gray-600 dark:bg-gray-900"
+            onSubmit={formik.handleSubmit}
           >
-            <Form
-              className="my-4"
-              onBlur={(values) => {
-                if (collection.subtitle != values.target.defaultValue) {
-                  toast.promise(
-                    changeSubtitleMutation({
-                      id: collection.id,
-                      subtitle: values.target.defaultValue,
-                    }),
-                    {
-                      loading: "Updating subtitle...",
-                      success: () => {
-                        refetchFn()
-                        return "Updated subtitle"
-                      },
-                      error: "Failed to update subtitle",
-                    }
-                  )
-                }
-              }}
+            <label htmlFor="subtitle" className="sr-only">
+              subtitle
+            </label>
+            <textarea
+              rows={1}
+              id="subtitle"
+              className="w-full border-0 text-center text-sm font-medium leading-5 focus:ring-0 dark:bg-gray-900 md:text-base "
+              {...formik.getFieldProps("subtitle")}
+            />
+            <button
+              type="submit"
+              className="mx-auto my-1 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
             >
-              <label htmlFor="subtitle" className="sr-only">
-                subtitle
-              </label>
-              <Field
-                id="subtitle"
-                name="subtitle"
-                placeholder={collection.subtitle}
-                type="text"
-                className="w-full border-0 text-center text-sm font-medium leading-5 focus:ring-0 dark:bg-gray-900 md:text-base "
-              />
-            </Form>
-          </Formik>
+              Save Subtitle
+            </button>
+          </form>
         </>
       ) : (
         <h2 className="mx-auto text-center text-sm font-medium leading-5 md:text-base">

--- a/app/collections/components/AdminSubtitle.tsx
+++ b/app/collections/components/AdminSubtitle.tsx
@@ -52,6 +52,9 @@ const Subtitle = ({ collection, refetchFn, isAdmin }) => {
               className="w-full border-0 text-center text-sm font-medium leading-5 focus:ring-0 dark:bg-gray-900 md:text-base "
               {...formik.getFieldProps("subtitle")}
             />
+            {formik.touched.subtitle && formik.errors.subtitle ? (
+              <span className="text-red-500">{` - ${formik.errors.subtitle}`}</span>
+            ) : null}
             <button
               type="submit"
               className="mx-auto my-1 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"

--- a/app/collections/components/AdminTitle.tsx
+++ b/app/collections/components/AdminTitle.tsx
@@ -52,6 +52,10 @@ const AdminTitle = ({ collection, refetchFn, isAdmin }) => {
               className="w-full select-none overflow-auto border-0 bg-white text-center text-3xl focus:ring-0 dark:bg-gray-900 md:text-5xl lg:text-6xl "
               {...formik.getFieldProps("title")}
             />
+            {formik.touched.title && formik.errors.title ? (
+              <span className="text-red-500">{` - ${formik.errors.title}`}</span>
+            ) : null}
+
             <button
               type="submit"
               className="mx-auto my-1 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"

--- a/app/collections/components/AdminTitle.tsx
+++ b/app/collections/components/AdminTitle.tsx
@@ -1,54 +1,64 @@
-import { useMutation } from "blitz"
+import { useMutation, validateZodSchema } from "blitz"
 import { Field, Form, Formik } from "formik"
 import toast from "react-hot-toast"
 import changeTitle from "../mutations/changeTitle"
+import { useFormik } from "formik"
+import { z } from "zod"
 
 const AdminTitle = ({ collection, refetchFn, isAdmin }) => {
   const [changeTitleMutation] = useMutation(changeTitle)
+
+  const formik = useFormik({
+    initialValues: {
+      title: collection.title,
+    },
+    validate: validateZodSchema(
+      z.object({
+        title: z.string().min(1).max(300),
+      })
+    ),
+    onSubmit: async (values) => {
+      toast.promise(
+        changeTitleMutation({
+          id: collection.id,
+          title: values.title,
+        }),
+        {
+          loading: "Updating title...",
+          success: () => {
+            refetchFn()
+            return "Updated title"
+          },
+          error: "Failed to update title",
+        }
+      )
+    },
+  })
 
   return (
     <>
       {(collection.title === null || !collection.public || collection.upgraded) && isAdmin ? (
         <>
-          <Formik
-            initialValues={{
-              title: collection.title,
-            }}
-            onSubmit={() => {}}
+          <form
+            className="module divide-y divide-gray-100 border-0 border-gray-100 bg-white pb-2 dark:divide-gray-600 dark:border-gray-600 dark:bg-gray-900"
+            onSubmit={formik.handleSubmit}
           >
-            <Form
-              className="my-4 w-full"
-              onBlur={(values) => {
-                if (collection.title != values.target.defaultValue) {
-                  toast.promise(
-                    changeTitleMutation({
-                      id: collection.id,
-                      title: values.target.defaultValue,
-                    }),
-                    {
-                      loading: "Updating title...",
-                      success: () => {
-                        refetchFn()
-                        return "Updated title"
-                      },
-                      error: "Failed to update title",
-                    }
-                  )
-                }
-              }}
+            <label htmlFor="title" className="sr-only">
+              title
+            </label>
+            <textarea
+              rows={1}
+              id="title"
+              className="w-full select-none overflow-auto border-0 bg-white text-center text-3xl focus:ring-0 dark:bg-gray-900 md:text-5xl lg:text-6xl "
+              {...formik.getFieldProps("title")}
+            />
+            <button
+              type="submit"
+              className="mx-auto my-1 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
             >
-              <label htmlFor="title" className="sr-only">
-                title
-              </label>
-              <Field
-                id="title"
-                name="title"
-                placeholder={collection.title}
-                type="text"
-                className="w-full select-none overflow-auto border-0 bg-white text-center text-3xl focus:ring-0 dark:bg-gray-900 md:text-5xl lg:text-6xl "
-              />
-            </Form>
-          </Formik>
+              Save Title
+            </button>
+          </form>
         </>
       ) : (
         <h2 className="my-4 w-full border-0 bg-white text-center text-3xl focus:ring-0 dark:bg-gray-900 md:text-5xl lg:text-6xl">


### PR DESCRIPTION
We are experiencing problems in production with the saving of the title, subtitle, and description based on the `onBlur` save action. It worked in test but that's useless if it doesn't work in prod :) 

So now we adjust to have the admin portal display buttons to actively save - this should resolve the issue (although we can only know for sure when it's in production!).

<img width="1469" alt="Screenshot 2022-10-27 at 16 47 01" src="https://user-images.githubusercontent.com/2946344/198321527-fd07f24b-8b3a-4e62-8aa2-cef508b39df7.png">
