### PR TITLE
Fixing a potential typo in a function name - `getCurrentWorkspace`-> `useCurrentModule`

### DIFF
--- a/app/modules/queries/useCurrentModule.ts
+++ b/app/modules/queries/useCurrentModule.ts
@@ -1,6 +1,6 @@
 import db from "db"
 
-export default async function getCurrentWorkspace({ suffix }: { suffix: string }) {
+export default async function useCurrentModule({ suffix }: { suffix: string }) {
   const currentModule = await db.module.findFirst({
     where: { suffix },
     include: {


### PR DESCRIPTION
@chartgerink This is a super tiny fix, but I noticed that the function name in useCurrentModule is now getCurrentWorkspace. It's a default export. As far as I can see, other modules import this as "useCurrentModule".

We could also change to "getCurrentModule" (since the prefix use can imply that it will return an array output from useState), but then it's a bit of nitpicky detail, so I just suggest this change for consistency only for now. 🤞 