### PR TITLE
Update from `roles` to `role`

### DIFF
--- a/app/auth/mutations/login.ts
+++ b/app/auth/mutations/login.ts
@@ -37,7 +37,7 @@ export default resolver.pipe(resolver.zod(Login), async ({ email, password }, ct
 
   await ctx.session.$create({
     userId: user.id,
-    roles: [user.role, user.memberships[0]!.role],
+    role: user.role,
     workspaceId: user.memberships[0]!.workspaceId,
   })
 

--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -85,11 +85,11 @@ export default resolver.pipe(
       }),
       ctx.session.$create({
         userId: user.id,
-        roles: [user.role, user.memberships[0]!.role],
+        role: user.role,
         workspaceId: user.memberships[0]!.workspaceId,
       }),
     ])
 
     return user
-  }
+  },
 )

--- a/app/auth/mutations/upgradeSupporting.ts
+++ b/app/auth/mutations/upgradeSupporting.ts
@@ -15,7 +15,7 @@ const upgradeSupporting = async (input: any, ctx: Ctx) => {
   if (!user) throw new AuthenticationError()
 
   await ctx.session.$setPublicData({
-    roles: [user.role],
+    role: user.role,
   })
 
   return user

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -112,7 +112,7 @@ const Admin: BlitzPage = () => {
                 actionIdx === actions.length - 1
                   ? "rounded-bl-lg rounded-br-lg sm:rounded-bl-none"
                   : "",
-                "group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+                "group relative bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500",
               )}
             >
               <div>
@@ -120,7 +120,7 @@ const Admin: BlitzPage = () => {
                   className={classNames(
                     action.iconBackground,
                     action.iconForeground,
-                    "inline-flex rounded-lg p-3 ring-4 ring-white"
+                    "inline-flex rounded-lg p-3 ring-4 ring-white",
                   )}
                 >
                   <action.icon className="h-6 w-6" aria-hidden="true" />

--- a/pages/api/[suffix]/upgrade-collection.ts
+++ b/pages/api/[suffix]/upgrade-collection.ts
@@ -6,7 +6,7 @@ import db from "../../../db"
 const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSession(req, res)
 
-  if (session.$publicData.roles![0] != "SUPERADMIN") {
+  if (session.$publicData.role != "SUPERADMIN") {
     return res.status(403).json({ error: `Forbidden` })
   }
 
@@ -31,7 +31,7 @@ const webhook = async (req: NextApiRequest, res: NextApiResponse) => {
   res.end(
     JSON.stringify({
       message: `Collection ${req.query.suffix} successfully upgraded to ${type.type}`,
-    })
+    }),
   )
 }
 

--- a/types.ts
+++ b/types.ts
@@ -11,7 +11,7 @@ declare module "@blitzjs/auth" {
     isAuthorized: SimpleRolesIsAuthorized<Role>
     PublicData: {
       userId: User["id"]
-      roles: Array<Role>
+      role: Role
       workspaceId?: Workspace["id"]
     }
   }


### PR DESCRIPTION
This PR updates the `roles` element of the user data to `role`. It appears that BlitzJS only validates against the `role` and therefore was having issues allowing people with the right permissions to access restricted pages (e.g., `/admin` but also the membership area).

Fixes #1958.
