### PR TITLE
Add broadcast stream

### DIFF
--- a/app/core/mutations/broadcast-all.ts
+++ b/app/core/mutations/broadcast-all.ts
@@ -20,6 +20,7 @@ async function broadcastMessage({ subject, htmlContent, textContent }) {
         Subject: subject,
         HtmlBody: htmlContent,
         TextBody: textContent,
+        MessageStream: "broadcast",
       }
     })
   )

--- a/app/core/mutations/broadcast-marketing.ts
+++ b/app/core/mutations/broadcast-marketing.ts
@@ -22,6 +22,7 @@ async function broadcastMessage({ subject, htmlContent, textContent }) {
         Subject: subject,
         HtmlBody: htmlContent,
         TextBody: textContent,
+        MessageStream: "broadcast",
       }
     })
   )

--- a/app/core/mutations/broadcast-supporting.ts
+++ b/app/core/mutations/broadcast-supporting.ts
@@ -21,6 +21,7 @@ async function broadcastMessage({ subject, htmlContent, textContent }) {
         Subject: subject,
         HtmlBody: htmlContent,
         TextBody: textContent,
+        MessageStream: "broadcast",
       }
     })
   )


### PR DESCRIPTION
This PR ensures all broadcast messages are sent on the broadcast stream instead of the transactional stream on Postmark.

This ensures our transactional mails don't get polluted in case people mark the marketing or so as spam.