### PR TITLE
Add nixpacks as buildtype and version env variable

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -16,11 +16,13 @@
           "cpu": 0.5,
           "memory": 1024,
           "domain": "www.researchequals.com",
+          "buildType": "nixpacks",
           "minInstances": 1,
           "maxInstances": 1,
           "buildCommand": "npx blitz prisma migrate deploy && npx blitz db seed && npm run build",
           "startCommand": "quirrel ci && npm run start:production",
           "envVariables": {
+            "NIXPACKS_VERSION": "1.18.0",
             "ALGOLIA_API_ADMIN_KEY": {
               "fromParameterStore": "ALGOLIA_API_ADMIN_KEY"
             },


### PR DESCRIPTION
This PR changes `buildType` to use `NixPacks` and locking to the latest to date `1.18.0`.