### PR TITLE
Fixing the issue of sending out approval emails with wrong approver's names

### DIFF
--- a/app/authorship/mutations/approveAuthorship.ts
+++ b/app/authorship/mutations/approveAuthorship.ts
@@ -2,7 +2,7 @@ import { resolver } from "@blitzjs/rpc"
 import db from "db"
 import approvalMailer from "pages/api/approval-mailer"
 
-export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, suffix, user }) => {
   await db.authorship.update({
     where: {
       id,
@@ -65,9 +65,12 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix }) => {
     },
   })
 
-  await approvalMailer.enqueue(currentModule!.id, {
-    id: currentModule!.id.toString(),
-  })
+  await approvalMailer.enqueue(
+    { moduleId: currentModule!.id, user },
+    {
+      id: currentModule!.id.toString(),
+    }
+  )
 
   return currentModule!
 })

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -176,6 +176,7 @@ const ModuleEdit = ({
                             approveAuthorshipMutation({
                               id: ownAuthorship!.id,
                               suffix: moduleEdit!.suffix,
+                              user,
                             }),
                             {
                               loading: "Loading",


### PR DESCRIPTION
This PR addresses the issue where the app sends out an approval email for all users, even though only one author has approved the module for publication. 

The problem was that the mailer function was sending out an approval email for all authors with their own respective name.  (e.g., Author A gets an email saying that Author A approved the module, and Author B gets that Author B approved that module, even though in reality, Author C was the one who approved the module).

I tried to address this issue by passing the `user` object from the front end to get who is approving. Then, I use that information to send all authors that this particular person has approved the module. 

Hope this works!

Fixes #730 