### PR TITLE
Comment out og-images

### DIFF
--- a/pages/graph.jsx
+++ b/pages/graph.jsx
@@ -155,7 +155,7 @@ Graph.getLayout = (page) => (
           property="og:description"
           content="Step by step publishing of your research, with a new publishing format: Research modules."
         />
-        <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" />
+        {/* <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" /> */}
         <meta
           property="og:image:alt"
           content="Screenshot of the homepage of ResearchEquals.com, including the description and a sign up button for release updates."

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,7 +103,7 @@ Home.getLayout = (page) => (
           property="og:description"
           content="Step by step publishing of your research, with a new publishing format: Research modules."
         />
-        <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" />
+        {/* <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" /> */}
         <meta
           property="og:image:alt"
           content="Screenshot of the homepage of ResearchEquals.com, including the description and a sign up button for release updates."

--- a/pages/stats.jsx
+++ b/pages/stats.jsx
@@ -330,7 +330,7 @@ Stats.getLayout = (page) => (
           property="og:description"
           content="Step by step publishing of your research, with a new publishing format: Research modules."
         />
-        <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" />
+        {/* <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" /> */}
         <meta
           property="og:image:alt"
           content="Screenshot of the homepage of ResearchEquals.com, including the description and a sign up button for release updates."

--- a/pages/supporting-member.tsx
+++ b/pages/supporting-member.tsx
@@ -102,7 +102,7 @@ SupportingMemberPage.getLayout = (page) => (
           property="og:description"
           content="Step by step publishing of your research, with a new publishing format: Research modules."
         />
-        <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" />
+        {/* <meta property="og:image" content="https://og-images.herokuapp.com/api/researchequals" /> */}
         <meta
           property="og:image:alt"
           content="Screenshot of the homepage of ResearchEquals.com, including the description and a sign up button for release updates."


### PR DESCRIPTION
This removes use of our `og-images` app to ensure appropriate deletion is possible, without any errors. We will have to create new 
social images, nonetheless (see #1747).
