### PR TITLE
Fix parsing of DataCite API attributes

### DIFF
--- a/app/modules/mutations/createReferenceModule.ts
+++ b/app/modules/mutations/createReferenceModule.ts
@@ -107,8 +107,7 @@ export default resolver.pipe(resolver.authorize(), async ({ doi }: Input, ctx) =
           data: {
             published: true,
             publishedAt: new Date(
-              metadata.data.attributes.publicationYear.toString() ||
-                metadata.data.attributes.published
+              metadata.data.attributes.registered || metadata.data.attributes.created
             ),
             publishedWhere: metadata.data.attributes.publisher,
             originMetadata: "DataCite",


### PR DESCRIPTION
The current implementation erroneously defaults to the publication year, and as a result, all DataCite publications will be parsed as being on the same date of the correct publication year. This is incorrect, as reported by @cmeesters.

This fix ensures that the registered or creation date are used, with registered taking precedence (equates published).
