### PR TITLE
Add encoding to cited DOIs

### DIFF
--- a/app/core/crossref/citation_list.tsx
+++ b/app/core/crossref/citation_list.tsx
@@ -101,7 +101,7 @@ const citation_list = ({ citations }: { citations: Cite[] }): CitationList => {
             children: [
               {
                 type: "text",
-                value: `${prefix}/${suffix}`,
+                value: `${prefix}/${encodeURIComponent(suffix)}`,
               },
             ],
           } as DOI,


### PR DESCRIPTION
This PR adds encoding to the suffix of a DOI cited. This is in response to this thread on the Crossref forum:
https://community.crossref.org/t/citation-dois-not-accepted-in-xml-upload/3083

We have not had this issue, but trying to prevent this error. Note: I have not tested this as it is such a minor change. Will need to do so upon deploy.