### PR TITLE
Remove `react-tooltip` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "react-media-hook": "0.5.0",
         "react-quilljs": "1.3.3",
         "react-syntax-highlighter": "15.5.0",
-        "react-tooltip": "4.4.3",
         "react-xarrows": "2.0.2",
         "recharts": "2.1.16",
         "recoil": "0.7.6",
@@ -20197,30 +20196,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-tooltip": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.4.3.tgz",
-      "integrity": "sha512-l7/TDBwq3JtuLBtq6FvIs7wsqcHjvoHFT8AvNGpf0JhHwzh+ZhCDN25wM/+gxelj8i1ngw/ULFv53XRQ/wCMzQ==",
-      "dependencies": {
-        "prop-types": "^15.8.1",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "npm": ">=6.13"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/react-tooltip/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
@@ -40024,22 +39999,6 @@
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        }
-      }
-    },
-    "react-tooltip": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.4.3.tgz",
-      "integrity": "sha512-l7/TDBwq3JtuLBtq6FvIs7wsqcHjvoHFT8AvNGpf0JhHwzh+ZhCDN25wM/+gxelj8i1ngw/ULFv53XRQ/wCMzQ==",
-      "requires": {
-        "prop-types": "^15.8.1",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "react-media-hook": "0.5.0",
     "react-quilljs": "1.3.3",
     "react-syntax-highlighter": "15.5.0",
-    "react-tooltip": "4.4.3",
     "react-xarrows": "2.0.2",
     "recharts": "2.1.16",
     "recoil": "0.7.6",


### PR DESCRIPTION
This PR removes `react-tooltip` as a dependency, since we are no longer using it after the marketing page port. 

Fixes #888 

Also....
![giphy](https://user-images.githubusercontent.com/17035406/199530498-f75f799f-0519-4e06-9b99-7e314abd2f7a.gif)
