### PR TITLE
Fixing the 400 error on dashboard page

### DIFF
--- a/app/core/components/OnboardingQuests.jsx
+++ b/app/core/components/OnboardingQuests.jsx
@@ -38,19 +38,19 @@ const OnboardingQuests = ({ expire, signature }) => {
 
   return (
     <>
-      <OnboardingSupporting data={currentUser.supporting} />
-      <OnboardingEmail data={currentUser.emailIsVerified} />
-      <OnboardingEmailAccept data={currentUser} />
-      <OnboardingAvatar
-        data={currentWorkspace}
-        expire={expire}
-        signature={signature}
-      />
-      <OnboardingProfile data={currentWorkspace} />
-      <OnboardingDraft data={currentWorkspace} />
-      <OnboardingCollection data={currentWorkspace} />
-      <OnboardingAffiliation data={currentWorkspace} />
-      <OnboardingDiscord />
+      {currentUser && (
+        <>
+          <OnboardingSupporting data={currentUser.supporting} />
+          <OnboardingEmail data={currentUser.emailIsVerified} />
+          <OnboardingEmailAccept data={currentUser} />
+          <OnboardingAvatar data={currentWorkspace} expire={expire} signature={signature} />
+          <OnboardingProfile data={currentWorkspace} />
+          <OnboardingDraft data={currentWorkspace} />
+          <OnboardingCollection data={currentWorkspace} />
+          <OnboardingAffiliation data={currentWorkspace} />
+          <OnboardingDiscord />
+        </>
+      )}
     </>
   )
 }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -55,67 +55,64 @@ const DashboardContent = ({
     }
   }, [upgradeSupportingMutation, query.supporting])
 
-    return (
-      <>
-        <Modal
-          isOpen={celebrate}
-          setIsOpen={setCelebrate}
-          title="We appreciate your support! 🥰"
-          body={
-            <>
-              <Confetti width={width} height={height} numberOfPieces={200} />
-              <div>
-                <Image
-                  src="https://ucarecdn.com/8c487c87-19f2-42c6-ba15-049c452f735d/supportingmember.gif"
-                  alt="A cute pink dinosaur coming out of a door waving and a heart appearing. It is a GIF on a continuous loop."
-                  width="480"
-                  height="480"
-                />
-                <p>Thank you so much!</p>
-                <p>If you have issues accessing the Membership Area, please log out and back in.</p>
-                <p>We look forward to seeing you at our next General Assembly.</p>
-              </div>
-            </>
-          }
-          primaryAction="See you there!"
-          primaryButtonClass="bg-indigo-50 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-indigo-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
-          secondaryAction="Go to Membership Area"
-          secondaryButtonClass="bg-green-50 text-green-700 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-green-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
-          onSubmit={() => {}}
-          onCancel={() => {
-            router.push("/membership-area")
-          }}
-        />
-        <div className="text-gray-900 dark:text-gray-200">
-          <div className="p-4">
-          <div className="my-0">
-              <h1 className="text-center text-4xl font-medium">
-                Welcome,{" "}
-                {currentWorkspace!.firstName && currentWorkspace!.lastName
-                  ? `${currentWorkspace!.firstName} ${currentWorkspace!.lastName}`
-                  : `@${currentWorkspace!.handle}`}
-                !
-              </h1>
-            </div>
-            <div className="mt-4 w-full gap-2 lg:flex">
-            <Suspense fallback="Loading...">
-              <OnboardingQuests
-                expire={expire}
-                signature={signature}
+  return (
+    <>
+      <Modal
+        isOpen={celebrate}
+        setIsOpen={setCelebrate}
+        title="We appreciate your support! 🥰"
+        body={
+          <>
+            <Confetti width={width} height={height} numberOfPieces={200} />
+            <div>
+              <Image
+                src="https://ucarecdn.com/8c487c87-19f2-42c6-ba15-049c452f735d/supportingmember.gif"
+                alt="A cute pink dinosaur coming out of a door waving and a heart appearing. It is a GIF on a continuous loop."
+                width="480"
+                height="480"
               />
-              </Suspense>
+              <p>Thank you so much!</p>
+              <p>If you have issues accessing the Membership Area, please log out and back in.</p>
+              <p>We look forward to seeing you at our next General Assembly.</p>
             </div>
+          </>
+        }
+        primaryAction="See you there!"
+        primaryButtonClass="bg-indigo-50 text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-indigo-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+        secondaryAction="Go to Membership Area"
+        secondaryButtonClass="bg-green-50 text-green-700 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 dark:border dark:border-gray-600 dark:bg-gray-800 dark:text-green-500 dark:hover:border-gray-400 dark:hover:bg-gray-700"
+        onSubmit={() => {}}
+        onCancel={() => {
+          router.push("/membership-area")
+        }}
+      />
+      <div className="text-gray-900 dark:text-gray-200">
+        <div className="p-4">
+          <div className="my-0">
+            <h1 className="text-center text-4xl font-medium">
+              Welcome,{" "}
+              {currentWorkspace?.firstName && currentWorkspace?.lastName
+                ? `${currentWorkspace.firstName} ${currentWorkspace.lastName}`
+                : `@${currentWorkspace?.handle}`}
+              !
+            </h1>
           </div>
-          <div className="flex w-full flex-col px-4">
-            <div className="my-2">
-              <Suspense fallback="Loading...">
-                <ModuleBoxFeed />
-              </Suspense>
-            </div>
+          <div className="mt-4 w-full gap-2 lg:flex">
+            <Suspense fallback="Loading...">
+              <OnboardingQuests expire={expire} signature={signature} />
+            </Suspense>
           </div>
         </div>
-      </>
-    )
+        <div className="flex w-full flex-col px-4">
+          <div className="my-2">
+            <Suspense fallback="Loading...">
+              <ModuleBoxFeed />
+            </Suspense>
+          </div>
+        </div>
+      </div>
+    </>
+  )
 }
 
 const Dashboard = ({ expire, signature }) => {


### PR DESCRIPTION
This is my attempt to fix the 400 error on the dashboard page. As reported in #2101, the dashboard page was throwing a 400 error. The error message varied from `d is null` to `Cannot read properties of null (reading "firstName")`. 

When looking at the Dashboard page, I noticed that the workspace information is expected to be non-null, by non-null assertion by bang (!):

```tsx
{currentWorkspace!.firstName && currentWorkspace!.lastName
? `${currentWorkspace!.firstName} ${currentWorkspace!.lastName}`
: `@${currentWorkspace!.handle}`}
```

I assume this means that when the currentWorkspace object is indeed null (when logging out), it will throw an error.  I changed this part of the code to allow nullish values:

```tsx
{currentWorkspace?.firstName && currentWorkspace?.lastName
? `${currentWorkspace.firstName} ${currentWorkspace.lastName}`
: `@${currentWorkspace?.handle}`}
```


Other line changes are due to code formatting.


@chartgerink : Could you check logging in and out several times to see if you get a 400 error on your side? 
