### PR TITLE
Fixing the overlapping Collection description by moving the line clamping to the <span> parent

### DIFF
--- a/pages/collections.tsx
+++ b/pages/collections.tsx
@@ -139,12 +139,12 @@ const CollectionCard = ({ collection, isAdmin }) => {
           </div>
           {collection.type.type === "COMMUNITY" && (
             <div className="flex p-4">
-              <p className="flex-grow text-xs line-clamp-2">
+              <p className="flex-grow text-xs">
                 <span
                   dangerouslySetInnerHTML={{
                     __html: collection.description as string,
                   }}
-                  className="quilljs-collection text-gray-900 dark:text-white"
+                  className="quilljs-collection line-clamp-6 text-gray-900 dark:text-white"
                 />
               </p>
               <div className="scale-90">


### PR DESCRIPTION
This PR fixes the overlapping collection description, by moving the line clamping to the <span> parent of the description. I also changed the line-clamp-2 to line-clamp-6 since I assume that the rendered height of the description is more appropriate. 

Before:
<img width="593" alt="image" src="https://github.com/libscie/ResearchEquals.com/assets/17035406/6535bac2-d206-4a22-a3ec-bcf714bd50c0">

After:
<img width="596" alt="image" src="https://github.com/libscie/ResearchEquals.com/assets/17035406/0e526c32-5624-4a97-a41a-dccd21200c9b">


Side note: I spend more time creating the collection than working on this problem tbh 😓 (setting up the Stripe etc). It may be wise to include collections to the seeding procedure. 