### PR TITLE
Allow coupons in collection checkout

### DIFF
--- a/pages/api/checkout_sessions_collections.ts
+++ b/pages/api/checkout_sessions_collections.ts
@@ -35,6 +35,7 @@ const CreateSessionCollection = async (req: NextApiRequest, res: NextApiResponse
             },
           ],
           mode: "payment",
+          allow_promotion_codes: true,
           success_url: `${req.headers.origin}/collections/${req.query.suffix}/admin?success=true`,
           cancel_url: `${req.headers.origin}`,
           automatic_tax: { enabled: true },


### PR DESCRIPTION
This PR enables coupons for checkout, finally!

It was much easier than expected. :-) The only thing left is actually creating the coupons.