### PR TITLE
Show a confirmation modal for collections submissions via DOI

### DIFF
--- a/app/pages/collections/[suffix].tsx
+++ b/app/pages/collections/[suffix].tsx
@@ -566,7 +566,7 @@ const AddSubmmision = ({ collection, currentWorkspace, refetchFn }) => {
                     </Link>
                   )}
                   {selectedWorkType === "doi" && (
-                    <Link href={`https://doi.org/${selectedDoiWorkData?.doi}`} passHref>
+                    <Link href={selectedDoiWorkData.url} passHref>
                       <a target="_blank">{selectedDoiWorkData?.title}</a>
                     </Link>
                   )}

--- a/app/pages/collections/[suffix].tsx
+++ b/app/pages/collections/[suffix].tsx
@@ -461,7 +461,7 @@ const AddSubmmision = ({ collection, currentWorkspace, refetchFn }) => {
           refetchFn()
           return "Submitted work to collection!"
         },
-        error: "Failed to add work to collection...",
+        error: "Failed to submit work to collection...",
       }
     )
   }

--- a/app/pages/collections/[suffix].tsx
+++ b/app/pages/collections/[suffix].tsx
@@ -532,7 +532,7 @@ const AddSubmmision = ({ collection, currentWorkspace, refetchFn }) => {
                                       setSelectedDoiWorkData(data)
                                       setIsConfirmationOpen(true)
 
-                                      return "Confirm your submission"
+                                      return "Record added to database"
                                     },
                                     error: "Could not add record.",
                                   }

--- a/app/pages/collections/[suffix].tsx
+++ b/app/pages/collections/[suffix].tsx
@@ -456,7 +456,7 @@ const AddSubmmision = ({ collection, currentWorkspace, refetchFn }) => {
         moduleId: data.id,
       }),
       {
-        loading: "Adding work to collection...",
+        loading: "Submitting work to collection...",
         success: () => {
           refetchFn()
           return "Added work to collection!"

--- a/app/pages/collections/[suffix].tsx
+++ b/app/pages/collections/[suffix].tsx
@@ -459,7 +459,7 @@ const AddSubmmision = ({ collection, currentWorkspace, refetchFn }) => {
         loading: "Submitting work to collection...",
         success: () => {
           refetchFn()
-          return "Added work to collection!"
+          return "Submitted work to collection!"
         },
         error: "Failed to add work to collection...",
       }


### PR DESCRIPTION
This PR adds a confirmation modal for submission to collections via DOI. (This is a follow-up to a previous PR added a confirmation modal for module submission https://github.com/libscie/ResearchEquals.com/pull/884)

https://user-images.githubusercontent.com/17035406/199476764-b31fc5f8-8143-4a4f-8e82-1a52a85a6aa3.mov

## Approach

1. created a state value to track the type of the submission ("module" vs "doi")
2. created a state value to store the doi data
3. refactored the toast promise, and moved it as an input to the module component 
4. make different toast promise run for module vs doi submissions  (`onSubmit` of the module component)

Fixes #875 