### PR TITLE
Setting Prettier config on trailing comma to "ES5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "prettier": {
     "semi": false,
-    "printWidth": 100
+    "printWidth": 100,
+    "trailingComma": "es5"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [


### PR DESCRIPTION
This PR sets the trailing comma setting on Prettier to ES5.

More info on the Prettier Doc:
https://prettier.io/docs/en/options.html#trailing-commas

I just realize that the default from Prettier is "all"—do we want "all" instead? It's going to be bit weird if "all" since we will have something like the comma in function arguments, for example:
```js
console.log(
  `Skipping seeding test users since there are already ${numUsers} users in the database.`,
)
```