### PR TITLE
Add extension check in addition to mimetype

### DIFF
--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -17,9 +17,10 @@ const PDFJS_DIST_VERSION = process.env.PDFJS_DIST_VERSION
 const MainFileViewer = ({ mainFile, module }) => {
   const prefersDarkMode = useMediaPredicate("(prefers-color-scheme: dark)")
   const [mainFileMarkdown, setMarkdown] = useState("")
+  const isMarkdown = mainFile.mimeType.startsWith("text/markdown") || mainFile.name.endsWith(".md")
 
   useEffect(() => {
-    if (mainFile.mimeType === "text/markdown") {
+    if (isMarkdown) {
       fetch(mainFile.cdnUrl)
         .then((response) => response.text())
         .then((body) => setMarkdown(body))
@@ -29,9 +30,6 @@ const MainFileViewer = ({ mainFile, module }) => {
     }
   }, [])
 
-  console.log(mainFile)
-
-  // alert(mainFile.mimeType)
   return (
     <>
       {mainFile.name && (
@@ -57,7 +55,7 @@ const MainFileViewer = ({ mainFile, module }) => {
             </Worker>
           )}
           {/* Preview Markdown */}
-          {(mainFile.mimeType.startsWith("text/markdown") || mainFile.name.endsWith(".md")) && (
+          {isMarkdown && (
             <div className="coc">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}

--- a/app/core/components/FilePreviewer.tsx
+++ b/app/core/components/FilePreviewer.tsx
@@ -29,6 +29,8 @@ const MainFileViewer = ({ mainFile, module }) => {
     }
   }, [])
 
+  console.log(mainFile)
+
   // alert(mainFile.mimeType)
   return (
     <>
@@ -55,7 +57,7 @@ const MainFileViewer = ({ mainFile, module }) => {
             </Worker>
           )}
           {/* Preview Markdown */}
-          {mainFile.mimeType.startsWith("text/markdown") && (
+          {(mainFile.mimeType.startsWith("text/markdown") || mainFile.name.endsWith(".md")) && (
             <div className="coc">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}


### PR DESCRIPTION
This adds an extension check in addition the mimetype check for a Markdown file.

Fixes #1278.