### PR TITLE
Allow WAV files (PubCast partnership)

### DIFF
--- a/app/core/utils/fileTypeLimit.ts
+++ b/app/core/utils/fileTypeLimit.ts
@@ -123,6 +123,7 @@ export const fileTypeLimit = (fileInfo: FileInfo) => {
     "tex",
     "toml",
     "txt",
+    "wav",
     "webm",
     "webp",
     "woff",


### PR DESCRIPTION
This is a request from our PubCast partner as they were trying to upload wav files. Many podcasts and audio recordings will come in this file format.