### PR TITLE
Fix ROR api to v1

### DIFF
--- a/app/core/components/WorkspaceSettings.tsx
+++ b/app/core/components/WorkspaceSettings.tsx
@@ -340,7 +340,7 @@ const WorkspaceSettings = ({ workspace, setIsOpen }) => {
                       },
                       async getItems(query) {
                         const results = await axios.get(
-                          `https://api.ror.org/organizations?query.advanced=${query.query}`
+                          `https://api.ror.org/v1/organizations?query.advanced=${query.query}`
                         )
 
                         return results.data.items.slice(0, 5)


### PR DESCRIPTION
The ROR API is upgrading to `v2`, and non-versioned API calls will default to v2 by July 28th upcoming. 

The new version is breaking for our current implementation as the name is no longer in the root of the item (`item.name`) but nested into a `names` array with objects (for example, [`item.names[0].types[0] === "ror_display"`](https://api.ror.org/v2/organizations?query.advanced=liberate)). This requires some more complexity to handle.

The current PR fixes API at `v1` – note that this is not a permanent fix as the `v1` route will be deprecated by end of year.

> Note that version 1 of the ROR schema will sunset altogether in December 2025, so we recommend planning to switch to version 2 of the ROR schema and API before the end of this year. Read our changelog entry "[Timeline for the Sunset of Version 1 of the ROR API and Schema](https://ror.readme.io/changelog/2025-07-01-sunset-of-version-1)" for further details and consult [the ROR API documentation](https://ror.readme.io/docs/rest-api) for general help. Feel free to contact us at [support@ror.org](mailto:support@ror.org) with any questions.