### PR TITLE
Move ordering of authorshipRank

### DIFF
--- a/app/modules/mutations/publishModule.ts
+++ b/app/modules/mutations/publishModule.ts
@@ -30,15 +30,15 @@ export const getToBePublishedModule = async (id: number) =>
             },
           },
         },
+        orderBy: {
+          authorshipRank: "asc",
+        },
       },
       references: {
         include: {
           authors: {
             include: {
               workspace: true,
-            },
-            orderBy: {
-              authorshipRank: "asc",
             },
           },
         },
@@ -108,5 +108,5 @@ export default resolver.pipe(
     })
 
     return true
-  }
+  },
 )


### PR DESCRIPTION
This PR fixes the authorshipRank ordering, which was incorrectly placed resulting in incorrect XML generation for DOI registration.