### PR TITLE
Swap out Splitbee for Plausible

### DIFF
--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -47,7 +47,11 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
       <Head>
         <title>{title || "ResearchEquals"}</title>
         <link rel="icon" href="/favicon-32.png" />
-        <script data-respect-dnt data-no-cookie async src="https://cdn.splitbee.io/sb.js"></script>
+        <script
+          defer
+          data-domain="researchequals.com"
+          src="https://plausible.io/js/script.js"
+        ></script>
         {cookie}
         {/* {cookie ? <script type="text/javascript">{crispCode}</script> : ""} */}
         {/* <script type="text/javascript">{cookie ? crispCode : false}</script> */}

--- a/app/core/modals/PublishModuleModal.tsx
+++ b/app/core/modals/PublishModuleModal.tsx
@@ -242,7 +242,6 @@ export default function PublishModule({
                                 )
                               }
                               role="link"
-                              data-splitbee-event={`Publish module`}
                               className="mr-2 inline-flex justify-center rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                               disabled={!waiver}
                             >
@@ -261,7 +260,6 @@ export default function PublishModule({
                         <>
                           <button
                             type="button"
-                            data-splitbee-event={`Publish module`}
                             className="mr-2 inline-flex justify-center rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                             onClick={async () => {
                               await toast.promise(publishModuleMutation({ id: currentModule.id }), {
@@ -366,7 +364,6 @@ export default function PublishModule({
                             )
                           }
                           role="link"
-                          data-splitbee-event={`Publish module`}
                           className="mr-2 inline-flex justify-center rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                           disabled={!waiver}
                         >

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -162,11 +162,9 @@ We use cookies for different purposes, but only if they are strictly necessary t
 
 Typically, these cookies do not contain personal data. However, if that may be the case in certain situations, the processing of such data is based on Art. 6 par. 1 lit. f) GDPR and the aforementioned purposes constitute the legitimate interests we pursue with them.
 
-### 2. Splitbee
+### 2. Plausible
 
-We use the service Splitbee provided by Tobias Lins e.U. Alserbachstraße 10 1090 Vienna. Splitbee helps us to analyze your use of our Site. It collects certain information such as a unique ID, your country, page views, the referrer, the user agent and usage duration. Splitbee does not store an IP Address or any information that would make it possible to identify you as a natural person. Our use of Splitbee also does not store any cookies or other information on your end device. Any processing of personal data for these purposes is based on Art. 6 par. 1 lit. f) GDPR whereas our legitimate interest is to get insights how our Site is used.
-
-You can opt-out by enabling the Do Not Track functionality in your browser.
+We use the service Plausible provided by Plausible Insights OÜ Västriku tn 2, 50403, Tartu, Estonia. Plausible helps us to analyze your use of our Site. It collects certain information such as a unique ID, your country, page views, the referrer, the user agent and usage duration. Plausible does not store an IP Address or any information that would make it possible to identify you as a natural person. Our use of Plausible also does not store any cookies or other information on your end device. Any processing of personal data for these purposes is based on Art. 6 par. 1 lit. f) GDPR whereas our legitimate interest is to get insights how our Site is used.
 
 ### 3. Crisp
 

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -266,7 +266,6 @@ const SignupPage: BlitzPage = () => {
             {termsAccepted && cocAccepted ? (
               <button
                 type="submit"
-                data-splitbee-event="Sign up"
                 className="text-medium w-full rounded-md border border-transparent bg-indigo-600 px-3 py-2 text-sm font-medium leading-4 text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-transparent"
               >
                 Sign up


### PR DESCRIPTION
This PR swaps out Splitbee for Plausible.

This is a required change as Splitbee was acquired by Vercel, and websites need to be deployed using Vercel to get the analytics. No sense in us keeping Splitbee as it's not being maintained.

We had done previous evaluations before we even launched ResearchEquals, and Plausible came out as a contender back then. It seems to still fit our needs, is open-source, and privacy respecting.