### PR TITLE
Quickfix for the supporting file bug

### DIFF
--- a/app/modules/components/EditSupportingFiles.jsx
+++ b/app/modules/components/EditSupportingFiles.jsx
@@ -1,6 +1,6 @@
 import { invoke, useMutation } from "@blitzjs/rpc"
 import { Widget } from "@uploadcare/react-widget"
-import { useRef } from "react"
+import { useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { Add } from "@carbon/icons-react"
 
@@ -14,28 +14,32 @@ const validators = [fileTypeLimit, fileSizeLimit]
 const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace, expire, signature }) => {
   const widgetApi = useRef()
   const [addSupportingMutation] = useMutation(addSupporting)
+  const [updateFiles, setUpdate] = useState(false)
 
   const updateSupporting = async (info) => {
-    try {
-      const newFiles = await invoke(getSupportingFiles, { groupUuid: info.uuid })
-      toast.promise(
-        addSupportingMutation({
-          id: moduleEdit.id,
-          newFiles: newFiles.files,
-        }),
-        {
-          loading: "Uploading...",
-          success: (data) => {
-            setQueryData(data)
-            return "Uploaded!"
-          },
-          error: (error) => {
-            return error.toString()
-          },
-        }
-      )
-    } catch (err) {
-      alert(err)
+    if (updateFiles) {
+      try {
+        const newFiles = await invoke(getSupportingFiles, { groupUuid: info.uuid })
+        toast.promise(
+          addSupportingMutation({
+            id: moduleEdit.id,
+            newFiles: newFiles.files,
+          }),
+          {
+            loading: "Uploading...",
+            success: (data) => {
+              setQueryData(data)
+              return "Uploaded!"
+            },
+            error: (error) => {
+              return error.toString()
+            },
+          }
+        )
+        setUpdate(false)
+      } catch (err) {
+        alert(err)
+      }
     }
   }
 
@@ -63,6 +67,9 @@ const EditSupportingFiles = ({ setQueryData, moduleEdit, user, workspace, expire
               clearable
               localeTranslations={uploadcareError}
               onChange={updateSupporting}
+              onDialogClose={() => {
+                setUpdate(true)
+              }}
             />
           </button>
         </>


### PR DESCRIPTION
This is a quickfix for #1439 - I used a dirty hack using state to ensure it doesn't upload the files to more than one draft.

Tested and works as expected for:
- Upload a file to one draft, switch to other, open upload widget, close the widget
- Upload a file to one draft, switch to other, open upload widget, click "Add" in the widget

https://github.com/libscie/ResearchEquals.com/assets/2946344/a0aa5b89-fbfe-4e30-99f1-632198dcf5a5

