### PR TITLE
Update Browse page to explicitly allow unauthenticated use

### DIFF
--- a/pages/browse.jsx
+++ b/pages/browse.jsx
@@ -136,6 +136,7 @@ const Browse = () => {
   )
 }
 
+Browse.authenticate = false
 Browse.suppressFirstRenderFlicker = true
 Browse.getLayout = (page) => (
   <Layout


### PR DESCRIPTION
Currently, for some odd reason, the browse page requires authentication. This is not the intended behavior – the intended behavior is to be able to browse without authentication.