### PR TITLE
Add support for sponsored supporting members

### DIFF
--- a/app/core/components/AccountSettings.tsx
+++ b/app/core/components/AccountSettings.tsx
@@ -78,7 +78,7 @@ const WorkspaceSettings = ({ user, setIsOpen }) => {
               >
                 <button
                   type="button"
-                  className="mx-1 flex rounded-md bg-sky-50 py-2 px-4 text-sm font-medium text-sky-700 hover:bg-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-sky-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+                  className="mx-1 flex rounded-md bg-sky-50 px-4 py-2 text-sm font-medium text-sky-700 hover:bg-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-sky-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                   // onClick={openModal}
                 >
                   <Wheat
@@ -94,7 +94,7 @@ const WorkspaceSettings = ({ user, setIsOpen }) => {
                 button={
                   <button
                     type="button"
-                    className="mx-1 flex rounded-md bg-green-50 py-2 px-4 text-sm font-medium text-green-700 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-green-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+                    className="mx-1 flex rounded-md bg-green-50 px-4 py-2 text-sm font-medium text-green-700 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-green-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                     // onClick={openModal}
                   >
                     <Sprout
@@ -196,12 +196,12 @@ const WorkspaceSettings = ({ user, setIsOpen }) => {
           <DeleteModal />
         </div>
 
-        <div className="absolute right-0 bottom-0 flex w-full border-t border-gray-300 bg-white py-2 text-right dark:border-gray-600 dark:bg-gray-900 sm:sticky">
+        <div className="absolute bottom-0 right-0 flex w-full border-t border-gray-300 bg-white py-2 text-right dark:border-gray-600 dark:bg-gray-900 sm:sticky">
           <span className="flex-grow"></span>
           <div className="">
             <button
               type="reset"
-              className="mx-4 flex rounded-md bg-red-50 py-2 px-4 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+              className="mx-4 flex rounded-md bg-red-50 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
               onClick={() => {
                 setIsOpen(false)
               }}
@@ -216,7 +216,7 @@ const WorkspaceSettings = ({ user, setIsOpen }) => {
           </div>
           <button
             type="submit"
-            className="mr-4 flex rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+            className="mr-4 flex rounded-md bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
           >
             <Checkmark
               size={32}

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -594,7 +594,6 @@ const OnboardingSupporting = ({ data }) => {
                     Subscribe<span aria-hidden="true">&rarr;</span>
                   </span>
                 }
-                sponsored={true}
               />
             </div>
           </div>

--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -84,7 +84,7 @@ const OnboardingEmail = ({ data }) => {
             </div>
           </div>
           <div className="block text-right text-amber-700 dark:text-amber-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               {isSuccess ? (
                 <p className="whitespace-nowrap font-medium  underline">Email sent!</p>
               ) : (
@@ -145,7 +145,7 @@ const OnboardingEmailAccept = ({ data }) => {
             </div>
           </div>
           <div className="block text-right text-cyan-700 dark:text-cyan-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               {isSuccess ? (
                 <button
                   className="whitespace-nowrap font-medium underline hover:cursor-pointer hover:text-blue-600"
@@ -225,7 +225,7 @@ const OnboardingOrcid = ({ data }) => {
             </div>
           </div>
           <div className="block text-right text-emerald-700 dark:text-emerald-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               <a href="/api/auth/orcid" className="whitespace-nowrap font-medium  underline">
                 Connect now <span aria-hidden="true">&rarr;</span>
               </a>
@@ -280,7 +280,7 @@ const OnboardingProfile = ({ data }) => {
           </div>
           <div className="block text-right text-pink-700 dark:text-pink-200">
             <button
-              className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:mt-0 md:ml-6"
+              className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:ml-6 md:mt-0"
               onClick={() => {
                 setSettingsModal(!settingsModal)
               }}
@@ -328,7 +328,7 @@ const OnboardingAffiliation = ({ data }) => {
           </div>
           <div className="block text-right text-teal-700 dark:text-teal-200">
             <button
-              className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:mt-0 md:ml-6"
+              className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:ml-6 md:mt-0"
               onClick={() => {
                 setSettingsModal(!settingsModal)
               }}
@@ -374,7 +374,7 @@ const OnboardingAvatar = ({ data, expire, signature, refetch }) => {
             </div>
           </div>
           <div className="block text-right text-indigo-700 dark:text-indigo-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               <button
                 className="whitespace-nowrap font-medium underline hover:text-blue-600"
                 onClick={() => {
@@ -441,7 +441,7 @@ const OnboardingDraft = ({ data, refetch }) => {
             </div>
           </div>
           <div className="block text-right text-violet-700 dark:text-violet-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               <QuickDraft
                 buttonText={
                   <>
@@ -488,7 +488,7 @@ const OnboardingCollection = ({ data, refetch }) => {
             </div>
           </div>
           <div className="block text-right text-orange-700 dark:text-orange-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               <CollectionsModal
                 button={
                   <>
@@ -538,7 +538,7 @@ const OnboardingDiscord = () => {
             </div>
           </div>
           <div className="block text-right text-fuchsia-700 dark:text-fuchsia-200">
-            <p className="mt-3 text-sm md:mt-0 md:ml-6">
+            <p className="mt-3 text-sm md:ml-6 md:mt-0">
               <Link
                 href="https://discord.gg/SefsGJWWSw"
                 target="_blank"
@@ -587,13 +587,14 @@ const OnboardingSupporting = ({ data }) => {
             </div>
           </div>
           <div className="block text-right text-green-700 dark:text-green-200">
-            <div className="mt-3 text-sm md:mt-0 md:ml-6">
+            <div className="mt-3 text-sm md:ml-6 md:mt-0">
               <SupportingMemberSignupModal
                 button={
                   <span className="underline">
                     Subscribe<span aria-hidden="true">&rarr;</span>
                   </span>
                 }
+                sponsored={true}
               />
             </div>
           </div>

--- a/app/core/modals/SupportingMemberSignupModal.tsx
+++ b/app/core/modals/SupportingMemberSignupModal.tsx
@@ -12,7 +12,7 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
 }
 
-export default function SignupModal({ button, sponsored = false }) {
+export default function SupportingMemberSignupModal({ button, sponsored = false }) {
   let currentUser = useCurrentUser()
   let [isOpen, setIsOpen] = useState(false)
   const [waiver, setWaiver] = useState(false)
@@ -74,7 +74,8 @@ export default function SignupModal({ button, sponsored = false }) {
                   <div className="mt-2">
                     <p className="text-sm">
                       As an individual supporting member, you will get personal invitations to our
-                      quarterly General Assemblies, the governance body for ResearchEquals.
+                      quarterly General Assemblies, the governance body for ResearchEquals.{" "}
+                      {sponsored && "You are eligible for a sponsored membership for one year."}
                     </p>
                     <select
                       onChange={(data) => {

--- a/app/core/modals/SupportingMemberSignupModal.tsx
+++ b/app/core/modals/SupportingMemberSignupModal.tsx
@@ -12,7 +12,7 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
 }
 
-export default function SignupModal({ button }) {
+export default function SignupModal({ button, sponsored = false }) {
   let currentUser = useCurrentUser()
   let [isOpen, setIsOpen] = useState(false)
   const [waiver, setWaiver] = useState(false)
@@ -90,18 +90,22 @@ export default function SignupModal({ button }) {
                             : "price_1MWHibLmgtJbKHNGLs3AcfQ1"
                         }
                       >
-                        Yearly - €79.99 (recurring)
+                        Yearly - {sponsored ? "€0" : "€79.99"} (recurring)
                       </option>
-                      <option
-                        value={
-                          // Hardcodes price_id for production and test
-                          process.env.ALGOLIA_PREFIX === "production"
-                            ? "price_1MgXRnLmgtJbKHNGALFmoCR7"
-                            : "price_1MWHibLmgtJbKHNGBMUtwKEL"
-                        }
-                      >
-                        Monthly - €9.99 (recurring){" "}
-                      </option>
+                      {sponsored ? (
+                        ""
+                      ) : (
+                        <option
+                          value={
+                            // Hardcodes price_id for production and test
+                            process.env.ALGOLIA_PREFIX === "production"
+                              ? "price_1MgXRnLmgtJbKHNGALFmoCR7"
+                              : "price_1MWHibLmgtJbKHNGBMUtwKEL"
+                          }
+                        >
+                          Monthly - {sponsored ? "€0" : "€9.99"} (recurring){" "}
+                        </option>
+                      )}
                     </select>
                   </div>
                   <div className="my-4 flex">
@@ -168,23 +172,23 @@ export default function SignupModal({ button }) {
                       type="button"
                       onClick={() =>
                         handlePayment(
-                          `/api/checkout_sessions_supporting?email=${encodeURIComponent(
-                            currentUser?.email!
-                          )}&price_id=${price}`,
+                          `/api/checkout_sessions_supporting${
+                            sponsored ? "_sponsored" : ""
+                          }?email=${encodeURIComponent(currentUser?.email!)}&price_id=${price}`,
                           router,
                           toast,
                           antiCSRFToken
                         )
                       }
                       role="link"
-                      className="mr-2 inline-flex justify-center rounded-md bg-emerald-50 py-2 px-4 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+                      className="mr-2 inline-flex justify-center rounded-md bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-emerald-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                       disabled={!waiver}
                     >
                       Pay and Subscribe
                     </button>
                     <button
                       type="button"
-                      className="mr-2 inline-flex justify-center rounded-md bg-red-50 py-2 px-4 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+                      className="mr-2 inline-flex justify-center rounded-md bg-red-50 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
                       onClick={closeModal}
                     >
                       Cancel

--- a/pages/api/checkout_sessions_supporting_sponsored.ts
+++ b/pages/api/checkout_sessions_supporting_sponsored.ts
@@ -11,6 +11,7 @@ const CreateSessionSupporting = async (req: NextApiRequest, res: NextApiResponse
         const coupon = await stripe.coupons.create({
           duration: "forever",
           percent_off: 100,
+          max_redemptions: 1,
         })
 
         // Create Checkout Sessions from body params.

--- a/pages/api/checkout_sessions_supporting_sponsored.ts
+++ b/pages/api/checkout_sessions_supporting_sponsored.ts
@@ -1,0 +1,56 @@
+import { api } from "app/blitz-server"
+import { NextApiRequest, NextApiResponse } from "next"
+const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY, { apiVersion: "2020-03-02" })
+
+const CreateSessionSupporting = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (!req.query.email || !req.query.price_id) {
+    res.status(500).end("Incomplete request")
+  } else {
+    if (req.method === "POST" && req.query.price_id && req.query.email) {
+      try {
+        const coupon = await stripe.coupons.create({
+          duration: "forever",
+          percent_off: 100,
+        })
+
+        // Create Checkout Sessions from body params.
+        const session = await stripe.checkout.sessions.create({
+          customer_email: req.query.email,
+          billing_address_collection: "auto",
+          line_items: [
+            {
+              price: req.query.price_id,
+              quantity: 1,
+            },
+          ],
+          subscription_data: {
+            metadata: {
+              subType: "sponsored",
+            },
+          },
+          // https://stripe.com/docs/billing/subscriptions/coupons?dashboard-or-api=api#using-coupons-in-checkout
+          discounts: [
+            {
+              coupon: coupon.id,
+            },
+          ],
+          mode: "subscription",
+          success_url: `${req.headers.origin}/dashboard?supporting=true`,
+          cancel_url: `${req.headers.origin}/dashboard`,
+          automatic_tax: { enabled: true },
+          tax_id_collection: {
+            enabled: true,
+          },
+        })
+        res.status(200).json({ url: session.url })
+      } catch (err) {
+        res.status(err.statusCode || 500).json(err.message)
+      }
+    } else {
+      res.setHeader("Allow", "POST")
+      res.status(405).end("Method Not Allowed")
+    }
+  }
+}
+
+export default api(CreateSessionSupporting)

--- a/pages/api/stripe_webhook.ts
+++ b/pages/api/stripe_webhook.ts
@@ -171,7 +171,8 @@ const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
       await supportingSignup(event.data.object.customer_email)
       // If it's a sponsored supporter, make sure to cancel the subscription immediately
       // Sponsored memberships last only for a year
-      if (event.data.object.lines.data[0].metadata.subType === "sponsored") {
+      const isSponsored = event.data.object.lines.data[0].metadata.subType === "sponsored"
+      if (isSponsored) {
         await stripe.subscriptions.del(event.data.object.subscription)
       }
 

--- a/pages/api/stripe_webhook.ts
+++ b/pages/api/stripe_webhook.ts
@@ -169,6 +169,11 @@ const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
         },
       })
       await supportingSignup(event.data.object.customer_email)
+      // If it's a sponsored supporter, make sure to cancel the subscription immediately
+      // Sponsored memberships last only for a year
+      if (event.data.object.lines.data[0].metadata.subType === "sponsored") {
+        await stripe.subscriptions.del(event.data.object.subscription)
+      }
 
     case "customer.subscription.updated":
       if (event.data.object.cancel_at_period_end) {


### PR DESCRIPTION
This PR adds all the required payment infrastructure (I think) for sponsored supporting members to sign up.

* Signup modal now takes a `sponsored` argument, which defaults to false. If `true`, it will set prices to zero and go to a new checkout session that auto-generates a discount code and applies it to the subscription.
* The signup modal for sponsored memberships only allows yearly memberships - not monthly (institutions sponsor in years)
* The `stripe_webhook` now auto-cancels the subscription after it's created. Sponsorships are on a yearly basis, so after a year the sponsorship ends. A user is always able to resubscribe with a sponsorship, if these are available when they need to resubscribe

Here's a video showing how it looks after `sponsored = true`.

https://user-images.githubusercontent.com/2946344/236178734-509048be-ad25-4ff4-8efe-a9e1c2109b5b.mov

For review, please note there is currently no implementation of the sponsored memberships. This video was created for demo purposes.