### PR TITLE
Make the title of log in page to `R= Log In`

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -19,6 +19,6 @@ const LoginPage: BlitzPage = () => {
 }
 
 LoginPage.redirectAuthenticatedTo = "/dashboard"
-LoginPage.getLayout = (page) => <Layout title="Log In">{page}</Layout>
+LoginPage.getLayout = (page) => <Layout title="R= Log In">{page}</Layout>
 
 export default LoginPage


### PR DESCRIPTION
This PR makes the title of the log-in page to `R= Log In` from `Log In`. I chose `R= ` instead of other options since it's consistent with the titles with other pages (e.g., modules, terms). 

Fixes #1187 