### PR TITLE
Reduce RDS to 50gb

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -105,7 +105,7 @@
           "engine": "postgres",
           "engineVersion": "13",
           "instanceSize": "db.t4g.small",
-          "storage": 100,
+          "storage": 50,
           "maxStorage": 1000,
           "private": false,
           "deletionProtection": true


### PR DESCRIPTION
We're only using 6% of our current storage of 100GB. We pay for each GB/month and reducing this cost is possible.

This PR reduces the RDS size to 50GB for now.