### PR TITLE
Add `Pubcast` module type

### DIFF
--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -53,6 +53,7 @@ const seed = async () => {
     { wikidata: "Q1744627", name: "Classification algorithm", schema: "CreativeWork" },
     { wikidata: "Q642946", name: "Gamebook", schema: "CreativeWork" },
     { wikidata: "Q116740071", name: "Reproducibility Report", schema: "CreativeWork" },
+    { wikidata: "Q7257257", name: "Pubcast", schema: "CreativeWork" },
   ]
 
   // This adds the record or updates the existing one


### PR DESCRIPTION
This pull request adds the `Pubcast` module type. 

> A PubCast is an [audiobook](https://en.wikipedia.org/wiki/Audiobook)-style, abridged and annotated reading of a [research article](https://en.wikipedia.org/wiki/Academic_publishing), usually recorded by the author.[[1]](https://en.wikipedia.org/wiki/Pubcast#cite_note-canscipub-1)