### PR TITLE
Change dependabot from `weekly` to `monthly`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "00:00"
-      timezone: "Europe/Berlin"
+      interval: "monthly"
     labels:
       - "Maintenance"
     open-pull-requests-limit: 999


### PR DESCRIPTION
This PR updates dependabot upgrades to be monthly, instead of weekly.

We as maintainers agreed to switch to do dependabot upgrades every two weeks, but apparently [GitHub Actions doesn't allow for fortnightly upgrades](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file). We will try tou monthly upgrades and see how this goes.