### PR TITLE
Allow `.ino` files

### DIFF
--- a/app/core/utils/fileTypeLimit.ts
+++ b/app/core/utils/fileTypeLimit.ts
@@ -55,6 +55,7 @@ export const fileTypeLimit = (fileInfo: FileInfo) => {
     "ifc",
     "ifcxml",
     "ifczip",
+    "ino",
     "ipynb",
     "j2k",
     "jp2",


### PR DESCRIPTION
This PR adds support for `.ino` files.

`.ino` are Arduino source files, and are plain text files. I received a support chat for a researcher who wanted to share this as a supporting file, and after verifying I decided it would be a good idea to add this. 

Any contributors who have more experience with Arduino and can help provide further thoughts on how we could support Arduino in the future? Let us know in the [ResearchEquals Discord](https://discord.gg/SefsGJWWSw) 😊 