### PR TITLE
Fix `undefined undefined` in emails

### DIFF
--- a/app/authorship/mutations/approveAuthorship.ts
+++ b/app/authorship/mutations/approveAuthorship.ts
@@ -2,7 +2,7 @@ import { resolver } from "@blitzjs/rpc"
 import db from "db"
 import approvalMailer from "pages/api/approval-mailer"
 
-export default resolver.pipe(resolver.authorize(), async ({ id, suffix, user }) => {
+export default resolver.pipe(resolver.authorize(), async ({ id, suffix, workspace }) => {
   await db.authorship.update({
     where: {
       id,
@@ -66,7 +66,7 @@ export default resolver.pipe(resolver.authorize(), async ({ id, suffix, user }) 
   })
 
   await approvalMailer.enqueue(
-    { moduleId: currentModule!.id, user },
+    { moduleId: currentModule!.id, workspace },
     {
       id: currentModule!.id.toString(),
     }

--- a/app/modules/components/ModuleEdit.tsx
+++ b/app/modules/components/ModuleEdit.tsx
@@ -177,7 +177,7 @@ const ModuleEdit = ({
                             approveAuthorshipMutation({
                               id: ownAuthorship!.id,
                               suffix: moduleEdit!.suffix,
-                              user,
+                              workspace,
                             }),
                             {
                               loading: "Loading",

--- a/pages/api/approval-mailer.ts
+++ b/pages/api/approval-mailer.ts
@@ -1,25 +1,28 @@
 import { sendApproval } from "app/postmark"
 import { Queue } from "quirrel/next"
-import db, { User } from "../../db"
+import db, { Workspace } from "../../db"
 
-export default Queue("api/approval-mailer", async (payload: { moduleId: number; user: User }) => {
-  const { moduleId, user } = payload
-  const currentModule = await db.module.findFirst({
-    where: {
-      id: moduleId,
-    },
-    include: {
-      authors: {
-        include: {
-          workspace: {
-            include: {
-              members: {
-                include: {
-                  user: {
-                    select: {
-                      emailConsent: true,
-                      email: true,
-                      emailIsVerified: true,
+export default Queue(
+  "api/approval-mailer",
+  async (payload: { moduleId: number; workspace: Workspace }) => {
+    const { moduleId, workspace } = payload
+    const currentModule = await db.module.findFirst({
+      where: {
+        id: moduleId,
+      },
+      include: {
+        authors: {
+          include: {
+            workspace: {
+              include: {
+                members: {
+                  include: {
+                    user: {
+                      select: {
+                        emailConsent: true,
+                        email: true,
+                        emailIsVerified: true,
+                      },
                     },
                   },
                 },
@@ -28,30 +31,26 @@ export default Queue("api/approval-mailer", async (payload: { moduleId: number; 
           },
         },
       },
-    },
-  })
-
-  const currentApprover = currentModule?.authors.find((author) => author.workspaceId === user.id)
-
-  currentModule?.authors.map(async (author) => {
-    author.workspace?.members.map(async (member) => {
-      if (
-        member.emailApprovals &&
-        member.user?.emailConsent &&
-        member.user.emailIsVerified &&
-        author.acceptedInvitation
-      ) {
-        await sendApproval(
-          {
-            // TODO: This name should be checked
-            // https://github.com/libscie/ResearchEquals.com/issues/730
-            name: `${currentApprover?.workspace?.firstName} ${currentApprover?.workspace?.lastName}`,
-            title: currentModule.title,
-            url: `${process.env.APP_ORIGIN}/drafts?suffix=${currentModule.suffix}`,
-          },
-          member.user?.email
-        )
-      }
     })
-  })
-})
+
+    currentModule?.authors.map(async (author) => {
+      author.workspace?.members.map(async (member) => {
+        if (
+          member.emailApprovals &&
+          member.user?.emailConsent &&
+          member.user.emailIsVerified &&
+          author.acceptedInvitation
+        ) {
+          await sendApproval(
+            {
+              name: `${workspace.firstName} ${workspace.lastName}`,
+              title: currentModule.title,
+              url: `${process.env.APP_ORIGIN}/drafts?suffix=${currentModule.suffix}`,
+            },
+            member.user?.email
+          )
+        }
+      })
+    })
+  }
+)

--- a/pages/api/collection-submission-mailer.ts
+++ b/pages/api/collection-submission-mailer.ts
@@ -58,24 +58,4 @@ export default Queue("api/collection-submission-mailer", async (submissionId: nu
       }
     })
   })
-  // submission.
-  // module?.authors.map(async (author) => {
-  //   author.workspace?.members.map(async (member) => {
-  //     if (
-  //       member.emailApprovals &&
-  //       member.user?.emailConsent &&
-  //       member.user.emailIsVerified &&
-  //       author.acceptedInvitation
-  //     ) {
-  //       await sendApproval(
-  //         {
-  //           name: `${author.workspace?.firstName} ${author.workspace?.lastName}`,
-  //           title: module.title,
-  //           url: `${process.env.APP_ORIGIN}/drafts?suffix=${module.suffix}`,
-  //         },
-  //         member.user?.email
-  //       )
-  //     }
-  //   })
-  // })
 })


### PR DESCRIPTION
There was a common issue of people receiving approval emails for `undefined undefined` - documentation in screenshot:

![Screenshot 2023-06-08 at 11 01 21](https://github.com/libscie/ResearchEquals.com/assets/2946344/1c9525a3-fdb4-445b-8d6c-e13296703ef4)

This was originally fixed in #952, but apparently there was a remaining bug here.

Upon some digging I discovered we are using the `user.id` to match to a `workspace` - this leads to an undefined workspace and undefined names. User IDs do not necessarily match workspace ids, but our test environments led us to believe it worked because there they were.

The fix here is to pass the approver's workspace data into the approval mailer directly. This allows us to use their names for the email, without any matching needed.