### PR TITLE
Quick fixes to UI collections

### DIFF
--- a/app/collections/components/AdminCollectedWorks.tsx
+++ b/app/collections/components/AdminCollectedWorks.tsx
@@ -20,7 +20,7 @@ const CollectedWorks = ({ collection, editorIdSelf, refetchFn, editorIsAdmin }) 
       <div>
         <Autocomplete
           className=""
-          openOnFocus={false}
+          openOnFocus={true}
           defaultActiveItemId="0"
           getSources={({ query }) => [
             {

--- a/app/collections/components/AdminWorkCard.tsx
+++ b/app/collections/components/AdminWorkCard.tsx
@@ -158,9 +158,10 @@ const WorkComment = ({ submission, index, editorIdSelf, refetchFn, editorIsAdmin
                 {/* <span className="inline-block h-full align-middle"></span> */}
                 <a
                   href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                    submission.comment
-                  )}&via=ResearchEquals
-                  `}
+                    `"${submission.comment}"\n-${submission.editor.workspace.firstName} ${submission.editor.workspace.lastName} on`
+                  )}&url=${encodeURIComponent(
+                    `https://doi.org/${submission.module.prefix}/${submission.module.suffix}`
+                  )}&via=ResearchEquals`}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/app/collections/components/ViewWorkCard.tsx
+++ b/app/collections/components/ViewWorkCard.tsx
@@ -56,7 +56,7 @@ const WorkComment = ({ submission, index }) => {
       {submission.comment && submission.comment != "" && (
         <>
           {/* for inspiration https://shuffle.dev/components/all/all/testimonials */}
-          <blockquote className="my-1 border-l-2 border-indigo-600 bg-indigo-100 p-2 font-serif text-xl italic dark:border-indigo-500 dark:bg-indigo-800">
+          <blockquote className="my-4 border-l-2 border-indigo-600 bg-indigo-100 p-2 font-serif text-xl italic dark:border-indigo-500 dark:bg-indigo-800 sm:my-1">
             {submission.comment}
           </blockquote>
           <div className="my-2 flex w-full">

--- a/app/collections/components/ViewWorkCard.tsx
+++ b/app/collections/components/ViewWorkCard.tsx
@@ -82,9 +82,10 @@ const WorkComment = ({ submission, index }) => {
                 {/* <span className="inline-block h-full align-middle"></span> */}
                 <a
                   href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                    submission.comment
-                  )}&via=ResearchEquals
-                  `}
+                    `"${submission.comment}"\n-${submission.editor.workspace.firstName} ${submission.editor.workspace.lastName} on`
+                  )}&url=${encodeURIComponent(
+                    `https://doi.org/${submission.module.prefix}/${submission.module.suffix}`
+                  )}&via=ResearchEquals`}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/app/core/modals/DeleteEditorModal.tsx
+++ b/app/core/modals/DeleteEditorModal.tsx
@@ -26,9 +26,7 @@ export default function SetEditorToInactiveModal({ editor, refetchFn }) {
         <TrashCan
           size={32}
           id="delete-editor"
-          className={`${
-            editor.isActive ? "" : "rotate-180"
-          } shrink-0 p-1 text-gray-900 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:text-gray-200 dark:hover:text-gray-300`}
+          className={`shrink-0 p-1 text-gray-900 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:text-gray-200 dark:hover:text-gray-300`}
         />
       </button>
       <Transition appear show={isOpen} as={Fragment}>

--- a/app/core/modals/MakeCollectionPublicModal.tsx
+++ b/app/core/modals/MakeCollectionPublicModal.tsx
@@ -24,7 +24,7 @@ export default function MakeCollectionPublicModal({ collection, refetchFn, works
 
   return (
     <>
-      <div className="sticky top-0 z-50 flex w-full bg-amber-50 py-4 px-2 text-center dark:bg-amber-800">
+      <div className="sticky top-0 z-10 flex w-full bg-amber-50 py-4 px-2 text-center dark:bg-amber-800">
         <div className="mx-auto flex">
           <div className="inline-block align-middle">
             <CheckmarkOutline

--- a/app/core/modals/MakeCollectionPublicModal.tsx
+++ b/app/core/modals/MakeCollectionPublicModal.tsx
@@ -88,7 +88,7 @@ export default function MakeCollectionPublicModal({ collection, refetchFn, works
                 <div className="mt-2">
                   <p className="text-sm">
                     Once you make the collection public you cannot change the title and subtitle
-                    (except after upgrading).
+                    {collection.type.type !== "COMMUNITY" && " (except after upgrading)"}.
                   </p>
                   {!collection.title ? (
                     <p className="text-sm">

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -250,12 +250,28 @@ body {
 
 .workquote:has(blockquote) {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  /* grid-template-columns: 1fr; */
 }
 
 .workquote:has(form) {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  /* grid-template-columns: 1fr; */
+}
+
+@media (min-width: 600px) {
+  .workquote:has(blockquote) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: 1fr;
+  }
+
+  .workquote:has(form) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: 1fr;
+  }
 }
 
 .collection-1 {

--- a/app/pages/collections.tsx
+++ b/app/pages/collections.tsx
@@ -65,12 +65,8 @@ const CollectionsPage: BlitzPage = () => {
               This is your opportunity to become your own editor.
             </p>
             <CollectionsModal
-              styling=""
-              button={
-                <button className="mt-8 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-sky-50 px-5 py-3 text-base font-medium text-sky-700  hover:bg-sky-100 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-sky-500 dark:hover:border-gray-400 dark:hover:bg-gray-700 sm:w-auto">
-                  Create a collection
-                </button>
-              }
+              styling="mt-8 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-sky-50 px-5 py-3 text-base font-medium text-sky-700  hover:bg-sky-100 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-sky-500 dark:hover:border-gray-400 dark:hover:bg-gray-700 sm:w-auto"
+              button={"Create a collection"}
               user={currentUser}
               workspace={currentWorkspace}
             />

--- a/app/pages/collections/[suffix].tsx
+++ b/app/pages/collections/[suffix].tsx
@@ -430,7 +430,7 @@ const AddSubmmision = ({ collection, currentWorkspace, refetchFn }) => {
       {collection?.type.type === "COMMUNITY" && (
         <Autocomplete
           className="w-full"
-          openOnFocus={false}
+          openOnFocus={true}
           defaultActiveItemId="0"
           getSources={({ query }) => [
             {

--- a/app/pages/collections/[suffix]/admin.tsx
+++ b/app/pages/collections/[suffix]/admin.tsx
@@ -294,7 +294,7 @@ const CollectedWorks = ({ collection, editorIdSelf, refetchFn, editorIsAdmin }) 
       <div>
         <Autocomplete
           className=""
-          openOnFocus={false}
+          openOnFocus={true}
           defaultActiveItemId="0"
           getSources={({ query }) => [
             {


### PR DESCRIPTION
This PR fixes several minor things at once (quicker to fix than make issue most of the time).

1. Improve tweet intent for collected works
2. Remove trash icon flipping when editor inactive
3. Default to showing suggested items while searching for items to submit to collection
4. Fixes #802 
5. Improve handling of editor's comments to prevent overflow