### PR TITLE
Improve UX on upload modal

### DIFF
--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -414,6 +414,9 @@ const ModuleEdit = ({
           <h2 className="my-2 text-lg leading-4 text-gray-500 dark:text-gray-200">
             Supporting file(s)
           </h2>
+          <p className="my-2 text-xs font-normal leading-4 text-gray-900 dark:text-gray-200">
+            Uploading an updated file with same name? Delete the original here first.
+          </p>
           {supportingRaw.files.length > 0 ? (
             <>
               {supportingRaw.files.map((file) => (

--- a/app/modules/mutations/addSupporting.ts
+++ b/app/modules/mutations/addSupporting.ts
@@ -10,12 +10,15 @@ export default resolver.pipe(resolver.authorize(), async ({ id, newFiles }) => {
   let supportingFiles = oldModule?.supporting as Prisma.JsonObject
   // 2. Map the array to push each files object into supporting files
   newFiles.map((newFile) => {
-    supportingFiles.files.filter((file) => {
+    let x = supportingFiles.files.filter((file) => {
       if (file.original_filename == newFile.original_filename) {
-        throw new Error("Please check for duplicates.")
+        // throw new Error("Please check for duplicates.")
+        return file
       }
     })
-    supportingFiles.files.push(newFile)
+    if (x.length === 0) {
+      supportingFiles.files.push(newFile)
+    }
   })
 
   // Force all authors to reapprove for publishing


### PR DESCRIPTION
This PR improves the UX on the upload modal, where the person trying to upload in multiple steps on the same load of the page does not need to delete the previous batch first. 
Now, the upload finds the duplicates and skips those in the upload. The modal still resets upon refresh of the page.

There will inevitably be other issues. We can still improve this experience. For now, fixes #877.

Video:


https://user-images.githubusercontent.com/2946344/208873700-27389915-3962-44bc-9a05-1581384ec63e.mov

