### PR TITLE
Fix the slide-outs for the previous, next, and manage modules

### DIFF
--- a/app/modules/components/ChildPanel.tsx
+++ b/app/modules/components/ChildPanel.tsx
@@ -9,7 +9,7 @@ const ChildPanel = ({ openObject, openFunction, module }) => {
   return (
     <>
       <Transition.Root show={openObject} as={Fragment}>
-        <Dialog as="div" className="fixed inset-0 overflow-hidden" onClose={openFunction}>
+        <Dialog as="div" className="fixed inset-0 z-30 overflow-hidden" onClose={openFunction}>
           <div className="absolute inset-0 overflow-hidden">
             <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-25 transition-opacity" />
 

--- a/app/modules/components/ManageParents.tsx
+++ b/app/modules/components/ManageParents.tsx
@@ -13,7 +13,7 @@ const ManageParents = ({ open, setOpen, moduleEdit, setQueryData }) => {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="fixed inset-0 overflow-hidden" onClose={setOpen}>
+      <Dialog as="div" className="fixed inset-0 z-30 overflow-hidden" onClose={setOpen}>
         <div className="absolute inset-0 overflow-hidden">
           <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-25 transition-opacity" />
 

--- a/app/modules/components/ParentPanel.tsx
+++ b/app/modules/components/ParentPanel.tsx
@@ -9,7 +9,7 @@ const ParentPanel = ({ openObject, openFunction, module }) => {
   return (
     <>
       <Transition.Root show={openObject} as={Fragment}>
-        <Dialog as="div" className="fixed inset-0 overflow-hidden" onClose={openFunction}>
+        <Dialog as="div" className="fixed inset-0 z-30 overflow-hidden" onClose={openFunction}>
           <div className="absolute inset-0 overflow-hidden">
             <Dialog.Overlay className="fixed inset-0 bg-gray-900 bg-opacity-25 transition-opacity" />
 


### PR DESCRIPTION
This PR fixes the z-index issues for the slide outs showing (1) previous modules, (2) next modules, and (3) modules managed in the draft.


## Previous modules

![image](https://user-images.githubusercontent.com/17035406/199513470-8afe5a87-d463-4ccc-b132-253e63725243.png)


## Next modules

![image](https://user-images.githubusercontent.com/17035406/199513586-58ddba33-f41a-40d2-a666-60cf7543eccc.png)


## Manage modules (in draft)

![image](https://user-images.githubusercontent.com/17035406/199513716-1a6c30ba-eecc-4e2a-880b-ca58aca0e5fe.png)


Fixes #885