### PR TITLE
Improve layering of collections confirmation modal

### DIFF
--- a/app/core/modals/PayCreateCollectionModal.tsx
+++ b/app/core/modals/PayCreateCollectionModal.tsx
@@ -36,7 +36,7 @@ export default function PayCreateCollectionModal({ user, price, type, workspace 
       </button>
 
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="fixed inset-0 z-10 overflow-y-auto" onClose={closeModal}>
+        <Dialog as="div" className="fixed inset-0 z-50 overflow-y-auto" onClose={closeModal}>
           <div className="min-h-screen px-4 text-center">
             <Transition.Child
               as={Fragment}


### PR DESCRIPTION
Just another layering issue that needs to be fixed as soon as possible.

Confirmation modal for collections was behind the options modal (z-10 confirmation on z-50 collections modal). Now it should be on top again (both z-50).