### PR TITLE
fix(browse-modules): Render only R= modules on the browse page

### DIFF
--- a/app/modules/queries/getBrowseModuleFeed.ts
+++ b/app/modules/queries/getBrowseModuleFeed.ts
@@ -26,6 +26,7 @@ export default resolver.pipe(
           ...paginateArgs,
           where: {
             published: true,
+            publishedWhere: "ResearchEquals",
           },
           orderBy: [
             {


### PR DESCRIPTION
This PR renders only R= modules on the browse page, relying on the `publishedWhere` attribute.

Fixes #2167 