### PR TITLE
Revert to non-VPC'ed `preview-db` in the preview environments

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -214,7 +214,7 @@
           "instanceSize": "db.t4g.small",
           "storage": 20,
           "maxStorage": 20,
-          "private": true,
+          "private": false,
           "deletionProtection": false
         }
       ]


### PR DESCRIPTION
As based on the Flightcontrol team recommendations.