### PR TITLE
Changing the node version described in README from 16 to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Our house may be different from yours, and if you find any of this unagreeable, 
 
 ## Development
 
-Development for this project uses `node` version 16. Please make sure you are using this version.
+Development for this project uses `node` version 18. Please make sure you are using this version.
 
 Please clone the repository and make sure you have [BlitzJS](https://www.blitzjs.com/) installed:
 


### PR DESCRIPTION
Hi @chartgerink!
I noticed that the node version described in the README was 16, but the package.json specifies 18.x. So I think would it be a good idea to update this?  

(Submitting a PR off the bat since hte change is super minor)