### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+      time: "00:00"
+      timezone: "Europe/Berlin"
     labels:
       - "Maintenance"
     open-pull-requests-limit: 999

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "wednesday"
     labels:
       - "Maintenance"
     open-pull-requests-limit: 999


### PR DESCRIPTION
Update dependabot to run once a week on Wednesday, as @nsunami, our main dependabot'er requested 😊 

Based this on the [docs for dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval)