### PR TITLE
Add flightcontrol preview envs

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -111,6 +111,109 @@
           "deletionProtection": true
         }
       ]
+    },
+    {
+      "source": {
+        "pr": true,
+        "filter": {
+          "toBranches": ["main"]
+        }
+      },
+      "services": [
+        {
+          "id": "researchequals-preview",
+          "name": "researchequals-preview",
+          "type": "fargate",
+          "cpu": 0.5,
+          "memory": 1024,
+          "buildType": "nixpacks",
+          "minInstances": 1,
+          "maxInstances": 1,
+          "buildCommand": "npx blitz prisma migrate deploy && npx blitz db seed && npm run build",
+          "startCommand": "quirrel ci && npm run start:production",
+          "envVariables": {
+            "NIXPACKS_VERSION": "1.18.0",
+            "NIXPACKS_PKGS": "python39,gnumake,gcc9",
+            "NIXPACKS_PYTHON_VERSION": "3.9",
+            "ALGOLIA_API_ADMIN_KEY": {
+              "fromParameterStore": "ALGOLIA_API_ADMIN_KEY_PREVIEW"
+            },
+            "ALGOLIA_API_SEARCH_KEY": {
+              "fromParameterStore": "ALGOLIA_API_SEARCH_KEY_PREVIEW"
+            },
+            "ALGOLIA_APP_ID": {
+              "fromParameterStore": "ALGOLIA_APP_ID_PREVIEW"
+            },
+            "ALGOLIA_PREFIX": "preview",
+            "APP_ENV": "preview",
+            "APP_ORIGIN": "https://preview.researchequals.com",
+            "CROSSREF_LOGIN_ID": {
+              "fromParameterStore": "CROSSREF_LOGIN_ID_PREVIEW"
+            },
+            "CROSSREF_LOGIN_PASSWD": {
+              "fromParameterStore": "CROSSREF_LOGIN_PASSWD_PREVIEW"
+            },
+            "CROSSREF_URL": "https://test.crossref.org/servlet/deposit",
+            "DATABASE_URL": {
+              "fromService": {
+                "id": "preview-db",
+                "value": "dbConnectionString"
+              }
+            },
+            "DOI_PREFIX": "10.53962",
+            "ORCID_CLIENT_ID": { "fromParameterStore": "ORCID_CLIENT_ID" },
+            "ORCID_CLIENT_SANDBOX": "false",
+            "ORCID_CLIENT_SECRET": {
+              "fromParameterStore": "ORCID_CLIENT_SECRET"
+            },
+            "POSTMARK_TOKEN": {
+              "fromParameterStore": "POSTMARK_TOKEN_PREVIEW"
+            },
+            "PORT": "3000",
+            "MAIL_FROM": "no-reply@libscie.org",
+            "QUIRREL_BASE_URL": "https://preview.researchequals.com/",
+            "QUIRREL_ENCRYPTION_SECRET": {
+              "fromParameterStore": "QUIRREL_ENCRYPTION_SECRET_PREVIEW"
+            },
+            "QUIRREL_API_URL": {
+              "fromParameterStore": "QUIRREL_API_URL"
+            },
+            "QUIRREL_TOKEN": {
+              "fromParameterStore": "QUIRREL_TOKEN"
+            },
+            "SESSION_SECRET_KEY": {
+              "fromParameterStore": "SESSION_SECRET_KEY_PREVIEW"
+            },
+            "STRIPE_PUBLISHABLE_KEY": {
+              "fromParameterStore": "STRIPE_PUBLISHABLE_KEY_PREVIEW"
+            },
+            "STRIPE_SECRET_KEY": {
+              "fromParameterStore": "STRIPE_SECRET_KEY_PREVIEW"
+            },
+            "STRIPE_WEBHOOK_SECRET": {
+              "fromParameterStore": "STRIPE_WEBHOOK_SECRET_PREVIEW"
+            },
+            "UPLOADCARE_LOCALE": "en",
+            "UPLOADCARE_PUBLIC_KEY": {
+              "fromParameterStore": "UPLOADCARE_PUBLIC_KEY_PREVIEW"
+            },
+            "UPLOADCARE_SECRET_KEY": {
+              "fromParameterStore": "UPLOADCARE_SECRET_KEY_PREVIEW"
+            }
+          }
+        },
+        {
+          "id": "preview-db",
+          "type": "rds",
+          "engine": "postgres",
+          "engineVersion": "13",
+          "instanceSize": "db.t4g.small",
+          "storage": 20,
+          "maxStorage": 20,
+          "private": true,
+          "deletionProtection": false
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds [Flightcontrol Preview Environments](https://www.flightcontrol.dev/docs/guides/flightcontrol/preview-environment). This is slated to replace our Heroku pipeline deployments.

Benefits of this transition are (among others):

* Preview deployments are more similar to our production deployment - issues can no longer be arbitrary Heroku ones
* One cost center instead of two (simplifies bookkeeping)
* Our money helps support Flightcontrol instead of Heroku - who've been key to our own journey

 We'll need to stay on the lookout for how this may affect our (p)review of new PRs. Flightcontrol preview environments are not (?) auto-destroyed, so it is good to not leave them for too long (Heroku auto-destroys after 24h right now).