### PR TITLE
Add filter for null values

### DIFF
--- a/pages/api/weekly-digest-mailer.ts
+++ b/pages/api/weekly-digest-mailer.ts
@@ -197,7 +197,7 @@ export default CronJob(
                   url: `${process.env.APP_ORIGIN}/${workspace.handle}`,
                 }
               }),
-              collections: collections,
+              collections: collections?.filter((x) => x),
               product_url: process.env.APP_ORIGIN,
               product_name: "ResearchEquals",
               company_name: "Liberate Science GmbH",

--- a/pages/api/weekly-digest-mailer.ts
+++ b/pages/api/weekly-digest-mailer.ts
@@ -154,6 +154,7 @@ export default CronJob(
           return js
         }
       })
+      collections = collections?.filter((x) => x)
       workspace.members.map(async (member) => {
         if (
           member.emailInvitations &&
@@ -197,7 +198,7 @@ export default CronJob(
                   url: `${process.env.APP_ORIGIN}/${workspace.handle}`,
                 }
               }),
-              collections: collections?.filter((x) => x),
+              collections: collections,
               product_url: process.env.APP_ORIGIN,
               product_name: "ResearchEquals",
               company_name: "Liberate Science GmbH",


### PR DESCRIPTION
This PR adds a filter for `null` values, as the weekly digest was receiving the following template data:

```
  "collections": [
    null,
    null
  ],
```

This resulted in emails being sent even if there were no drafts etc:
<img width="621" alt="Screenshot 2023-07-11 at 09 32 18" src="https://github.com/libscie/ResearchEquals.com/assets/2946344/f4472215-9561-4e13-818f-40871d959df5">

As a result of the filter, the template data will be:

```
  "collections": [

  ],
```

which results in no email being sent.