### PR TITLE
Temporarily comment out deletion of avatar

### DIFF
--- a/app/workspaces/mutations/changeAvatar.ts
+++ b/app/workspaces/mutations/changeAvatar.ts
@@ -35,14 +35,14 @@ export default resolver.pipe(
       if (workspaceOld!.avatar.match(/ucarecdn/g)) {
         const uuid = /((\w{4,12}-?)){5}/.exec(workspaceOld!.avatar!)![0]
         const datestring = new Date()
-        await axios.delete(`https://api.uploadcare.com/files/${uuid}/`, {
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/vnd.uploadcare-v0.5+json",
-            Date: datestring.toUTCString(),
-            Authorization: `Uploadcare.Simple ${process.env.UPLOADCARE_PUBLIC_KEY}:${process.env.UPLOADCARE_SECRET_KEY}`,
-          },
-        })
+        // await axios.delete(`https://api.uploadcare.com/files/${uuid}/`, {
+        //   headers: {
+        //     "Content-Type": "application/json",
+        //     Accept: "application/vnd.uploadcare-v0.5+json",
+        //     Date: datestring.toUTCString(),
+        //     Authorization: `Uploadcare.Simple ${process.env.UPLOADCARE_PUBLIC_KEY}:${process.env.UPLOADCARE_SECRET_KEY}`,
+        //   },
+        // })
       }
     }
 


### PR DESCRIPTION
This temporarily comments out avatar deletion, because we've been having some issues with this as a result. This may result in some increased storage but that's okay.