### PR TITLE
Add `/api/collections` and `/api/modules` routes

### DIFF
--- a/pages/api/collections.ts
+++ b/pages/api/collections.ts
@@ -1,0 +1,32 @@
+import { api } from "app/blitz-server"
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "@blitzjs/auth"
+import db from "../../db"
+
+const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
+  const date = req.query.from as string
+
+  let collections
+  if (date) {
+    collections = await db.collection.findMany({
+      where: {
+        updatedAt: {
+          gte: new Date(date),
+        },
+        public: true,
+      },
+    })
+  } else {
+    collections = await db.collection.findMany({})
+  }
+
+  res.statusCode = 200
+  res.setHeader("Content-Type", "application/json")
+  res.end(
+    JSON.stringify({
+      collections,
+    }),
+  )
+}
+
+export default api(webhook)

--- a/pages/api/modules.ts
+++ b/pages/api/modules.ts
@@ -1,0 +1,38 @@
+import { api } from "app/blitz-server"
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "@blitzjs/auth"
+import db from "../../db"
+
+const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
+  const date = req.query.from as string
+
+  let modules
+  if (date) {
+    modules = await db.module.findMany({
+      where: {
+        publishedAt: {
+          gte: new Date(date),
+        },
+        publishedWhere: "ResearchEquals",
+        published: true,
+      },
+    })
+  } else {
+    modules = await db.module.findMany({
+      where: {
+        publishedWhere: "ResearchEquals",
+        published: true,
+      },
+    })
+  }
+
+  res.statusCode = 200
+  res.setHeader("Content-Type", "application/json")
+  res.end(
+    JSON.stringify({
+      modules,
+    }),
+  )
+}
+
+export default api(webhook)


### PR DESCRIPTION
This PR adds two public API routes to provide the data for collections and modules. 

Usage:
- `/api/collections` or `/api/collections?from=<DATE>` (e.g., `/api/collections?from=2023-08-08`)
- `/api/modules` or `/api/modules?from=<DATE>` (e.g., `/api/modules?from=2023-08-08`)

This implementation is necessary based on [our immediate archive strategy.](https://libscie.org/researchequals-archival-strategy/)