### PR TITLE
Removing section grid template on wider screen

### DIFF
--- a/app/core/modals/CollectionsModal.tsx
+++ b/app/core/modals/CollectionsModal.tsx
@@ -104,7 +104,7 @@ export default function CollectionsModal({ button, styling, user, workspace }) {
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <div className="sm:min-w-120 sm:max-w-120 inline-block min-h-screen w-full transform rounded bg-transparent text-left align-middle text-gray-900 transition-all dark:border-gray-600 dark:bg-gray-900 sm:min-h-full sm:w-auto">
+              <div className="sm:min-w-120 inline-block min-h-screen w-full transform rounded bg-transparent text-left align-middle text-gray-900 transition-all dark:border-gray-600 dark:bg-gray-900 sm:min-h-full sm:w-auto">
                 <button className="absolute top-0 right-0 float-right inline-flex items-center justify-center  rounded-md bg-transparent p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:text-gray-500 dark:hover:text-gray-300">
                   <span className="sr-only">Close menu</span>
                   <Close
@@ -116,7 +116,7 @@ export default function CollectionsModal({ button, styling, user, workspace }) {
                     }}
                   />
                 </button>
-                <section className="mx-auto grid grid-cols-1 overflow-hidden py-32">
+                <section className="mx-auto grid grid-cols-1 overflow-hidden py-32 2xl:grid-cols-3">
                   <div className="container col-span-1 mx-auto px-4">
                     <div className=" flex flex-wrap items-center">
                       <div className="max-w-lg pb-5 lg:p-5">

--- a/app/core/modals/CollectionsModal.tsx
+++ b/app/core/modals/CollectionsModal.tsx
@@ -116,7 +116,7 @@ export default function CollectionsModal({ button, styling, user, workspace }) {
                     }}
                   />
                 </button>
-                <section className="mx-auto grid grid-cols-1 overflow-hidden py-32 2xl:grid-cols-3">
+                <section className="mx-auto grid grid-cols-1 overflow-hidden py-32">
                   <div className="container col-span-1 mx-auto px-4">
                     <div className=" flex flex-wrap items-center">
                       <div className="max-w-lg pb-5 lg:p-5">


### PR DESCRIPTION
This PR fixes the visual bug reported in issue #1986 
![Collections-modal-screenshot](https://github.com/libscie/ResearchEquals.com/assets/42837484/697cd4ea-610c-447d-bf19-de7f5b96c47e)
Fixes #1986 