### PR TITLE
Add `Reproducibility Report` module type

### DIFF
--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -52,6 +52,7 @@ const seed = async () => {
     { wikidata: "Q580922", name: "Preprint", schema: "CreativeWork" },
     { wikidata: "Q1744627", name: "Classification algorithm", schema: "CreativeWork" },
     { wikidata: "Q642946", name: "Gamebook", schema: "CreativeWork" },
+    { wikidata: "Q116740071", name: "Reproducibility Report", schema: "CreativeWork" },
   ]
 
   // This adds the record or updates the existing one


### PR DESCRIPTION
This PR adds a module type called the "Reproducibility Report." This was requested by @nuest, as they create these kinds of reports (also called `codecheck`s). 

