### PR TITLE
Fixing the inability to edit the profile when duplicate settings modals are showing up

### DIFF
--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import { useMutation, useQuery } from "@blitzjs/rpc"
 import { Widget } from "@uploadcare/react-widget"
-import { useRef, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { Formik, Form } from "formik"
 import {
   Building,
@@ -15,26 +15,20 @@ import {
   WatsonHealthStackedScrolling_1,
   Sprout,
 } from "@carbon/icons-react"
-import { useRecoilValue, useRecoilState } from "recoil"
+import { useRecoilState } from "recoil"
 import { smallFile } from "../utils/fileTypeLimit"
 
 import changeAvatar from "../../workspaces/mutations/changeAvatar"
 import getSignature from "../../auth/queries/getSignature"
 import QuickDraft from "../../modules/components/QuickDraft"
 import resendVerification from "../../auth/mutations/resendVerification"
-import {
-  workspaceFirstNameAtom,
-  workspaceLastNameAtom,
-  workspaceBioAtom,
-  workspacePronounsAtom,
-  workspaceUrlAtom,
-  settingsModalAtom,
-  userDiscordAtom,
-  emailNotificationsAtom,
-} from "../utils/Atoms"
+import { settingsModalAtom, userDiscordAtom, emailNotificationsAtom } from "../utils/Atoms"
 import changeEmailConsent from "../../users/mutations/changeEmailConsent"
 import CollectionsModal from "../modals/CollectionsModal"
 import SupportingMemberSignupModal from "../modals/SupportingMemberSignupModal"
+import SettingsModal from "../modals/settings"
+import { useCurrentUser } from "../hooks/useCurrentUser"
+import { useCurrentWorkspace } from "../hooks/useCurrentWorkspace"
 
 const validators = [smallFile]
 
@@ -242,23 +236,23 @@ const OnboardingOrcid = ({ data }) => {
   )
 }
 
-const OnboardingProfile = ({ data }) => {
-  // State management
-  const workspaceFirstName = useRecoilValue(workspaceFirstNameAtom)
-  const workspaceLastName = useRecoilValue(workspaceLastNameAtom)
-  const workspaceBio = useRecoilValue(workspaceBioAtom)
-  const workspacePronouns = useRecoilValue(workspacePronounsAtom)
-  const workspaceUrl = useRecoilValue(workspaceUrlAtom)
-  const [settingsModal, setSettingsModal] = useRecoilState(settingsModalAtom)
+const OnboardingProfile = () => {
+  const currentUser = useCurrentUser()
+  const currentWorkspace = useCurrentWorkspace()
+
+  const isInfoMissing = useMemo(() => {
+    return (
+      !currentWorkspace.firstName ||
+      !currentWorkspace.lastName ||
+      !currentWorkspace.bio ||
+      !currentWorkspace.pronouns ||
+      !currentWorkspace.url
+    )
+  }, [currentWorkspace])
 
   return (
     <>
-      {!data.workspace.bio ||
-      !workspaceFirstName ||
-      !workspaceLastName ||
-      !workspaceBio ||
-      !workspacePronouns ||
-      !workspaceUrl ? (
+      {isInfoMissing ? (
         <div
           key="onboarding profile-onboarding-quest"
           className="onboarding my-2 flex w-full flex-col rounded-r border-l-4 border-pink-400 bg-pink-50 p-4 dark:border-pink-200 dark:bg-pink-900 lg:my-0"
@@ -282,16 +276,17 @@ const OnboardingProfile = ({ data }) => {
             </div>
           </div>
           <div className="block text-right text-pink-700 dark:text-pink-200">
-            <button
-              className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:ml-6 md:mt-0"
-              onClick={() => {
-                setSettingsModal(!settingsModal)
-              }}
-            >
-              <>
-                Add information <span aria-hidden="true">&rarr;</span>
-              </>
-            </button>
+            {
+              <SettingsModal
+                button={
+                  <button className="mt-3 whitespace-nowrap text-sm font-medium underline hover:text-blue-600 md:ml-6 md:mt-0">
+                    Add information <span aria-hidden="true">&rarr;</span>
+                  </button>
+                }
+                user={currentUser}
+                workspace={currentWorkspace}
+              />
+            }
           </div>
         </div>
       ) : (

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -13,7 +13,7 @@ function classNames(...classes) {
 }
 
 export default function SettingsModal({ button, styling, user, workspace }) {
-  let [isOpen, setIsOpen] = useRecoilState(settingsModalAtom)
+  let [isOpen, setIsOpen] = useState(false)
   let [categories] = useState(["Workspace", "Account", "Emails"])
   const [emailNotifications, setEmailNotifications] = useRecoilState(emailNotificationsAtom)
   let x = user.memberships.map((membership) => {

--- a/app/core/modals/settings.tsx
+++ b/app/core/modals/settings.tsx
@@ -2,7 +2,7 @@ import { Dialog, Transition, Tab } from "@headlessui/react"
 import { Fragment, useEffect, useState } from "react"
 import { Close } from "@carbon/icons-react"
 import { useRecoilState } from "recoil"
-import { emailNotificationsAtom, settingsModalAtom } from "../utils/Atoms"
+import { emailNotificationsAtom } from "../utils/Atoms"
 
 import WorkspaceSettings from "../components/WorkspaceSettings"
 import AccountSettings from "../components/AccountSettings"


### PR DESCRIPTION
This PR fixes the bug where we cannot edit the profile. (fixes #1955)

I tried to fix this by removing the use of a Recoil state to handle the <SettingsModal>'s state. Doing so will remove the issue of having the duplicate modals open, which was tied to the issue.

By implementing this fix, I faced another bug, where I could no longer open the onboarding quest. (This was also handled by the Recoil state.) To fix this, I updated the <OnboardingProfile> component, and relied on the React queries. A small issue of this approach is that it takes time for the onboarding quest card to disappear after completing the information. But, I assume this is a small cost compared to not being able to edit the profile.

We could also work on hooks to evaluate whether the profile info is complete on the SettingsModal level and below, and control the OnboardingProfile card via Context/Reducer. But then, for now, I hope this fix is enough.

Hope this works! 🤞 