### PR TITLE
Add SUPERADMIN upgrade route

### DIFF
--- a/pages/api/[suffix]/upgrade-collection.ts
+++ b/pages/api/[suffix]/upgrade-collection.ts
@@ -1,0 +1,38 @@
+import { api } from "app/blitz-server"
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "@blitzjs/auth"
+import db from "../../../db"
+
+const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
+  const session = await getSession(req, res)
+
+  if (session.$publicData.roles![0] != "SUPERADMIN") {
+    return res.status(403).json({ error: `Forbidden` })
+  }
+
+  const type = await db.collectionType.findFirstOrThrow({
+    where: {
+      type: "COMMUNITY",
+    },
+  })
+
+  await db.collection.update({
+    where: {
+      suffix: req.query.suffix as string,
+    },
+    data: {
+      collectionTypeId: type.id,
+      upgraded: true,
+    },
+  })
+
+  res.statusCode = 200
+  res.setHeader("Content-Type", "application/json")
+  res.end(
+    JSON.stringify({
+      message: `Collection ${req.query.suffix} successfully upgraded to ${type.type}`,
+    })
+  )
+}
+
+export default api(webhook)


### PR DESCRIPTION
This adds a way to directly upgrade a collection to a community collection, as vouchers don't work for Stripe when there is a one-time payment and the discounted price (e.g., €0) does not meet the minimum sale price...

Route: `/api/[suffix]/upgrade-collection`

Only works for those with `SUPERADMIN` rights. May be moved to the admin portal directly at a later stage, for GUI interface.