### PR TITLE
Remove support chat

### DIFF
--- a/app/core/components/InstitutionalSupportingMembers.tsx
+++ b/app/core/components/InstitutionalSupportingMembers.tsx
@@ -1,4 +1,3 @@
-import { Crisp } from "crisp-sdk-web"
 import Tiu from "../icons/tiu"
 import KuLeuven from "public/images/kuleuven.png"
 import Oscl from "public/images/oscl.png"
@@ -52,18 +51,13 @@ const InstitutionalSupportingMembers = () => {
             <span className="hidden md:inline">
               Institutional supporting memberships start at €2,500 per year.
             </span>
-            <button
-              onClick={() => {
-                Crisp.chat.open()
-                Crisp.message.showText(
-                  "What would you like to know about institutional memberships?",
-                )
-              }}
+            <a
+              href="mailto:info@libscie.org"
               className="mx-2 font-semibold text-indigo-600 dark:text-indigo-400"
             >
               <span className="absolute inset-0" aria-hidden="true" /> Talk to us{" "}
               <span aria-hidden="true">&rarr;</span>
-            </button>
+            </a>
           </p>
         </div>
       </div>

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -15,18 +15,11 @@ type LayoutProps = {
   headChildren?: ReactNode
 }
 
-let crispCode = `window.$crisp=[];window.CRISP_WEBSITE_ID="cb17dd6e-f56c-4c2c-a85f-463da113e860";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();`
-
 const Layout = ({ title, children, headChildren }: LayoutProps) => {
   const [cookie, setCookie] = useState(() => <></>)
   const [cookieAccepted, setCookieAccepted] = useState(
     getCookieConsentValue("researchequals-website-cookie") === "true"
   )
-  useEffect(() => {
-    if (cookieAccepted) {
-      setCookie(<script type="text/javascript">{crispCode}</script>)
-    }
-  }, [cookieAccepted])
 
   const [isAnnouncementBannerOpen, setAnnouncementBannerOpen] = useState(true)
 
@@ -46,17 +39,6 @@ const Layout = ({ title, children, headChildren }: LayoutProps) => {
       <Head>
         <title>{title || "ResearchEquals"}</title>
         <link rel="icon" href="/favicon-32.png" />
-        {cookie}
-        {/* {cookie ? <script type="text/javascript">{crispCode}</script> : ""} */}
-        {/* <script type="text/javascript">{cookie ? crispCode : false}</script> */}
-        {/* <div
-        dangerouslySetInnerHTML={{
-          __html:
-            getCookieConsentValue("researchequals-website-cookie") !== "true"
-              ? '<script type="text/javascript"></script'
-              : '<script type="text/javascript">window.$crisp=[];window.CRISP_WEBSITE_ID="cb17dd6e-f56c-4c2c-a85f-463da113e860";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();</script>',
-        }}
-      /> */}
         {headChildren}
       </Head>
       <RecoilRoot>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "blitz": "2.0.3",
         "classnames": "2.5.1",
         "concurrently": "8.2.2",
-        "crisp-sdk-web": "1.0.25",
         "dagre": "0.8.5",
         "feed": "4.2.2",
         "filesize": "10.1.1",
@@ -8170,11 +8169,6 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "license": "MIT"
-    },
-    "node_modules/crisp-sdk-web": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/crisp-sdk-web/-/crisp-sdk-web-1.0.25.tgz",
-      "integrity": "sha512-CWTHFFeHRV0oqiXoPh/aIAKhFs6xcIM4NenGPnClAMCZUDQgQsF1OWmZWmnVNjJriXUmWRgDfeUxcxygS0dCRA=="
     },
     "node_modules/cron-parser": {
       "version": "4.7.0",
@@ -16899,6 +16893,669 @@
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4"
       }
+    },
+    "node_modules/node-libxml/node_modules/abbrev": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/aproba": {
+      "version": "1.2.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/are-we-there-yet": {
+      "version": "1.1.7",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/node-libxml/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/concat-map": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/delegates": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/node-libxml/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/gauge": {
+      "version": "2.7.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/ignore-walk": {
+      "version": "3.0.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/node-libxml/node_modules/inflight": {
+      "version": "1.0.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/inherits": {
+      "version": "2.0.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/ini": {
+      "version": "1.3.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/isarray": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/minimatch": {
+      "version": "3.0.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-libxml/node_modules/needle": {
+      "version": "2.9.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/node-libxml/node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/needle/node_modules/ms": {
+      "version": "2.1.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp": {
+      "version": "0.17.0",
+      "deprecated": "Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "mkdirp": "^0.5.5",
+        "needle": "^2.5.2",
+        "nopt": "^4.0.3",
+        "npm-packlist": "^1.4.8",
+        "npmlog": "^4.1.2",
+        "rc": "^1.2.8",
+        "rimraf": "^2.7.1",
+        "semver": "^5.7.1",
+        "tar": "^4.4.13"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/chownr": {
+      "version": "1.1.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minimatch": {
+      "version": "3.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minimist": {
+      "version": "1.2.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minipass": {
+      "version": "2.9.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/minizlib": {
+      "version": "1.3.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/nopt": {
+      "version": "4.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/rimraf": {
+      "version": "2.7.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "extraneous": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/semver": {
+      "version": "5.7.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/tar": {
+      "version": "4.4.19",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/node-libxml/node_modules/node-pre-gyp/node_modules/yallist": {
+      "version": "3.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/npm-packlist": {
+      "version": "1.4.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/npmlog": {
+      "version": "4.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/object-assign": {
+      "version": "4.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/once": {
+      "version": "1.4.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/osenv": {
+      "version": "0.1.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/rc": {
+      "version": "1.2.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/node-libxml/node_modules/rc/node_modules/minimist": {
+      "version": "1.2.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-libxml/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/node-libxml/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/sax": {
+      "version": "1.2.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/signal-exit": {
+      "version": "3.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/node-libxml/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/string-width": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-libxml/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/node-libxml/node_modules/wide-align": {
+      "version": "1.1.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/node-libxml/node_modules/wrappy": {
+      "version": "1.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/node-releases": {
       "version": "2.0.14",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "blitz": "2.0.3",
     "classnames": "2.5.1",
     "concurrently": "8.2.2",
-    "crisp-sdk-web": "1.0.25",
     "dagre": "0.8.5",
     "feed": "4.2.2",
     "filesize": "10.1.1",


### PR DESCRIPTION
As we work towards 2.0, we are reducing some of the overhead on the production version. The chat is barely used, and this allows us to keep track of one fewer things.

This does not mean we do not provide any support, only that we do not have a chat bubble at this time.
