### PR TITLE
Cleaning up the Next.js `Link` component to solve the warning message 

### DIFF
--- a/app/core/components/home/ApproachSection.tsx
+++ b/app/core/components/home/ApproachSection.tsx
@@ -107,7 +107,7 @@ export const ApproachSection = () => {
             <ApproachBox key={idx} data={data} className="w-full" />
           ))}
         </div>
-        <Link href="/signup" passHref legacyBehavior>
+        <Link href="/signup">
           <Button color="primary">Publish Openly with ResearchEquals</Button>
         </Link>
       </div>

--- a/app/core/components/home/Hero.tsx
+++ b/app/core/components/home/Hero.tsx
@@ -24,7 +24,7 @@ export const Hero = () => {
         <p className="max-w-[800px] text-base text-slate-600 dark:text-slate-300 md:text-xl">
           {t("hero_subtitle")}
         </p>
-        <Link href="/signup" passHref legacyBehavior>
+        <Link href="/signup">
           <Button color="primary" className="mt-4 w-auto">
             {t("primary_cta")}
           </Button>

--- a/app/core/components/home/JoinCommunitySection.tsx
+++ b/app/core/components/home/JoinCommunitySection.tsx
@@ -10,7 +10,7 @@ export const JoinCommunitySection = () => {
         <p className="text-center text-3xl font-bold leading-10 md:text-5xl lg:text-left">
           Join a community of people making their research journey visible
         </p>
-        <Link href="/signup" passHref legacyBehavior>
+        <Link href="/signup">
           <Button variant="outlined" color="inherit" className="lg:min-w-[340px]">
             Sign up for ResearchEquals
           </Button>


### PR DESCRIPTION
This PR cleans up the `Link` component by removing unused `passHref` and `legacyBehavior` arguments so that we can remove the warning message on the homepage.

Fixes #954.